### PR TITLE
feat: add market scope key

### DIFF
--- a/src/arch/market_assets/base_data.rs
+++ b/src/arch/market_assets/base_data.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use super::market_core::Market;
+use super::market_core::{Market, MarketScope};
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub struct InstrumentKey {
@@ -8,6 +8,14 @@ pub struct InstrumentKey {
     pub inst_type: InstrumentType,
     pub inst: String,
     pub extra: Option<String>,
+}
+
+impl InstrumentKey {
+    pub fn market_scope(&self) -> Option<MarketScope> {
+        self.market
+            .clone()
+            .map(|market| MarketScope::new(market, self.extra.clone()))
+    }
 }
 
 #[derive(Clone, Debug, Default, Hash, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/arch/market_assets/exchange/hyperliquid/api_utils.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/api_utils.rs
@@ -15,6 +15,7 @@ pub const HYPERLIQUID_BUILDER_PERP_DEX_STRIDE: u32 = 10_000;
 pub const HYPERLIQUID_FUNDING_INTERVAL_HOURS: u64 = 1;
 pub const HYPERLIQUID_BUILDER_ADDRESS_EXTRA_KEY: &str = "builder_b";
 pub const HYPERLIQUID_BUILDER_FEE_EXTRA_KEY: &str = "builder_f";
+pub const HYPERLIQUID_PERP_DEX_SCOPE_PREFIX: &str = "hl_dex:";
 const HYPERLIQUID_FUNDING_INTERVAL_MS: u64 = HYPERLIQUID_FUNDING_INTERVAL_HOURS * 60 * 60 * 1000;
 const HYPERLIQUID_KILO_PREFIX: &str = "k";
 const CLI_KILO_PREFIX: &str = "1000";
@@ -45,6 +46,23 @@ impl HyperliquidMarketCache {
 
 pub fn hyperliquid_perp_asset_id(index: usize) -> String {
     index.to_string()
+}
+
+pub fn hyperliquid_scope_extra_from_dex(dex: &str) -> Option<String> {
+    let dex = dex.trim();
+    if dex.is_empty() {
+        None
+    } else {
+        Some(format!("{HYPERLIQUID_PERP_DEX_SCOPE_PREFIX}{dex}"))
+    }
+}
+
+pub fn hyperliquid_dex_from_scope_extra(extra: Option<&str>) -> Option<String> {
+    extra?
+        .strip_prefix(HYPERLIQUID_PERP_DEX_SCOPE_PREFIX)
+        .map(str::trim)
+        .filter(|dex| !dex.is_empty())
+        .map(ToString::to_string)
 }
 
 pub fn hyperliquid_spot_asset_id(index: u32) -> String {

--- a/src/arch/market_assets/market_core.rs
+++ b/src/arch/market_assets/market_core.rs
@@ -14,3 +14,31 @@ pub enum Market {
     GateUni,
     Okx,
 }
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct MarketScope {
+    pub market: Market,
+    pub extra: Option<String>,
+}
+
+impl MarketScope {
+    pub fn new(market: Market, extra: Option<String>) -> Self {
+        Self {
+            market,
+            extra: normalize_scope_extra(extra),
+        }
+    }
+
+    pub fn default_for(market: Market) -> Self {
+        Self {
+            market,
+            extra: None,
+        }
+    }
+}
+
+fn normalize_scope_extra(extra: Option<String>) -> Option<String> {
+    extra
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -15,7 +15,10 @@ pub use crate::errors::{InfraError, InfraResult};
 
 pub use crate::arch::{
     infra_core::{env_builder::EnvBuilder, env_mediator::EnvMediator},
-    market_assets::{base_data::*, market_core::Market},
+    market_assets::{
+        base_data::*,
+        market_core::{Market, MarketScope},
+    },
     strategy_base::{
         command::{
             ack_handle::{AckHandle, AckStatus},


### PR DESCRIPTION
## Summary
- add MarketScope as a reusable Market + extra routing key
- expose InstrumentKey::market_scope for deriving client scopes
- add Hyperliquid hl_dex scope extra format/parse helpers

## Tests
- cargo fmt --check
- cargo check --all-targets --features hyperliquid