### PR TITLE
feat(gate): support broker channel id on orders

### DIFF
--- a/src/arch/market_assets/exchange/gate/api_key.rs
+++ b/src/arch/market_assets/exchange/gate/api_key.rs
@@ -9,6 +9,8 @@ use serde_json::{Value, json};
 use crate::arch::market_assets::api_general::*;
 use crate::errors::{InfraError, InfraResult};
 
+use super::api_utils::GATE_CHANNEL_ID_HEADER;
+
 #[allow(dead_code)]
 pub fn read_gate_env_key() -> InfraResult<GateKey> {
     let _ = dotenvy::dotenv();
@@ -113,15 +115,30 @@ impl GateKey {
         body: &str,
         url: &str,
     ) -> InfraResult<Response> {
-        let res = client
+        self.post_request_with_channel_id(client, signature, body, url, None)
+            .await
+    }
+
+    pub(crate) async fn post_request_with_channel_id(
+        &self,
+        client: &Client,
+        signature: &Signature<u64>,
+        body: &str,
+        url: &str,
+        channel_id: Option<&str>,
+    ) -> InfraResult<Response> {
+        let mut request = client
             .post(url)
             .header("KEY", &self.api_key)
             .header("SIGN", &signature.signature)
             .header("Timestamp", signature.timestamp.to_string())
-            .header("Content-Type", "application/json")
-            .body(body.to_string())
-            .send()
-            .await?;
+            .header("Content-Type", "application/json");
+
+        if let Some(channel_id) = channel_id {
+            request = request.header(GATE_CHANNEL_ID_HEADER, channel_id);
+        }
+
+        let res = request.body(body.to_string()).send().await?;
 
         Ok(res)
     }
@@ -184,6 +201,31 @@ impl GateKey {
         };
 
         let label = format!("Gate {:?} {}", method, endpoint);
+        parse_json_response(&label, response).await
+    }
+
+    pub(crate) async fn send_signed_post_request_with_channel_id<T>(
+        &self,
+        client: &Client,
+        query_string: Option<&str>,
+        body: Option<&str>,
+        base_url: &str,
+        endpoint: &str,
+        channel_id: Option<&str>,
+    ) -> InfraResult<T>
+    where
+        T: DeserializeOwned + Send,
+    {
+        let encoded_query = encode_query_string(query_string);
+        let body_str = body.unwrap_or("");
+        let signature =
+            self.sign_now("POST", endpoint, encoded_query.as_deref(), Some(body_str))?;
+        let url = gate_build_full_url(base_url, endpoint, encoded_query.as_deref());
+        let response = self
+            .post_request_with_channel_id(client, &signature, body_str, &url, channel_id)
+            .await?;
+
+        let label = format!("Gate Post {}", endpoint);
         parse_json_response(&label, response).await
     }
 }

--- a/src/arch/market_assets/exchange/gate/api_utils.rs
+++ b/src/arch/market_assets/exchange/gate/api_utils.rs
@@ -1,9 +1,14 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tracing::error;
 
 use crate::arch::market_assets::{api_general::get_seconds_timestamp, base_data::SUBSCRIBE_LOWER};
 use crate::errors::{InfraError, InfraResult};
+
+pub const GATE_CHANNEL_ID_EXTRA_KEY: &str = "gate_channel_id";
+pub const GATE_CHANNEL_ID_HEADER: &str = "X-Gate-Channel-Id";
 
 pub fn ws_subscribe_msg_gate_futures(channel: &str, payload: Vec<String>) -> String {
     let msg = json!({
@@ -80,6 +85,30 @@ pub fn normalize_gate_text(text: &str) -> String {
     } else {
         format!("t-{}", text)
     }
+}
+
+pub fn take_gate_channel_id(extra: &mut HashMap<String, String>) -> InfraResult<Option<String>> {
+    let Some(channel_id) = extra.remove(GATE_CHANNEL_ID_EXTRA_KEY) else {
+        return Ok(None);
+    };
+
+    validate_gate_channel_id(&channel_id)?;
+    Ok(Some(channel_id))
+}
+
+fn validate_gate_channel_id(channel_id: &str) -> InfraResult<()> {
+    if channel_id.is_empty()
+        || channel_id.len() >= 20
+        || !channel_id
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+    {
+        return Err(InfraError::ApiCliError(format!(
+            "Invalid Gate broker channel id: {channel_id}; expected <20 lowercase letters/digits"
+        )));
+    }
+
+    Ok(())
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -223,5 +252,34 @@ mod tests {
         assert_eq!(infer_settle_from_inst("ZRX_USDT_PERP"), "usdt");
         assert_eq!(infer_settle_from_inst("BTC_USD_PERP"), "btc");
         assert_eq!(infer_settle_from_inst("BTC_USD_FUT_20241227"), "btc");
+    }
+
+    #[test]
+    fn takes_and_validates_gate_channel_id() {
+        let mut extra = HashMap::from([
+            (
+                GATE_CHANNEL_ID_EXTRA_KEY.to_string(),
+                "broker123".to_string(),
+            ),
+            ("account".to_string(), "spot".to_string()),
+        ]);
+
+        assert_eq!(
+            take_gate_channel_id(&mut extra).unwrap(),
+            Some("broker123".to_string())
+        );
+        assert!(!extra.contains_key(GATE_CHANNEL_ID_EXTRA_KEY));
+        assert_eq!(extra.get("account").map(String::as_str), Some("spot"));
+    }
+
+    #[test]
+    fn rejects_invalid_gate_channel_id() {
+        for channel_id in ["", "Broker123", "broker_123", "abcdefghijklmnopqrst"] {
+            let mut extra = HashMap::from([(
+                GATE_CHANNEL_ID_EXTRA_KEY.to_string(),
+                channel_id.to_string(),
+            )]);
+            assert!(take_gate_channel_id(&mut extra).is_err());
+        }
     }
 }

--- a/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
@@ -432,6 +432,7 @@ impl GateFuturesCli {
 
     async fn _place_order(&self, order_params: OrderParams) -> InfraResult<OrderAckData> {
         let mut extra = order_params.extra;
+        let gate_channel_id = take_gate_channel_id(&mut extra)?;
         let settle = extra
             .remove("settle")
             .unwrap_or_else(|| infer_settle_from_inst(&order_params.inst));
@@ -488,13 +489,13 @@ impl GateFuturesCli {
             .api_key
             .as_ref()
             .ok_or(InfraError::ApiCliNotInitialized)?
-            .send_signed_request(
+            .send_signed_post_request_with_channel_id(
                 &self.client,
-                RequestMethod::Post,
                 None,
                 Some(&body.to_string()),
                 GATE_BASE_URL,
                 &endpoint,
+                gate_channel_id.as_deref(),
             )
             .await?;
 

--- a/src/arch/market_assets/exchange/gate/gate_spot_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_spot_cli.rs
@@ -371,6 +371,7 @@ impl GateSpotCli {
         }
 
         let mut extra = order_params.extra;
+        let gate_channel_id = take_gate_channel_id(&mut extra)?;
         if let Some(account) = extra.remove("account") {
             body["account"] = json!(account);
         } else {
@@ -416,13 +417,13 @@ impl GateSpotCli {
             .api_key
             .as_ref()
             .ok_or(InfraError::ApiCliNotInitialized)?
-            .send_signed_request(
+            .send_signed_post_request_with_channel_id(
                 &self.client,
-                RequestMethod::Post,
                 None,
                 Some(&body.to_string()),
                 GATE_BASE_URL,
                 GATE_SPOT_ORDERS,
+                gate_channel_id.as_deref(),
             )
             .await?;
 


### PR DESCRIPTION
## Summary
- add Gate REST order support for broker channel header X-Gate-Channel-Id
- map internal OrderParams.extra gate_channel_id to the header for spot and futures orders
- validate Gate channel ids locally and keep the value out of order request bodies

## Test
- cargo fmt
- cargo test --features "binance gate okx hyperliquid" --lib --offline --quiet
- git diff --check