### PR TITLE
feat: support Hyperliquid builder dex quotes

### DIFF
--- a/src/arch/market_assets/exchange/hyperliquid/api_utils.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/api_utils.rs
@@ -8,7 +8,7 @@ use crate::arch::market_assets::{
 use crate::errors::{InfraError, InfraResult};
 
 pub const HYPERLIQUID_QUOTE: &str = "USDC";
-pub const HYPERLIQUID_PERP_SUFFIX: &str = "_USDC_PERP";
+pub const HYPERLIQUID_PERP_TYPE_SUFFIX: &str = "_PERP";
 pub const HYPERLIQUID_SPOT_ASSET_OFFSET: u32 = 10_000;
 pub const HYPERLIQUID_BUILDER_PERP_ASSET_OFFSET: u32 = 100_000;
 pub const HYPERLIQUID_BUILDER_PERP_DEX_STRIDE: u32 = 10_000;
@@ -18,6 +18,30 @@ pub const HYPERLIQUID_BUILDER_FEE_EXTRA_KEY: &str = "builder_f";
 const HYPERLIQUID_FUNDING_INTERVAL_MS: u64 = HYPERLIQUID_FUNDING_INTERVAL_HOURS * 60 * 60 * 1000;
 const HYPERLIQUID_KILO_PREFIX: &str = "k";
 const CLI_KILO_PREFIX: &str = "1000";
+
+#[derive(Clone, Debug, Default)]
+pub struct HyperliquidMarketCache {
+    pub inst_index_map: HashMap<String, u32>,
+    pub perp_dex: Option<String>,
+    pub perp_dex_index: Option<u32>,
+    pub perp_quote: Option<String>,
+}
+
+impl HyperliquidMarketCache {
+    pub fn set_perp_dex(&mut self, dex: Option<String>) {
+        if self.perp_dex != dex {
+            self.inst_index_map.clear();
+            self.perp_dex_index = None;
+            self.perp_quote = None;
+        }
+
+        self.perp_dex = dex;
+    }
+
+    pub fn perp_dex(&self) -> &str {
+        self.perp_dex.as_deref().unwrap_or("")
+    }
+}
 
 pub fn hyperliquid_perp_asset_id(index: usize) -> String {
     index.to_string()
@@ -116,12 +140,8 @@ fn hyperliquid_cli_symbol_to_raw_symbol(symbol: &str) -> String {
 }
 
 pub(crate) fn normalize_hyperliquid_cli_inst(inst: &str) -> String {
-    if let Some(base) = inst.strip_suffix(HYPERLIQUID_PERP_SUFFIX) {
-        return format!(
-            "{}{}",
-            hyperliquid_symbol_to_cli_symbol(base),
-            HYPERLIQUID_PERP_SUFFIX
-        );
+    if let Some((base, quote)) = split_hyperliquid_cli_perp_inst(inst) {
+        return hyperliquid_perp_parts_to_cli(base, quote);
     }
 
     if let Some((base, quote)) = inst.split_once('_') {
@@ -138,15 +158,14 @@ pub(crate) fn normalize_hyperliquid_cli_inst(inst: &str) -> String {
 pub fn hyperliquid_cli_inst_to_raw_perp_coin(inst: &str) -> InfraResult<String> {
     let normalized_inst = normalize_hyperliquid_cli_inst(inst);
 
-    normalized_inst
-        .strip_suffix(HYPERLIQUID_PERP_SUFFIX)
-        .map(hyperliquid_cli_symbol_to_raw_symbol)
-        .ok_or_else(|| {
-            InfraError::ApiCliError(format!(
-                "Hyperliquid funding supports perpetual instruments only: {}",
-                inst
-            ))
-        })
+    let (base, _) = split_hyperliquid_cli_perp_inst(&normalized_inst).ok_or_else(|| {
+        InfraError::ApiCliError(format!(
+            "Hyperliquid funding supports perpetual instruments only: {}",
+            inst
+        ))
+    })?;
+
+    Ok(hyperliquid_cli_symbol_to_raw_symbol(base))
 }
 
 pub(crate) fn hyperliquid_cli_inst_to_raw_trade_coin(inst: &str) -> Option<String> {
@@ -161,12 +180,8 @@ pub(crate) fn hyperliquid_cli_inst_to_raw_trade_coin(inst: &str) -> Option<Strin
     None
 }
 
-pub fn hyperliquid_perp_to_cli(symbol: &str) -> String {
-    format!(
-        "{}{}",
-        hyperliquid_symbol_to_cli_symbol(symbol),
-        HYPERLIQUID_PERP_SUFFIX
-    )
+pub fn hyperliquid_perp_to_cli(symbol: &str, quote: &str) -> String {
+    hyperliquid_perp_parts_to_cli(hyperliquid_raw_perp_base(symbol), quote)
 }
 
 pub fn hyperliquid_spot_to_cli(symbol: &str, base: &str, quote: &str) -> String {
@@ -198,7 +213,7 @@ pub fn hyperliquid_inst_to_cli(coin: &str) -> String {
         );
     }
 
-    hyperliquid_perp_to_cli(coin)
+    hyperliquid_perp_to_cli(coin, HYPERLIQUID_QUOTE)
 }
 
 pub fn hyperliquid_funding_interval_hours() -> u64 {
@@ -228,7 +243,7 @@ pub fn normalize_funding_inst_filter(inst: Option<&str>) -> InfraResult<Option<S
     match inst {
         Some(inst) => {
             let normalized = normalize_hyperliquid_cli_inst(inst);
-            if !normalized.ends_with(HYPERLIQUID_PERP_SUFFIX) {
+            if !is_hyperliquid_cli_perp_inst(&normalized) {
                 return Err(InfraError::ApiCliError(format!(
                     "Hyperliquid funding supports perpetual instruments only: {}",
                     inst
@@ -248,6 +263,43 @@ pub fn normalize_asset_filters(assets: Option<&[String]>) -> Option<HashSet<Stri
             .map(|asset| hyperliquid_symbol_to_cli_symbol(asset))
             .collect()
     })
+}
+
+pub fn hyperliquid_cli_perp_quote(inst: &str) -> InfraResult<String> {
+    let normalized_inst = normalize_hyperliquid_cli_inst(inst);
+    let (_, quote) = split_hyperliquid_cli_perp_inst(&normalized_inst).ok_or_else(|| {
+        InfraError::ApiCliError(format!(
+            "Hyperliquid perpetual instrument must be BASE_QUOTE_PERP: {}",
+            inst
+        ))
+    })?;
+
+    Ok(hyperliquid_symbol_to_cli_symbol(quote))
+}
+
+pub fn is_hyperliquid_cli_perp_inst(inst: &str) -> bool {
+    split_hyperliquid_cli_perp_inst(inst).is_some()
+}
+
+fn split_hyperliquid_cli_perp_inst(inst: &str) -> Option<(&str, &str)> {
+    let base_quote = inst.strip_suffix(HYPERLIQUID_PERP_TYPE_SUFFIX)?;
+    base_quote.rsplit_once('_')
+}
+
+fn hyperliquid_raw_perp_base(symbol: &str) -> &str {
+    symbol
+        .split_once(':')
+        .map(|(_, base)| base)
+        .unwrap_or(symbol)
+}
+
+fn hyperliquid_perp_parts_to_cli(base: &str, quote: &str) -> String {
+    format!(
+        "{}_{}{}",
+        hyperliquid_symbol_to_cli_symbol(base),
+        hyperliquid_symbol_to_cli_symbol(quote),
+        HYPERLIQUID_PERP_TYPE_SUFFIX
+    )
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -435,4 +487,39 @@ fn is_hyperliquid_kilo_symbol(symbol: &str) -> bool {
         && symbol
             .bytes()
             .all(|b| b.is_ascii_uppercase() || b.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_perp_names_with_explicit_quote() {
+        let cases = [
+            ("BTC", "USDC", "BTC_USDC_PERP"),
+            ("flx:OIL", "USDH", "OIL_USDH_PERP"),
+            ("cash:WTI", "USDT0", "WTI_USDT0_PERP"),
+        ];
+
+        for (raw, quote, expected) in cases {
+            assert_eq!(
+                hyperliquid_perp_to_cli(raw, quote),
+                expected,
+                "raw={raw}, quote={quote}"
+            );
+        }
+    }
+
+    #[test]
+    fn parses_quote_from_base_quote_perp() {
+        assert_eq!(hyperliquid_cli_perp_quote("OIL_USDH_PERP").unwrap(), "USDH");
+    }
+
+    #[test]
+    fn computes_builder_dex_asset_id() {
+        assert_eq!(
+            hyperliquid_perp_asset_id_for_dex(7, Some(2)).unwrap(),
+            120007
+        );
+    }
 }

--- a/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
@@ -40,9 +40,7 @@ use super::{
 pub struct HyperliquidCli {
     pub client: Arc<Client>,
     pub auth: Option<HyperliquidAuth>,
-    pub inst_index_map: HashMap<String, u32>,
-    pub default_perp_dex: Option<String>,
-    pub default_perp_dex_index: Option<u32>,
+    pub market_cache: HyperliquidMarketCache,
 }
 
 impl Default for HyperliquidCli {
@@ -134,9 +132,7 @@ impl HyperliquidCli {
         Self {
             client: shared_client,
             auth: None,
-            inst_index_map: HashMap::new(),
-            default_perp_dex: None,
-            default_perp_dex_index: None,
+            market_cache: HyperliquidMarketCache::default(),
         }
     }
 
@@ -146,22 +142,20 @@ impl HyperliquidCli {
             (!dex.is_empty()).then_some(dex)
         });
 
-        if self.default_perp_dex != normalized_dex {
-            self.inst_index_map.clear();
-            self.default_perp_dex_index = None;
-        }
-
-        self.default_perp_dex = normalized_dex;
+        self.market_cache.set_perp_dex(normalized_dex);
     }
 
     pub async fn init_inst_index_map(&mut self) -> InfraResult<()> {
-        if self.default_perp_dex.is_some() && self.default_perp_dex_index.is_none() {
+        if self.market_cache.perp_dex.is_some() && self.market_cache.perp_dex_index.is_none() {
             self.init_perp_dex_index().await?;
         }
 
         let mut inst_index_map = HashMap::new();
 
-        for inst_info in self._get_instrument_info(InstrumentType::Perpetual).await? {
+        let (perp_infos, perp_quote) = self._get_perp_instrument_info_with_quote().await?;
+        self.market_cache.perp_quote = Some(perp_quote);
+
+        for inst_info in perp_infos {
             let inst = inst_info.inst;
             let index = hyperliquid_asset_id_to_index(
                 InstrumentType::Perpetual,
@@ -201,13 +195,13 @@ impl HyperliquidCli {
             }
         }
 
-        self.inst_index_map = inst_index_map;
+        self.market_cache.inst_index_map = inst_index_map;
 
         Ok(())
     }
 
     pub async fn init_perp_dex_index(&mut self) -> InfraResult<()> {
-        self.default_perp_dex_index = self._resolve_perp_dex_index().await?;
+        self.market_cache.perp_dex_index = self._resolve_perp_dex_index().await?;
         Ok(())
     }
 
@@ -217,10 +211,10 @@ impl HyperliquidCli {
     ) -> InfraResult<Vec<FundingRateData>> {
         let target_inst = normalize_funding_inst_filter(inst)?;
 
-        let data = self
-            ._get_meta_and_asset_ctxs()
-            .await?
-            .into_funding_rate_data()?
+        let ctxs = self._get_meta_and_asset_ctxs().await?;
+        let quote = self._perp_quote_from_meta(&ctxs.0).await?;
+        let data = ctxs
+            .into_funding_rate_data(&quote)?
             .into_iter()
             .filter(|entry| match &target_inst {
                 Some(inst) => entry.inst == *inst,
@@ -237,10 +231,10 @@ impl HyperliquidCli {
     ) -> InfraResult<Vec<FundingRateInfo>> {
         let target_inst = normalize_funding_inst_filter(inst)?;
 
-        let data = self
-            ._get_meta_and_asset_ctxs()
-            .await?
-            .into_funding_rate_info()?
+        let ctxs = self._get_meta_and_asset_ctxs().await?;
+        let quote = self._perp_quote_from_meta(&ctxs.0).await?;
+        let data = ctxs
+            .into_funding_rate_info(&quote)?
             .into_iter()
             .filter(|entry| match &target_inst {
                 Some(inst) => entry.inst == *inst,
@@ -266,7 +260,10 @@ impl HyperliquidCli {
             )));
         }
 
-        let coin = hyperliquid_cli_inst_to_raw_perp_coin(inst)?;
+        let normalized_inst = normalize_hyperliquid_cli_inst(inst);
+        self._ensure_perp_quote_matches(&normalized_inst)?;
+        let quote = hyperliquid_cli_perp_quote(&normalized_inst)?;
+        let coin = self._inst_to_raw_perp_coin(&normalized_inst)?;
         let mut body = json!({
             "type": "fundingHistory",
             "coin": coin,
@@ -283,7 +280,7 @@ impl HyperliquidCli {
         let data = res
             .into_vec()?
             .into_iter()
-            .map(FundingRateData::from)
+            .map(|entry| entry.into_funding_rate_data(&quote))
             .collect();
 
         Ok(data)
@@ -310,15 +307,17 @@ impl HyperliquidCli {
             ));
         }
 
-        if !inst.ends_with(HYPERLIQUID_PERP_SUFFIX) {
+        let normalized_inst = normalize_hyperliquid_cli_inst(inst);
+        if !is_hyperliquid_cli_perp_inst(&normalized_inst) {
             return Err(InfraError::ApiCliError(
                 "Hyperliquid set_leverage supports perpetual instruments only".into(),
             ));
         }
+        self._ensure_perp_quote_matches(&normalized_inst)?;
 
         let action = HyperliquidUpdateLeverageAction {
             kind: "updateLeverage",
-            asset: self._inst_to_asset_id(inst)?,
+            asset: self._inst_to_asset_id(&normalized_inst)?,
             is_cross: match margin_mode {
                 MarginMode::Cross => true,
                 MarginMode::Isolated => false,
@@ -346,39 +345,63 @@ impl HyperliquidCli {
     ) -> InfraResult<Vec<InstrumentInfo>> {
         match inst_type {
             InstrumentType::Perpetual => {
-                let body = json!({ "type": "meta", "dex": self._perp_dex() });
-                let res: RestResHyperliquid<RestMetaHyperliquid> =
-                    self._post_info_raw(&body).await?;
-
-                let data = res
-                    .into_vec()?
-                    .into_iter()
-                    .next()
-                    .ok_or(InfraError::ApiCliError(
-                        "No Hyperliquid perpetual instrument info returned".into(),
-                    ))?;
-
-                Ok(data.into_instrument_info())
+                let (data, _) = self._get_perp_instrument_info_with_quote().await?;
+                Ok(data)
             },
-            InstrumentType::Spot => {
-                let body = json!({ "type": "spotMeta" });
-                let res: RestResHyperliquid<RestSpotMetaHyperliquid> =
-                    self._post_info_raw(&body).await?;
-
-                let data = res
-                    .into_vec()?
-                    .into_iter()
-                    .next()
-                    .ok_or(InfraError::ApiCliError(
-                        "No Hyperliquid spot instrument info returned".into(),
-                    ))?;
-
-                Ok(data.into_instrument_info())
-            },
+            InstrumentType::Spot => Ok(self._get_spot_meta().await?.into_instrument_info()),
             _ => Err(InfraError::ApiCliError(
                 "Hyperliquid get_instrument_info currently supports Spot and Perpetual only".into(),
             )),
         }
+    }
+
+    async fn _get_perp_instrument_info_with_quote(
+        &self,
+    ) -> InfraResult<(Vec<InstrumentInfo>, String)> {
+        let meta = self._get_perp_meta().await?;
+        let quote = self._perp_quote_from_meta(&meta).await?;
+        Ok((meta.into_instrument_info(&quote), quote))
+    }
+
+    async fn _get_perp_meta(&self) -> InfraResult<RestMetaHyperliquid> {
+        let body = json!({ "type": "meta", "dex": self._perp_dex() });
+        let res: RestResHyperliquid<RestMetaHyperliquid> = self._post_info_raw(&body).await?;
+
+        res.into_vec()?
+            .into_iter()
+            .next()
+            .ok_or(InfraError::ApiCliError(
+                "No Hyperliquid perpetual instrument info returned".into(),
+            ))
+    }
+
+    async fn _get_spot_meta(&self) -> InfraResult<RestSpotMetaHyperliquid> {
+        let body = json!({ "type": "spotMeta" });
+        let res: RestResHyperliquid<RestSpotMetaHyperliquid> = self._post_info_raw(&body).await?;
+
+        res.into_vec()?
+            .into_iter()
+            .next()
+            .ok_or(InfraError::ApiCliError(
+                "No Hyperliquid spot instrument info returned".into(),
+            ))
+    }
+
+    async fn _perp_quote_from_meta(&self, meta: &RestMetaHyperliquid) -> InfraResult<String> {
+        let Some(collateral_token) = meta.collateral_token else {
+            return Ok(HYPERLIQUID_QUOTE.to_string());
+        };
+
+        let spot_meta = self._get_spot_meta().await?;
+        spot_meta
+            .token_name(collateral_token)
+            .map(hyperliquid_symbol_to_cli_symbol)
+            .ok_or_else(|| {
+                InfraError::ApiCliError(format!(
+                    "Hyperliquid collateral token not found in spotMeta: {}",
+                    collateral_token
+                ))
+            })
     }
 
     async fn _get_tickers(
@@ -388,6 +411,7 @@ impl HyperliquidCli {
     ) -> InfraResult<Vec<TickerData>> {
         match inst_type.unwrap_or(InstrumentType::Perpetual) {
             InstrumentType::Perpetual => {
+                let quote = self._perp_quote_for_conversion()?;
                 let body = json!({ "type": "allMids", "dex": self._perp_dex() });
                 let res: RestResHyperliquid<RestAllMidsHyperliquid> =
                     self._post_info_raw(&body).await?;
@@ -399,7 +423,7 @@ impl HyperliquidCli {
                     .ok_or(InfraError::ApiCliError(
                         "No Hyperliquid allMids data returned".into(),
                     ))?
-                    .into_perp_ticker_data(get_micros_timestamp())
+                    .into_perp_ticker_data(get_micros_timestamp(), quote)
                     .into_iter()
                     .filter(|ticker| match insts {
                         Some(list) => list.contains(&ticker.inst),
@@ -422,19 +446,7 @@ impl HyperliquidCli {
                             "No Hyperliquid allMids data returned".into(),
                         ))?;
 
-                let meta_body = json!({ "type": "spotMeta" });
-                let meta_res: RestResHyperliquid<RestSpotMetaHyperliquid> =
-                    self._post_info_raw(&meta_body).await?;
-                let meta =
-                    meta_res
-                        .into_vec()?
-                        .into_iter()
-                        .next()
-                        .ok_or(InfraError::ApiCliError(
-                            "No Hyperliquid spot instrument info returned".into(),
-                        ))?;
-
-                let spot_inst_by_coin = meta.into_spot_inst_by_coin();
+                let spot_inst_by_coin = self._get_spot_meta().await?.into_spot_inst_by_coin();
                 let data = mids
                     .into_spot_ticker_data(get_micros_timestamp(), &spot_inst_by_coin)
                     .into_iter()
@@ -532,13 +544,12 @@ impl HyperliquidCli {
             ))?;
 
         let normalized_insts = normalize_inst_filters(insts);
-        let mark_px_by_coin = self
-            ._get_meta_and_asset_ctxs()
-            .await?
-            .into_perp_mark_px_by_coin()?;
+        let ctxs = self._get_meta_and_asset_ctxs().await?;
+        let quote = self._perp_quote_from_meta(&ctxs.0).await?;
+        let mark_px_by_coin = ctxs.into_perp_mark_px_by_coin()?;
 
         let positions = data
-            .into_position_data(&mark_px_by_coin)
+            .into_position_data(&mark_px_by_coin, &quote)
             .into_iter()
             .filter(|position| match &normalized_insts {
                 Some(insts) => insts.contains(&position.inst),
@@ -576,6 +587,11 @@ impl HyperliquidCli {
         };
 
         let normalized_inst = normalize_hyperliquid_cli_inst(inst);
+        let perp_quote = if is_hyperliquid_cli_perp_inst(&normalized_inst) {
+            Some(hyperliquid_cli_perp_quote(&normalized_inst)?)
+        } else {
+            None
+        };
 
         let res: RestResHyperliquid<RestOrderStatusHyperliquid> =
             self._post_info_raw(&body).await?;
@@ -583,7 +599,7 @@ impl HyperliquidCli {
         let mut data: Vec<HistoOrderData> = res
             .into_vec()?
             .into_iter()
-            .map(HistoOrderData::from)
+            .map(|order| order.into_histo_order_data(perp_quote.as_deref()))
             .filter(|order| order.inst == normalized_inst)
             .collect();
 
@@ -679,17 +695,23 @@ impl HyperliquidCli {
     }
 
     fn _inst_to_trade_coin(&self, inst: &str) -> InfraResult<String> {
+        let normalized_inst = normalize_hyperliquid_cli_inst(inst);
+        if is_hyperliquid_cli_perp_inst(&normalized_inst) {
+            self._ensure_perp_quote_matches(&normalized_inst)?;
+            return self._inst_to_raw_perp_coin(&normalized_inst);
+        }
+
         if let Some(coin) = hyperliquid_cli_inst_to_raw_trade_coin(inst) {
             return Ok(coin);
         }
 
-        let normalized_inst = normalize_hyperliquid_cli_inst(inst);
         let index = self
+            .market_cache
             .inst_index_map
             .get(&normalized_inst)
             .copied()
             .ok_or_else(|| {
-                if self.inst_index_map.is_empty() {
+                if self.market_cache.inst_index_map.is_empty() {
                     InfraError::ApiCliError(
                         "Hyperliquid inst_index_map is empty, call init_inst_index_map() first"
                             .into(),
@@ -705,6 +727,14 @@ impl HyperliquidCli {
         Ok(format!("@{}", index))
     }
 
+    fn _inst_to_raw_perp_coin(&self, inst: &str) -> InfraResult<String> {
+        let base = hyperliquid_cli_inst_to_raw_perp_coin(inst)?;
+        match self.market_cache.perp_dex.as_deref() {
+            Some(dex) => Ok(format!("{dex}:{base}")),
+            None => Ok(base),
+        }
+    }
+
     fn _owner_address(&self) -> InfraResult<&str> {
         self.auth
             .as_ref()
@@ -713,11 +743,42 @@ impl HyperliquidCli {
     }
 
     fn _perp_dex(&self) -> &str {
-        self.default_perp_dex.as_deref().unwrap_or("")
+        self.market_cache.perp_dex()
+    }
+
+    fn _perp_quote_for_conversion(&self) -> InfraResult<&str> {
+        match (
+            self.market_cache.perp_dex.as_deref(),
+            self.market_cache.perp_quote.as_deref(),
+        ) {
+            (Some(_), Some(quote)) => Ok(quote),
+            (Some(dex), None) => Err(InfraError::ApiCliError(format!(
+                "Hyperliquid perp quote is not initialized for dex {}, call init_inst_index_map() first",
+                dex
+            ))),
+            (None, Some(quote)) => Ok(quote),
+            (None, None) => Ok(HYPERLIQUID_QUOTE),
+        }
+    }
+
+    fn _ensure_perp_quote_matches(&self, inst: &str) -> InfraResult<()> {
+        let inst_quote = hyperliquid_cli_perp_quote(inst)?;
+        let expected_quote = self._perp_quote_for_conversion()?;
+        if inst_quote != expected_quote {
+            return Err(InfraError::ApiCliError(format!(
+                "Hyperliquid perp quote mismatch for {}: expected {} for dex {}, got {}",
+                inst,
+                expected_quote,
+                self._perp_dex(),
+                inst_quote
+            )));
+        }
+
+        Ok(())
     }
 
     async fn _resolve_perp_dex_index(&self) -> InfraResult<Option<u32>> {
-        let Some(dex) = self.default_perp_dex.as_deref() else {
+        let Some(dex) = self.market_cache.perp_dex.as_deref() else {
             return Ok(None);
         };
 
@@ -773,11 +834,12 @@ impl HyperliquidCli {
     fn _inst_to_asset_id(&self, inst: &str) -> InfraResult<u32> {
         let normalized_inst = normalize_hyperliquid_cli_inst(inst);
         let index = self
+            .market_cache
             .inst_index_map
             .get(&normalized_inst)
             .copied()
             .ok_or_else(|| {
-                if self.inst_index_map.is_empty() {
+                if self.market_cache.inst_index_map.is_empty() {
                     InfraError::ApiCliError(
                         "Hyperliquid inst_index_map is empty, call init_inst_index_map() first"
                             .into(),
@@ -790,9 +852,10 @@ impl HyperliquidCli {
                 }
             })?;
 
-        if normalized_inst.ends_with(HYPERLIQUID_PERP_SUFFIX) {
-            let perp_dex_index = match self.default_perp_dex.as_deref() {
-                Some(dex) => Some(self.default_perp_dex_index.ok_or_else(|| {
+        if is_hyperliquid_cli_perp_inst(&normalized_inst) {
+            self._ensure_perp_quote_matches(&normalized_inst)?;
+            let perp_dex_index = match self.market_cache.perp_dex.as_deref() {
+                Some(dex) => Some(self.market_cache.perp_dex_index.ok_or_else(|| {
                     InfraError::ApiCliError(format!(
                         "Hyperliquid perp dex index is not initialized for dex {}, call init_inst_index_map() first",
                         dex

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest/all_mids.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest/all_mids.rs
@@ -12,13 +12,13 @@ use crate::arch::market_assets::{
 pub struct RestAllMidsHyperliquid(pub HashMap<String, String>);
 
 impl RestAllMidsHyperliquid {
-    pub fn into_perp_ticker_data(self, timestamp: u64) -> Vec<TickerData> {
+    pub fn into_perp_ticker_data(self, timestamp: u64, quote: &str) -> Vec<TickerData> {
         self.0
             .into_iter()
             .filter(|(coin, _)| !coin.starts_with('@') && !coin.contains('/'))
             .map(|(coin, price)| TickerData {
                 timestamp,
-                inst: hyperliquid_perp_to_cli(&coin),
+                inst: hyperliquid_perp_to_cli(&coin, quote),
                 inst_type: InstrumentType::Perpetual,
                 price: price.parse().unwrap_or_default(),
             })

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest/asset_ctxs.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest/asset_ctxs.rs
@@ -51,7 +51,7 @@ impl RestMetaAndAssetCtxsHyperliquid {
             .collect())
     }
 
-    pub fn into_funding_rate_data(self) -> InfraResult<Vec<FundingRateData>> {
+    pub fn into_funding_rate_data(self, quote: &str) -> InfraResult<Vec<FundingRateData>> {
         let now_ms = get_mills_timestamp();
         let timestamp = ts_to_micros(now_ms);
         let funding_time = ts_to_micros(hyperliquid_next_funding_time_ms(now_ms));
@@ -63,14 +63,14 @@ impl RestMetaAndAssetCtxsHyperliquid {
             .zip(asset_ctxs)
             .map(|(meta, ctx)| FundingRateData {
                 timestamp,
-                inst: hyperliquid_perp_to_cli(&meta.name),
+                inst: hyperliquid_perp_to_cli(&meta.name, quote),
                 funding_rate: value_to_f64(&ctx.funding),
                 funding_time,
             })
             .collect())
     }
 
-    pub fn into_funding_rate_info(self) -> InfraResult<Vec<FundingRateInfo>> {
+    pub fn into_funding_rate_info(self, quote: &str) -> InfraResult<Vec<FundingRateInfo>> {
         let timestamp = ts_to_micros(get_mills_timestamp());
         let funding_interval_sec = hyperliquid_funding_interval_sec();
         let (meta, asset_ctxs) = self.split()?;
@@ -81,7 +81,7 @@ impl RestMetaAndAssetCtxsHyperliquid {
             .zip(asset_ctxs)
             .map(|(meta, _)| FundingRateInfo {
                 timestamp,
-                inst: hyperliquid_perp_to_cli(&meta.name),
+                inst: hyperliquid_perp_to_cli(&meta.name, quote),
                 funding_interval_sec,
             })
             .collect())

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest/clearinghouse_state.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest/clearinghouse_state.rs
@@ -17,7 +17,11 @@ pub struct RestClearinghouseStateHyperliquid {
 }
 
 impl RestClearinghouseStateHyperliquid {
-    pub fn into_position_data(self, mark_px_by_coin: &HashMap<String, f64>) -> Vec<PositionData> {
+    pub fn into_position_data(
+        self,
+        mark_px_by_coin: &HashMap<String, f64>,
+        quote: &str,
+    ) -> Vec<PositionData> {
         self.assetPositions
             .into_iter()
             .map(|position| {
@@ -25,7 +29,7 @@ impl RestClearinghouseStateHyperliquid {
                     .get(&position.position.coin)
                     .copied()
                     .unwrap_or_default();
-                position.into_position_data(mark_price)
+                position.into_position_data(mark_price, quote)
             })
             .collect()
     }
@@ -60,12 +64,12 @@ pub struct RestLeverageHyperliquid {
 }
 
 impl RestAssetPositionHyperliquid {
-    pub fn into_position_data(self, mark_price: f64) -> PositionData {
+    pub fn into_position_data(self, mark_price: f64, quote: &str) -> PositionData {
         let size = value_to_f64(&self.position.szi);
 
         PositionData {
             timestamp: get_micros_timestamp(),
-            inst: hyperliquid_perp_to_cli(&self.position.coin),
+            inst: hyperliquid_perp_to_cli(&self.position.coin, quote),
             inst_type: InstrumentType::Perpetual,
             position_side: if size > 0.0 {
                 PositionSide::Long

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest/funding_history.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest/funding_history.rs
@@ -21,13 +21,13 @@ pub struct RestFundingHistoryHyperliquid {
     pub time: u64,
 }
 
-impl From<RestFundingHistoryHyperliquid> for FundingRateData {
-    fn from(d: RestFundingHistoryHyperliquid) -> Self {
+impl RestFundingHistoryHyperliquid {
+    pub fn into_funding_rate_data(self, quote: &str) -> FundingRateData {
         FundingRateData {
             timestamp: get_micros_timestamp(),
-            inst: hyperliquid_perp_to_cli(&d.coin),
-            funding_rate: d.fundingRate.parse().unwrap_or_default(),
-            funding_time: ts_to_micros(d.time),
+            inst: hyperliquid_perp_to_cli(&self.coin, quote),
+            funding_rate: self.fundingRate.parse().unwrap_or_default(),
+            funding_time: ts_to_micros(self.time),
         }
     }
 }

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest/meta.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest/meta.rs
@@ -9,6 +9,8 @@ use crate::arch::market_assets::{
 #[derive(Clone, Debug, Deserialize)]
 pub struct RestMetaHyperliquid {
     pub universe: Vec<RestMetaUniverseHyperliquid>,
+    #[serde(default, rename = "collateralToken")]
+    pub collateral_token: Option<u32>,
 }
 
 #[allow(non_snake_case)]
@@ -23,17 +25,17 @@ pub struct RestMetaUniverseHyperliquid {
 }
 
 impl RestMetaHyperliquid {
-    pub fn into_instrument_info(self) -> Vec<InstrumentInfo> {
+    pub fn into_instrument_info(self, quote: &str) -> Vec<InstrumentInfo> {
         self.universe
             .into_iter()
             .enumerate()
-            .map(|(index, inst)| inst.into_instrument_info(index))
+            .map(|(index, inst)| inst.into_instrument_info(index, quote))
             .collect()
     }
 }
 
 impl RestMetaUniverseHyperliquid {
-    fn into_instrument_info(self, index: usize) -> InstrumentInfo {
+    fn into_instrument_info(self, index: usize, quote: &str) -> InstrumentInfo {
         let lot_size = if self.szDecimals == 0 {
             1.0
         } else {
@@ -41,7 +43,7 @@ impl RestMetaUniverseHyperliquid {
         };
 
         InstrumentInfo {
-            inst: hyperliquid_perp_to_cli(&self.name),
+            inst: hyperliquid_perp_to_cli(&self.name, quote),
             inst_code: Some(hyperliquid_perp_asset_id(index)),
             inst_type: InstrumentType::Perpetual,
             lot_size,

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest/order_status.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest/order_status.rs
@@ -5,7 +5,7 @@ use crate::arch::market_assets::{
     api_data::account_data::HistoOrderData,
     api_general::{ts_to_micros, value_to_f64},
     base_data::{OrderSide, OrderStatus, OrderType},
-    exchange::hyperliquid::api_utils::hyperliquid_inst_to_cli,
+    exchange::hyperliquid::api_utils::{hyperliquid_inst_to_cli, hyperliquid_perp_to_cli},
 };
 
 #[allow(non_snake_case)]
@@ -32,13 +32,26 @@ pub struct RestBasicOrderHyperliquid {
 
 impl From<RestOrderStatusHyperliquid> for HistoOrderData {
     fn from(d: RestOrderStatusHyperliquid) -> Self {
+        d.into_histo_order_data(None)
+    }
+}
+
+impl RestOrderStatusHyperliquid {
+    pub fn into_histo_order_data(self, perp_quote: Option<&str>) -> HistoOrderData {
+        let d = self;
         let remaining_size = value_to_f64(&d.order.sz).abs();
         let orig_size = value_to_f64(&d.order.origSz).abs();
         let filled_size = (orig_size - remaining_size).max(0.0);
+        let inst = match perp_quote {
+            Some(quote) if !d.order.coin.contains('/') && !d.order.coin.starts_with('@') => {
+                hyperliquid_perp_to_cli(&d.order.coin, quote)
+            },
+            _ => hyperliquid_inst_to_cli(&d.order.coin),
+        };
 
         HistoOrderData {
             timestamp: ts_to_micros(d.order.timestamp),
-            inst: hyperliquid_inst_to_cli(&d.order.coin),
+            inst,
             order_id: d.order.oid.to_string(),
             cli_order_id: d.order.cloid.filter(|id| !id.is_empty()),
             side: match d.order.side.as_str() {

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest/spot_meta.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest/spot_meta.rs
@@ -44,6 +44,13 @@ pub struct RestSpotTokenHyperliquid {
 }
 
 impl RestSpotMetaHyperliquid {
+    pub fn token_name(&self, token_index: u32) -> Option<&str> {
+        self.tokens
+            .iter()
+            .find(|token| token.index == token_index)
+            .map(|token| token.name.as_str())
+    }
+
     pub fn into_instrument_info(self) -> Vec<InstrumentInfo> {
         let token_map: HashMap<u32, RestSpotTokenHyperliquid> = self
             .tokens


### PR DESCRIPTION
Summary
- normalize Hyperliquid perps as BASE_QUOTE_PERP instead of assuming USDC
- derive builder dex collateral quotes from meta/spotMeta during market cache initialization
- validate quote/dex matches before converting instruments to Hyperliquid asset ids

Tests
- cargo fmt --check
- cargo check --all-features
- cargo test --features hyperliquid hyperliquid::api_utils::tests

Live smoke checked via api_checkers
- flx: OIL_USDH_PERP open/close succeeded
- vntl: WHEAT_USDH_PERP open/close succeeded