### PR TITLE
docs: add Hyperliquid API example

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -446,3 +446,6 @@ Downstream repositories currently exercise these patterns:
   runtime.
 - `examples/websocket_private_account_example.rs`: private account websocket
   setup.
+- `examples/hyperliquid_api_usage_example.rs`: read-only Hyperliquid REST API
+  usage, including public market data and optional account balance/position
+  reads by owner address.

--- a/examples/complex_strategy_example.rs
+++ b/examples/complex_strategy_example.rs
@@ -1,3 +1,16 @@
+//! Larger runtime wiring example.
+//!
+//! This example combines public websocket data, model prediction tasks, order
+//! execution relays, and an account module. It is intended to show how the
+//! runtime pieces fit together rather than provide a production trading
+//! strategy.
+//!
+//! Run it with:
+//!
+//! ```text
+//! cargo run --example complex_strategy_example --features okx
+//! ```
+
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::oneshot;
 use tracing::{error, info, warn};

--- a/examples/empty_strategy_example.rs
+++ b/examples/empty_strategy_example.rs
@@ -1,3 +1,15 @@
+//! Minimal scheduler strategy example.
+//!
+//! This example shows the smallest useful `EnvBuilder` setup: one strategy
+//! module, one time scheduler task, and the broadcast channels required for
+//! scheduler events.
+//!
+//! Run it with:
+//!
+//! ```text
+//! cargo run --example empty_strategy_example
+//! ```
+
 use std::{sync::Arc, time::Duration};
 use tracing::info;
 

--- a/examples/hyperliquid_api_usage_example.rs
+++ b/examples/hyperliquid_api_usage_example.rs
@@ -1,0 +1,100 @@
+//! Read-only Hyperliquid REST API usage.
+//!
+//! This example shows how to call Hyperliquid through the LOB API traits:
+//! public instrument metadata, tickers, live funding rates, funding metadata,
+//! and optional read-only account balances/positions.
+//!
+//! It never places orders or signs exchange actions. Account read calls run only
+//! when an owner address is available in the environment.
+//!
+//! Run the public-only flow:
+//!
+//! ```text
+//! cargo run --example hyperliquid_api_usage_example --features hyperliquid
+//! ```
+//!
+//! Pass a different perpetual instrument as the first argument:
+//!
+//! ```text
+//! cargo run --example hyperliquid_api_usage_example --features hyperliquid -- ETH_USDC_PERP
+//! ```
+//!
+//! Enable the optional account read calls with:
+//!
+//! ```text
+//! HYPERLIQUID_OWNER_ADDRESS=0x...
+//! HYPERLIQUID_VAULT_ADDRESS=0x... # optional
+//! ```
+
+use std::env;
+
+use extrema_infra::{
+    arch::market_assets::{
+        base_data::InstrumentType,
+        exchange::prelude::{HyperliquidAuth, HyperliquidCli},
+    },
+    prelude::*,
+};
+
+#[tokio::main]
+async fn main() -> InfraResult<()> {
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("failed to install rustls crypto provider");
+
+    let mut cli = HyperliquidCli::default();
+
+    let perp_inst = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "BTC_USDC_PERP".to_string());
+
+    let perps = cli.get_instrument_info(InstrumentType::Perpetual).await?;
+    println!("perpetual instruments: {}", perps.len());
+    for inst in perps.iter().take(5) {
+        println!(
+            "  {} code={}",
+            inst.inst,
+            inst.inst_code.as_deref().unwrap_or("-")
+        );
+    }
+
+    let tickers = cli
+        .get_tickers(
+            Some(std::slice::from_ref(&perp_inst)),
+            Some(InstrumentType::Perpetual),
+        )
+        .await?;
+    println!("{perp_inst} ticker: {tickers:#?}");
+
+    let funding = cli.get_funding_rate_live(Some(&perp_inst)).await?;
+    println!("{perp_inst} live funding: {funding:#?}");
+
+    let funding_info = cli.get_funding_rate_info(Some(&perp_inst)).await?;
+    println!("{perp_inst} funding info: {funding_info:#?}");
+
+    if let Ok(owner_address) = env::var("HYPERLIQUID_OWNER_ADDRESS") {
+        cli.auth = Some(HyperliquidAuth {
+            owner_address: owner_address.to_ascii_lowercase(),
+            agent_private_key: String::new(),
+            vault_address: env::var("HYPERLIQUID_VAULT_ADDRESS")
+                .ok()
+                .map(|address| address.to_ascii_lowercase()),
+        });
+
+        let usdc = vec!["USDC".to_string()];
+        let balances = cli.get_balance(Some(&usdc)).await?;
+        println!("USDC balances: {balances:#?}");
+
+        let positions = cli
+            .get_positions(Some(std::slice::from_ref(&perp_inst)))
+            .await?;
+        println!("{perp_inst} positions: {positions:#?}");
+    } else {
+        println!(
+            "Skipping account read calls. Set HYPERLIQUID_OWNER_ADDRESS to fetch \
+             balances and positions."
+        );
+    }
+
+    Ok(())
+}

--- a/examples/multi_strategy_example.rs
+++ b/examples/multi_strategy_example.rs
@@ -1,3 +1,16 @@
+//! Multiple strategy modules in one runtime.
+//!
+//! This example wires an empty scheduler-driven strategy together with a Binance
+//! public websocket strategy. It demonstrates how multiple modules share one
+//! `EnvBuilder`, receive independent callbacks, and send websocket commands
+//! through task handles.
+//!
+//! Run it with:
+//!
+//! ```text
+//! cargo run --example multi_strategy_example --features binance
+//! ```
+
 use std::{sync::Arc, time::Duration};
 use tokio::sync::oneshot;
 use tracing::{error, info, warn};

--- a/examples/websocket_private_account_example.rs
+++ b/examples/websocket_private_account_example.rs
@@ -1,3 +1,18 @@
+//! Private account websocket example.
+//!
+//! This example shows how a strategy module connects private account websocket
+//! relays for Binance UM futures and OKX, sends connect/login/subscribe
+//! commands, and receives account balance/position updates through callbacks.
+//!
+//! Run it with:
+//!
+//! ```text
+//! cargo run --example websocket_private_account_example --features binance,okx
+//! ```
+//!
+//! Private streams require the corresponding exchange API-key environment
+//! variables documented in the usage guide.
+
 use std::{sync::Arc, time::Duration};
 use tokio::sync::oneshot;
 use tracing::{error, info, warn};


### PR DESCRIPTION
Summary:
- add a read-only Hyperliquid REST API example covering public metadata, tickers, funding, and optional account reads by owner address
- standardize top-level example docs and run commands
- reference the new example from the usage guide

Verification:
- cargo fmt --all -- --check
- cargo check --examples --all-features
- cargo test --doc --all-features
- HYPERLIQUID_OWNER_ADDRESS=0x32B8B3af7A141b39D41552C32512753042937DEF cargo run --example hyperliquid_api_usage_example --features hyperliquid -- BTC_USDC_PERP