### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 
 readme = "README.md"


### PR DESCRIPTION
## Summary
- bump extrema_infra crate version to 0.1.3 for the Hyperliquid builder dex asset id release

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo publish --dry-run --all-features