### PR TITLE
feat!: add instrument key extra field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 
 readme = "README.md"

--- a/src/arch/market_assets/base_data.rs
+++ b/src/arch/market_assets/base_data.rs
@@ -7,6 +7,7 @@ pub struct InstrumentKey {
     pub market: Option<Market>,
     pub inst_type: InstrumentType,
     pub inst: String,
+    pub extra: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Hash, Eq, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- add an optional extra field to InstrumentKey for route/scope-specific identity
- bump crate version to 0.1.5

## Breaking Change
- InstrumentKey now includes extra: Option<String>
- Downstream struct literals must provide the new field, usually extra: None

## Verification
- cargo fmt --check
- cargo check --all-features --all-targets