### PR TITLE
docs: use minor crate version in usage example

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -90,7 +90,7 @@ clients.
 # Local workspace development:
 extrema_infra = { path = "../extrema_infra" }
 # Published crate usage:
-# extrema_infra = "0.1.0"
+# extrema_infra = "0.1"
 tokio = { version = "1.52.3", features = ["full"] }
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
 tracing = "0.1"


### PR DESCRIPTION
## Summary
- use a minor-version dependency example for published extrema_infra usage
- avoid pinning docs to a specific patch release after every publish

## Test plan
- not run (documentation-only change)