### PR TITLE
fix: support Hyperliquid builder dex asset ids

### DIFF
--- a/src/arch/market_assets/exchange/hyperliquid/api_utils.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/api_utils.rs
@@ -10,6 +10,8 @@ use crate::errors::{InfraError, InfraResult};
 pub const HYPERLIQUID_QUOTE: &str = "USDC";
 pub const HYPERLIQUID_PERP_SUFFIX: &str = "_USDC_PERP";
 pub const HYPERLIQUID_SPOT_ASSET_OFFSET: u32 = 10_000;
+pub const HYPERLIQUID_BUILDER_PERP_ASSET_OFFSET: u32 = 100_000;
+pub const HYPERLIQUID_BUILDER_PERP_DEX_STRIDE: u32 = 10_000;
 pub const HYPERLIQUID_FUNDING_INTERVAL_HOURS: u64 = 1;
 pub const HYPERLIQUID_BUILDER_ADDRESS_EXTRA_KEY: &str = "builder_b";
 pub const HYPERLIQUID_BUILDER_FEE_EXTRA_KEY: &str = "builder_f";
@@ -23,6 +25,38 @@ pub fn hyperliquid_perp_asset_id(index: usize) -> String {
 
 pub fn hyperliquid_spot_asset_id(index: u32) -> String {
     (HYPERLIQUID_SPOT_ASSET_OFFSET + index).to_string()
+}
+
+pub fn hyperliquid_perp_asset_id_for_dex(
+    index_in_meta: u32,
+    perp_dex_index: Option<u32>,
+) -> InfraResult<u32> {
+    let Some(perp_dex_index) = perp_dex_index else {
+        return Ok(index_in_meta);
+    };
+
+    if perp_dex_index == 0 {
+        return Ok(index_in_meta);
+    }
+
+    let dex_offset = perp_dex_index
+        .checked_mul(HYPERLIQUID_BUILDER_PERP_DEX_STRIDE)
+        .ok_or_else(|| {
+            InfraError::ApiCliError(format!(
+                "Hyperliquid builder perp dex index overflow: {}",
+                perp_dex_index
+            ))
+        })?;
+
+    HYPERLIQUID_BUILDER_PERP_ASSET_OFFSET
+        .checked_add(dex_offset)
+        .and_then(|base| base.checked_add(index_in_meta))
+        .ok_or_else(|| {
+            InfraError::ApiCliError(format!(
+                "Hyperliquid builder perp asset id overflow: dex_index={}, index_in_meta={}",
+                perp_dex_index, index_in_meta
+            ))
+        })
 }
 
 pub fn hyperliquid_index_to_asset_id(inst_type: InstrumentType, index: u32) -> InfraResult<u32> {

--- a/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
@@ -30,7 +30,7 @@ use super::{
         all_mids::RestAllMidsHyperliquid, asset_ctxs::RestMetaAndAssetCtxsHyperliquid,
         clearinghouse_state::RestClearinghouseStateHyperliquid,
         funding_history::RestFundingHistoryHyperliquid, meta::RestMetaHyperliquid,
-        order_status::RestOrderStatusHyperliquid,
+        order_status::RestOrderStatusHyperliquid, perp_dexs::RestPerpDexHyperliquid,
         spot_clearinghouse_state::RestSpotClearinghouseStateHyperliquid,
         spot_meta::RestSpotMetaHyperliquid, trade_order::RestOrderAckHyperliquid,
     },
@@ -42,6 +42,7 @@ pub struct HyperliquidCli {
     pub auth: Option<HyperliquidAuth>,
     pub inst_index_map: HashMap<String, u32>,
     pub default_perp_dex: Option<String>,
+    pub default_perp_dex_index: Option<u32>,
 }
 
 impl Default for HyperliquidCli {
@@ -135,17 +136,29 @@ impl HyperliquidCli {
             auth: None,
             inst_index_map: HashMap::new(),
             default_perp_dex: None,
+            default_perp_dex_index: None,
         }
     }
 
     pub fn set_perp_dex(&mut self, dex: Option<String>) {
-        self.default_perp_dex = dex.and_then(|dex| {
+        let normalized_dex = dex.and_then(|dex| {
             let dex = dex.trim().to_string();
             (!dex.is_empty()).then_some(dex)
         });
+
+        if self.default_perp_dex != normalized_dex {
+            self.inst_index_map.clear();
+            self.default_perp_dex_index = None;
+        }
+
+        self.default_perp_dex = normalized_dex;
     }
 
     pub async fn init_inst_index_map(&mut self) -> InfraResult<()> {
+        if self.default_perp_dex.is_some() && self.default_perp_dex_index.is_none() {
+            self.init_perp_dex_index().await?;
+        }
+
         let mut inst_index_map = HashMap::new();
 
         for inst_info in self._get_instrument_info(InstrumentType::Perpetual).await? {
@@ -190,6 +203,11 @@ impl HyperliquidCli {
 
         self.inst_index_map = inst_index_map;
 
+        Ok(())
+    }
+
+    pub async fn init_perp_dex_index(&mut self) -> InfraResult<()> {
+        self.default_perp_dex_index = self._resolve_perp_dex_index().await?;
         Ok(())
     }
 
@@ -698,6 +716,35 @@ impl HyperliquidCli {
         self.default_perp_dex.as_deref().unwrap_or("")
     }
 
+    async fn _resolve_perp_dex_index(&self) -> InfraResult<Option<u32>> {
+        let Some(dex) = self.default_perp_dex.as_deref() else {
+            return Ok(None);
+        };
+
+        let res: RestResHyperliquid<Option<RestPerpDexHyperliquid>> =
+            self._post_info_raw(&json!({ "type": "perpDexs" })).await?;
+
+        for (index, perp_dex) in res.into_vec()?.into_iter().enumerate() {
+            let Some(perp_dex) = perp_dex else {
+                continue;
+            };
+
+            if perp_dex.name == dex {
+                return u32::try_from(index).map(Some).map_err(|_| {
+                    InfraError::ApiCliError(format!(
+                        "Hyperliquid perp dex index overflow for dex {}: {}",
+                        dex, index
+                    ))
+                });
+            }
+        }
+
+        Err(InfraError::ApiCliError(format!(
+            "Hyperliquid perp dex not found in perpDexs: {}",
+            dex
+        )))
+    }
+
     async fn _post_info_raw<T>(&self, body: &Value) -> InfraResult<T>
     where
         T: serde::de::DeserializeOwned,
@@ -743,12 +790,20 @@ impl HyperliquidCli {
                 }
             })?;
 
-        let inst_type = if normalized_inst.ends_with(HYPERLIQUID_PERP_SUFFIX) {
-            InstrumentType::Perpetual
-        } else {
-            InstrumentType::Spot
-        };
+        if normalized_inst.ends_with(HYPERLIQUID_PERP_SUFFIX) {
+            let perp_dex_index = match self.default_perp_dex.as_deref() {
+                Some(dex) => Some(self.default_perp_dex_index.ok_or_else(|| {
+                    InfraError::ApiCliError(format!(
+                        "Hyperliquid perp dex index is not initialized for dex {}, call init_inst_index_map() first",
+                        dex
+                    ))
+                })?),
+                None => None,
+            };
 
-        hyperliquid_index_to_asset_id(inst_type, index)
+            hyperliquid_perp_asset_id_for_dex(index, perp_dex_index)
+        } else {
+            hyperliquid_index_to_asset_id(InstrumentType::Spot, index)
+        }
     }
 }

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest.rs
@@ -4,6 +4,7 @@ pub mod clearinghouse_state;
 pub mod funding_history;
 pub mod meta;
 pub mod order_status;
+pub mod perp_dexs;
 pub mod spot_clearinghouse_state;
 pub mod spot_meta;
 pub mod trade_order;

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest/perp_dexs.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest/perp_dexs.rs
@@ -1,0 +1,6 @@
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestPerpDexHyperliquid {
+    pub name: String,
+}


### PR DESCRIPTION
## Summary
- resolve Hyperliquid perp dex indexes from the perpDexs info endpoint
- clear cached instrument indexes when switching perp dexes
- encode builder-deployed perp asset ids when placing orders or setting leverage

## Verification
- cargo check --features hyperliquid
- cargo clippy --features hyperliquid --all-targets -- -D warnings