### PR TITLE
chore: release extrema_infra 0.1.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 
 readme = "README.md"


### PR DESCRIPTION
Summary
- bump extrema_infra crate version from 0.1.3 to 0.1.4
- prepare crates.io release for the Hyperliquid builder dex quote changes

Checks
- cargo fmt --check
- cargo check --all-features
- cargo test --features hyperliquid hyperliquid::api_utils::tests
- cargo publish --dry-run --all-features