### PR TITLE
docs: correct infra usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Extrema Infra
+# Extrema Infra
 
 A quantitative trading environment built in Rust.
 
@@ -173,7 +173,7 @@ shape = list(tensor.shape)
 
 ## LOB Exchange API Traits
 
-These traits apply only to LOB-based exchanges (Binance, OKX, dYdX, Hyperliquid, etc.)
+These traits apply only to LOB-based exchanges (Binance, OKX, Hyperliquid, etc.)
 
 For connecting to exchanges, you need to implement these traits for each exchange client:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,8 +9,8 @@ orchestrators, exchange websocket checkers, and account/order utilities.
 An application usually has four layers:
 
 1. **Strategy modules** implement business logic.
-2. **Tasks** own long-running work such as timers, model workers, order
-   execution, and websocket relays.
+2. **Tasks** own long-running work such as timers, model workers,
+   order-execution relays, and websocket relays.
 3. **Broadcast channels** publish task output to all registered strategy
    modules.
 4. **Command handles** let strategies send commands back to tasks after the
@@ -81,11 +81,16 @@ async fn main() {
 
 Strategy binaries should declare their direct runtime dependencies. Do not rely
 on transitive dependencies from `extrema_infra` when using `tokio`, `rustls`, or
-logging crates in your own code.
+logging crates in your own code. Binaries that use REST or websocket clients
+must also install the `rustls` AWS-LC provider before constructing those
+clients.
 
 ```toml
 [dependencies]
+# Local workspace development:
 extrema_infra = { path = "../extrema_infra" }
+# Published crate usage:
+# extrema_infra = "0.1.0"
 tokio = { version = "1.52.3", features = ["full"] }
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
 tracing = "0.1"
@@ -99,8 +104,9 @@ markets used by the binary:
 extrema_infra = { path = "../extrema_infra", features = ["binance", "okx"] }
 ```
 
-Use `features = ["lob_clients"]` or `features = ["all"]` when a process needs
-all built-in LOB exchange clients.
+Use `features = ["lob_clients"]` when a process needs the `LobClients`
+aggregate helper. Use `features = ["all"]` when it only needs all individual
+exchange modules.
 
 ## Strategy Module Checklist
 
@@ -175,14 +181,18 @@ Common `AltTaskType` values:
 - `ModelPreds(ModelRunner::Zmq(..))`: external model process integration.
 - `ModelPreds(ModelRunner::Onnx(..))`: in-process ONNX inference.
 
-Model prediction tasks also require
-`BoardCastChannel::default_model_preds()` and an `on_preds` handler.
+Each alt task needs its matching channel and callback: scheduler tasks use
+`BoardCastChannel::default_scheduler()` and `on_schedule`, intent tasks use
+`default_inst_intent()` and `on_inst_intent`, order-execution relay tasks use
+`default_order_execution()` and `on_order_execution`, and model prediction tasks
+use `default_model_preds()` and `on_preds`.
 
 ## Public Websocket Task
 
 A public market-data strategy typically receives a `WsTaskInfo` startup event,
 uses the command handle to connect and subscribe, then consumes normalized
-events such as trades, candles, or LOB updates.
+events such as trades or candles. LOB updates are available only for exchange
+relays that implement `WsChannel::Lob` routing.
 
 ```rust,ignore
 use std::sync::Arc;
@@ -309,14 +319,15 @@ let env = EnvBuilder::new()
 Useful callbacks:
 
 - `on_acc_order`: private order updates.
-- `on_acc_bal_pos`: balance and position snapshots.
+- `on_acc_bal_pos`: balance and position updates.
 - `on_acc_pos`: position-only updates.
 
 Exchange clients normally need API-key initialization in `Strategy::initialize`
 before private websocket login messages are built. Credentials and login flows
 are exchange-specific; for example, OKX uses a concrete login-message helper,
-while Binance private streams require listen-key management and periodic
-renewal.
+Binance UM/CM futures private streams require listen-key management and
+periodic renewal, and Binance Spot private streams use the WS API signed
+subscription helper.
 
 Built-in private clients read credentials from the process environment or a
 `.env` file:
@@ -428,7 +439,7 @@ Downstream repositories currently exercise these patterns:
 - `portfolio_orchestrator`: several strategy modules in one runtime, including
   signal allocation, portfolio mediation, order execution, transfer ticks,
   account websocket streams, and evaluation tasks.
-- `api_checkers`: small exchange-focused binaries that demonstrate REST calls,
+- `api_checkers`: small exchange-focused subcommands that demonstrate REST calls,
   public websocket streams, and private account websocket streams.
 - `examples/empty_strategy_example.rs`: the smallest scheduler example.
 - `examples/multi_strategy_example.rs`: multiple strategy modules in one

--- a/examples/complex_strategy_example.rs
+++ b/examples/complex_strategy_example.rs
@@ -104,8 +104,8 @@ impl HFTStrategy {
         Ok(())
     }
 
-    async fn connect_trade_channel(&self, channel: &WsChannel) -> InfraResult<()> {
-        if let Some(handle) = self.find_ws_handle(channel, 1) {
+    async fn connect_trade_channel(&self, channel: &WsChannel, task_id: u64) -> InfraResult<()> {
+        if let Some(handle) = self.find_ws_handle(channel, task_id) {
             info!("Sending connect to {:?}", handle);
 
             // Step 1: Request connection URL
@@ -130,7 +130,10 @@ impl HFTStrategy {
             };
             handle.send_command(cmd, None).await?;
         } else {
-            warn!("No handle found for channel {:?}", channel);
+            warn!(
+                "No handle found for channel {:?}, task_id={}",
+                channel, task_id
+            );
         }
 
         Ok(())
@@ -182,7 +185,9 @@ impl EventHandler for HFTStrategy {
 
     async fn on_ws_event(&mut self, msg: InfraMsg<WsTaskInfo>) {
         if msg.data.ws_channel == WsChannel::Trades(Some(TradesParam::AggTrades))
-            && let Err(e) = self.connect_trade_channel(&msg.data.ws_channel).await
+            && let Err(e) = self
+                .connect_trade_channel(&msg.data.ws_channel, msg.task_id)
+                .await
         {
             error!("connect ws public trade channel failed: {:?}", e);
         }

--- a/src/arch/strategy_base/command/command_core.rs
+++ b/src/arch/strategy_base/command/command_core.rs
@@ -136,8 +136,11 @@ impl CommandHandle {
     /// Use `expected_ack = None` for fire-and-forget commands, such as many
     /// websocket subscription messages or task-local intent/order/model
     /// commands. Use `Some((AckStatus::..., rx))` when the strategy needs to
-    /// confirm that a websocket connect/login/subscribe/shutdown step was
-    /// accepted before sending the next message.
+    /// wait until the relay has processed a command-specific acknowledgement
+    /// before sending the next message. For websocket text messages and
+    /// shutdown requests, the ack means the relay consumed and attempted the
+    /// command; exchange-level acceptance should still be inferred from the
+    /// venue's follow-up messages.
     ///
     /// Examples of common command flows:
     ///
@@ -191,7 +194,8 @@ impl CommandHandle {
 /// Websocket commands carry exchange-specific strings that are built by the
 /// concrete exchange client. For example, OKX private streams usually need a
 /// `WsConnect`, then a login `WsMessage`, then a subscribe `WsMessage`.
-/// Binance private streams often use listen-key URLs/messages, while public
+/// Binance UM/CM futures private streams use listen-key URLs/messages, Binance
+/// Spot private streams use signed WS API subscription helpers, and public
 /// trade/candle streams usually only need connect and subscribe.
 ///
 /// Alt-task commands carry normalized infra data:
@@ -265,10 +269,11 @@ pub enum TaskCommand {
 }
 
 impl TaskCommand {
-    /// Extracts an acknowledgement handle from commands that carry one.
+    /// Extracts an acknowledgement handle for the generic unexpected-command path.
     ///
-    /// This is used internally when a task receives an unexpected command and
-    /// still wants to unblock a caller waiting on an ack.
+    /// This is used internally when a task receives an unexpected `WsMessage` or
+    /// `WsShutdown` command and still wants to unblock a caller waiting on an
+    /// ack. `WsConnect` is acknowledged by the websocket relay's connect path.
     pub fn get_ack(self) -> Option<AckHandle> {
         match self {
             TaskCommand::WsMessage { ack, .. } | TaskCommand::WsShutdown { ack, .. } => Some(ack),

--- a/src/arch/task_execution/task_ws.rs
+++ b/src/arch/task_execution/task_ws.rs
@@ -12,8 +12,8 @@ pub struct WsTaskInfo {
     pub market: Market,
     /// Stream category handled by this task.
     pub ws_channel: WsChannel,
-    /// Whether the relay should filter raw exchange messages by channel before
-    /// publishing them.
+    /// Whether parse failures from expected non-target websocket payloads should
+    /// be ignored quietly instead of logged as parse errors.
     pub filter_channels: bool,
     /// Number of task instances to spawn.
     pub chunk: u64,
@@ -21,7 +21,10 @@ pub struct WsTaskInfo {
     pub task_base_id: Option<u64>,
 }
 
-/// Websocket channel categories understood by the runtime.
+/// Websocket channel categories used by websocket task declarations.
+///
+/// A variant is usable only when the selected exchange client and relay routing
+/// implement that market/channel combination.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum WsChannel {
     /// Private account order updates.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,10 +1,10 @@
 //! Error and result types used across the crate.
 //!
-//! Public APIs return [`InfraResult<T>`], which is a crate-local alias around
-//! [`Result`] with [`InfraError`]. The error enum keeps exchange, parsing,
-//! environment-variable, and unimplemented-endpoint failures in one type so
-//! strategy code can propagate errors without depending on exchange-specific
-//! error enums.
+//! Fallible exchange, IO, and parsing APIs commonly return [`InfraResult<T>`],
+//! which is a crate-local alias around [`Result`] with [`InfraError`]. The error
+//! enum keeps exchange, parsing, environment-variable, and
+//! unimplemented-endpoint failures in one type so strategy code can propagate
+//! errors without depending on exchange-specific error enums.
 
 use thiserror::Error;
 


### PR DESCRIPTION
Summary:
- correct usage docs found by five-agent review: feature flags, channel requirements, websocket ack/filter semantics, Binance private stream differences, and package README wording
- fix complex_strategy_example to use the websocket task_id from on_ws_event when chunk > 1
- strip README BOM for cleaner crates.io rendering

Tests:
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features
- cargo test --examples --all-features
- cargo test --doc --all-features
- RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
- cargo package --all-features --allow-dirty
- cargo publish --dry-run --all-features --allow-dirty