### PR TITLE
fix(binance,gate,okx): correct derivative symbol conversion

### DIFF
--- a/src/arch/market_assets/exchange/binance/api_utils.rs
+++ b/src/arch/market_assets/exchange/binance/api_utils.rs
@@ -401,13 +401,64 @@ fn cli_um_to_binance_symbol(symbol: &str) -> String {
 }
 
 pub fn cli_perp_to_binance_cm(symbol: &str) -> String {
-    symbol
-        .strip_suffix("_PERP")
-        .unwrap_or(symbol)
-        .replace("_USDT", "USD")
-        .to_string()
+    let upper = symbol.to_uppercase();
+    if let Some(pair) = upper.strip_suffix("_PERP") {
+        return format!("{}_PERP", normalize_binance_cm_pair(pair));
+    }
+
+    if let Some((pair, expiry)) = upper.rsplit_once("_FUT_") {
+        return format!("{}_{}", normalize_binance_cm_pair(pair), expiry);
+    }
+
+    normalize_binance_cm_pair(&upper)
+}
+
+pub fn cli_perp_to_binance_cm_pair(symbol: &str) -> String {
+    let upper = symbol.to_uppercase();
+    if let Some(pair) = upper.strip_suffix("_PERP") {
+        return normalize_binance_cm_pair(pair);
+    }
+
+    if let Some((pair, _)) = upper.rsplit_once("_FUT_") {
+        return normalize_binance_cm_pair(pair);
+    }
+
+    normalize_binance_cm_pair(&upper)
+}
+
+fn normalize_binance_cm_pair(pair: &str) -> String {
+    if let Some(base) = pair.strip_suffix("_USDT") {
+        format!("{}USD", base.replace('_', ""))
+    } else if let Some(base) = pair.strip_suffix("USDT") {
+        format!("{base}USD")
+    } else {
+        pair.replace('_', "")
+    }
 }
 
 pub fn cli_spot_to_binance_spot(inst: &str) -> String {
     inst.replace('_', "").to_uppercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_binance_cm_between_cli_and_native_symbol() {
+        assert_eq!(binance_fut_inst_to_cli("BTCUSD_PERP"), "BTC_USD_PERP");
+        assert_eq!(cli_perp_to_binance_cm("BTC_USD_PERP"), "BTCUSD_PERP");
+        assert_eq!(cli_perp_to_binance_cm("BTC_USDT_PERP"), "BTCUSD_PERP");
+        assert_eq!(
+            cli_perp_to_binance_cm("BTC_USD_FUT_240329"),
+            "BTCUSD_240329"
+        );
+    }
+
+    #[test]
+    fn converts_binance_cm_cli_to_pair_for_pair_endpoints() {
+        assert_eq!(cli_perp_to_binance_cm_pair("BTC_USD_PERP"), "BTCUSD");
+        assert_eq!(cli_perp_to_binance_cm_pair("BTC_USDT_PERP"), "BTCUSD");
+        assert_eq!(cli_perp_to_binance_cm_pair("BTC_USD_FUT_240329"), "BTCUSD");
+    }
 }

--- a/src/arch/market_assets/exchange/binance/binance_cm_futures_cli.rs
+++ b/src/arch/market_assets/exchange/binance/binance_cm_futures_cli.rs
@@ -177,7 +177,7 @@ impl BinanceCmCli {
         let mut url = format!(
             "{}/futures/data/openInterestHist?pair={}&contractType={}&period={}",
             BINANCE_CM_FUTURES_BASE_URL,
-            cli_perp_to_binance_cm(inst),
+            cli_perp_to_binance_cm_pair(inst),
             contract_type_str,
             period,
         );

--- a/src/arch/market_assets/exchange/gate/api_utils.rs
+++ b/src/arch/market_assets/exchange/gate/api_utils.rs
@@ -34,6 +34,10 @@ pub fn gate_fut_inst_to_cli(symbol: &str) -> String {
 }
 
 pub fn cli_perp_to_gate_inst(symbol: &str) -> String {
+    if let Some((pair, expiry)) = symbol.rsplit_once("_FUT_") {
+        return format!("{}_{}", pair, expiry).to_uppercase();
+    }
+
     let cleaned = symbol
         .strip_suffix("_PERP")
         .or_else(|| symbol.strip_suffix("_FUTURE"))
@@ -64,7 +68,10 @@ pub fn infer_settle_from_inst(inst: &str) -> String {
     let gate_inst = cli_perp_to_gate_inst(inst);
     let parts: Vec<&str> = gate_inst.split('_').collect();
     let quote = parts.get(1).copied().unwrap_or("USDT");
-    quote.to_lowercase()
+    match quote {
+        "USD" => "btc".to_string(),
+        _ => quote.to_lowercase(),
+    }
 }
 
 pub fn normalize_gate_text(text: &str) -> String {
@@ -190,5 +197,31 @@ impl GateWithdrawReq {
         }
 
         body.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_gate_futures_between_cli_and_native_symbol() {
+        assert_eq!(gate_fut_inst_to_cli("BTC_USD"), "BTC_USD_PERP");
+        assert_eq!(cli_perp_to_gate_inst("BTC_USD_PERP"), "BTC_USD");
+        assert_eq!(
+            gate_fut_inst_to_cli("BTC_USD_20241227"),
+            "BTC_USD_FUT_20241227"
+        );
+        assert_eq!(
+            cli_perp_to_gate_inst("BTC_USD_FUT_20241227"),
+            "BTC_USD_20241227"
+        );
+    }
+
+    #[test]
+    fn infers_gate_settle_for_linear_and_inverse_contracts() {
+        assert_eq!(infer_settle_from_inst("ZRX_USDT_PERP"), "usdt");
+        assert_eq!(infer_settle_from_inst("BTC_USD_PERP"), "btc");
+        assert_eq!(infer_settle_from_inst("BTC_USD_FUT_20241227"), "btc");
     }
 }

--- a/src/arch/market_assets/exchange/okx/api_utils.rs
+++ b/src/arch/market_assets/exchange/okx/api_utils.rs
@@ -40,11 +40,16 @@ pub fn get_okx_timestamp() -> String {
 }
 
 pub fn cli_perp_to_okx_inst(symbol: &str) -> String {
-    let mut inst = symbol.replace('_', "-");
-    if inst.ends_with("-PERP") {
-        inst = inst.trim_end_matches("-PERP").to_string() + "-SWAP";
+    let upper = symbol.to_uppercase();
+    if let Some((pair, expiry)) = upper.rsplit_once("_FUT_") {
+        return format!("{}-{}", pair.replace('_', "-"), expiry);
     }
-    inst
+
+    if let Some(pair) = upper.strip_suffix("_PERP") {
+        return format!("{}-SWAP", pair.replace('_', "-"));
+    }
+
+    upper.replace('_', "-")
 }
 
 pub fn okx_inst_to_cli(symbol: &str) -> String {
@@ -356,5 +361,18 @@ impl OkxAssetDepositHistoryReq {
         }
 
         parts.join("&")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_okx_instruments_between_cli_and_native_symbol() {
+        assert_eq!(okx_inst_to_cli("BTC-USDT-SWAP"), "BTC_USDT_PERP");
+        assert_eq!(cli_perp_to_okx_inst("BTC_USDT_PERP"), "BTC-USDT-SWAP");
+        assert_eq!(okx_inst_to_cli("BTC-USD-240329"), "BTC_USD_FUT_240329");
+        assert_eq!(cli_perp_to_okx_inst("BTC_USD_FUT_240329"), "BTC-USD-240329");
     }
 }


### PR DESCRIPTION
## Summary
- correct Binance COIN-M CLI-to-native conversion for inverse perpetual and delivery symbols
- keep COIN-M pair endpoints on pair format like BTCUSD
- support Gate delivery-style FUT conversion and infer BTC settle for inverse USD contracts
- correct OKX FUT conversion from CLI format to native instId like BTC-USD-240329

## Test
- cargo fmt
- cargo check --features "binance gate okx" --lib --quiet
- cargo test --features "binance gate okx hyperliquid" --lib --quiet