### PR TITLE
feat(okx): add account settings APIs

### DIFF
--- a/src/arch/market_assets/exchange/okx/config_assets.rs
+++ b/src/arch/market_assets/exchange/okx/config_assets.rs
@@ -6,8 +6,10 @@ pub const OKX_BASE_URL: &str = "https://www.okx.com";
 
 /// REST endpoints
 pub const OKX_ACCOUNT_BALANCE: &str = "/api/v5/account/balance";
+pub const OKX_ACCOUNT_CONFIG: &str = "/api/v5/account/config";
 pub const OKX_ACCOUNT_POSITIONS: &str = "/api/v5/account/positions";
 pub const OKX_ACCOUNT_SET_LEVERAGE: &str = "/api/v5/account/set-leverage";
+pub const OKX_ACCOUNT_SET_POSITION_MODE: &str = "/api/v5/account/set-position-mode";
 pub const OKX_ASSET_CURRENCIES: &str = "/api/v5/asset/currencies";
 pub const OKX_ASSET_BALANCES: &str = "/api/v5/asset/balances";
 pub const OKX_ASSET_DEPOSIT_ADDRESS: &str = "/api/v5/asset/deposit-address";

--- a/src/arch/market_assets/exchange/okx/okx_cli.rs
+++ b/src/arch/market_assets/exchange/okx/okx_cli.rs
@@ -23,9 +23,11 @@ use super::{
     config_assets::*,
     okx_rest_msg::RestResOkx,
     schemas::rest::{
-        account_balance::RestAccountBalOkx, account_positions::RestAccountPosOkx,
-        account_set_leverage::RestAccountSetLeverageOkx, asset_balances::RestAssetBalanceOkx,
-        asset_currencies::RestAssetCurrencyOkx, asset_deposit_address::RestAssetDepositAddressOkx,
+        account_balance::RestAccountBalOkx, account_config::RestAccountConfigOkx,
+        account_positions::RestAccountPosOkx, account_set_leverage::RestAccountSetLeverageOkx,
+        account_set_position_mode::RestAccountSetPositionModeOkx,
+        asset_balances::RestAssetBalanceOkx, asset_currencies::RestAssetCurrencyOkx,
+        asset_deposit_address::RestAssetDepositAddressOkx,
         asset_deposit_history::RestAssetDepositHistoryOkx, asset_transfer::RestAssetTransferOkx,
         asset_transfer_state::RestAssetTransferStateOkx, asset_withdrawal::RestAssetWithdrawalOkx,
         asset_withdrawal_history::RestAssetWithdrawalHistoryOkx,
@@ -175,6 +177,58 @@ impl OkxCli {
         });
 
         Ok(msg.to_string())
+    }
+
+    pub async fn get_account_config(&self) -> InfraResult<Vec<RestAccountConfigOkx>> {
+        let res: RestResOkx<RestAccountConfigOkx> = self
+            .api_key
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_signed_request(
+                &self.client,
+                RequestMethod::Get,
+                "{}".into(),
+                OKX_BASE_URL,
+                OKX_ACCOUNT_CONFIG,
+            )
+            .await?;
+
+        res.into_vec()
+    }
+
+    pub async fn set_position_mode(
+        &self,
+        hedge_mode: bool,
+    ) -> InfraResult<RestAccountSetPositionModeOkx> {
+        let pos_mode = if hedge_mode {
+            "long_short_mode"
+        } else {
+            "net_mode"
+        };
+        let body = json!({ "posMode": pos_mode }).to_string();
+
+        let res: RestResOkx<RestAccountSetPositionModeOkx> = self
+            .api_key
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_signed_request(
+                &self.client,
+                RequestMethod::Post,
+                body,
+                OKX_BASE_URL,
+                OKX_ACCOUNT_SET_POSITION_MODE,
+            )
+            .await?;
+
+        let data = res
+            .into_vec()?
+            .into_iter()
+            .next()
+            .ok_or(InfraError::ApiCliError(
+                "No OKX position mode data returned".into(),
+            ))?;
+
+        Ok(data)
     }
 
     pub async fn set_leverage(

--- a/src/arch/market_assets/exchange/okx/schemas/rest.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/rest.rs
@@ -1,6 +1,8 @@
 pub mod account_balance;
+pub mod account_config;
 pub mod account_positions;
 pub mod account_set_leverage;
+pub mod account_set_position_mode;
 pub mod asset_balances;
 pub mod asset_currencies;
 pub mod asset_deposit_address;

--- a/src/arch/market_assets/exchange/okx/schemas/rest/account_config.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/rest/account_config.rs
@@ -1,0 +1,46 @@
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::HashMap;
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct RestAccountConfigOkx {
+    #[serde(default)]
+    pub uid: Option<String>,
+    #[serde(default)]
+    pub mainUid: Option<String>,
+    #[serde(default)]
+    pub acctLv: Option<String>,
+    #[serde(default)]
+    pub posMode: Option<String>,
+    #[serde(default)]
+    pub autoLoan: Option<bool>,
+    #[serde(default)]
+    pub greeksType: Option<String>,
+    #[serde(default)]
+    pub feeType: Option<String>,
+    #[serde(default)]
+    pub acctStpMode: Option<String>,
+    #[serde(default)]
+    pub ctIsoMode: Option<String>,
+    #[serde(default)]
+    pub mgnIsoMode: Option<String>,
+    #[serde(default)]
+    pub spotOffsetType: Option<String>,
+    #[serde(default)]
+    pub roleType: Option<String>,
+    #[serde(default)]
+    pub spotRoleType: Option<String>,
+    #[serde(default)]
+    pub opAuth: Option<String>,
+    #[serde(default)]
+    pub kycLv: Option<String>,
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(default)]
+    pub traderInsts: Option<Vec<String>>,
+    #[serde(default)]
+    pub enableSpotBorrow: Option<bool>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}

--- a/src/arch/market_assets/exchange/okx/schemas/rest/account_set_position_mode.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/rest/account_set_position_mode.rs
@@ -1,0 +1,7 @@
+use serde::Deserialize;
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestAccountSetPositionModeOkx {
+    pub posMode: String,
+}


### PR DESCRIPTION
## Summary
- add OKX account config and set-position-mode endpoints
- expose OkxCli helpers for reading account config and toggling net/long-short position mode
- add typed OKX account config and position mode response schemas

## Test plan
- cargo check --features okx
- cargo check --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features
- git diff --check