### PR TITLE
ci: check default feature builds

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -42,7 +42,10 @@ jobs:
         with:
           components: clippy
 
-      - name: Run clippy
+      - name: Run clippy (default features)
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Run clippy (all features)
         run: cargo clippy --all-targets --all-features -- -D warnings
 
   test:
@@ -54,7 +57,10 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - name: Run tests
+      - name: Run tests (default features)
+        run: cargo test
+
+      - name: Run tests (all features)
         run: cargo test --all-features
 
   docs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,10 @@ okx = []
 name = "empty_strategy_example"
 
 [[example]]
+name = "hyperliquid_api_usage_example"
+required-features = ["hyperliquid"]
+
+[[example]]
 name = "complex_strategy_example"
 required-features = ["okx"]
 


### PR DESCRIPTION
## Summary
- add default-feature clippy and test CI steps alongside all-features
- gate the Hyperliquid API usage example behind the hyperliquid feature

## Tests
- cargo clippy --all-targets -- -D warnings
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features