### PR TITLE
Update CexPrivateRest trait and implementations to use HistoOrderData…

### DIFF
--- a/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
+++ b/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
@@ -90,7 +90,7 @@ impl CexPrivateRest for BinanceUmCli {
         end_time: Option<u64>,
         limit: Option<u32>,
         order_id: Option<u64>,
-    ) -> InfraResult<Vec<HistoricalOrder>> {
+    ) -> InfraResult<Vec<HistoOrderData>> {
         self._get_order_history(inst, start_time, end_time, limit, order_id)
             .await
     }
@@ -495,7 +495,7 @@ impl BinanceUmCli {
         end_time: Option<u64>,
         limit: Option<u32>,
         order_id: Option<u64>,
-    ) -> InfraResult<Vec<HistoricalOrder>> {
+    ) -> InfraResult<Vec<HistoOrderData>> {
         let mut query_string = format!("symbol={}", cli_perp_to_pure_uppercase(inst));
 
         if let Some(oid) = order_id {
@@ -530,7 +530,7 @@ impl BinanceUmCli {
         let data = res
             .into_vec()?
             .into_iter()
-            .map(HistoricalOrder::from)
+            .map(HistoOrderData::from)
             .collect();
 
         Ok(data)

--- a/src/arch/market_assets/exchange/cex_clients.rs
+++ b/src/arch/market_assets/exchange/cex_clients.rs
@@ -130,7 +130,7 @@ impl CexPrivateRest for CexClients {
         end_time: Option<u64>,
         limit: Option<u32>,
         order_id: Option<u64>,
-    ) -> InfraResult<Vec<HistoricalOrder>> {
+    ) -> InfraResult<Vec<HistoOrderData>> {
         match self {
             CexClients::BinanceUm(c) => {
                 c.get_order_history(inst, start_time, end_time, limit, order_id)

--- a/src/arch/traits/market_cex.rs
+++ b/src/arch/traits/market_cex.rs
@@ -85,7 +85,7 @@ pub trait CexPrivateRest: Send + Sync {
         _end_time: Option<u64>,
         _limit: Option<u32>,
         _order_id: Option<u64>,
-    ) -> impl Future<Output = InfraResult<Vec<HistoricalOrder>>> + Send {
+    ) -> impl Future<Output = InfraResult<Vec<HistoOrderData>>> + Send {
         ready(Err(InfraError::Unimplemented))
     }
 }


### PR DESCRIPTION
… instead of HistoricalOrder for consistency across order history methods.