### PR TITLE
ci: add rustfmt check

### DIFF
--- a/.github/workflows/rust_clippy.yml
+++ b/.github/workflows/rust_clippy.yml
@@ -25,8 +25,11 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Add clippy
-        run: rustup component add clippy
+      - name: Add rust components
+        run: rustup component add rustfmt clippy
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
 
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings


### PR DESCRIPTION
## Summary
- install rustfmt alongside clippy in CI
- run cargo fmt --all -- --check before clippy

## Tests
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings