### PR TITLE
chore: release extrema_infra 0.1.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 
 readme = "README.md"
@@ -29,20 +29,20 @@ futures = "0.3.32"
 futures-util = "0.3.32"
 
 # HTTP / WebSocket
-reqwest = { version = "0.13.3", features = ["json", "gzip"] }
+reqwest = { version = "0.13.4", features = ["json", "gzip"] }
 tokio-tungstenite = { version = "0.29.0", features = ["rustls-tls-webpki-roots"] }
 tungstenite = "0.29.0"
 
 # Serialization / JSON / Binary encoding
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde_json = "1.0.150"
 simd-json = "0.17.0"
 rmp-serde = "1.3.1"
 
 # Cryptography / Signing / Encoding
 hmac = "0.13.0"
 sha2 = "0.11.0"
-sha3 = "0.11.0"
+sha3 = "0.12.0"
 secp256k1 = { version = "0.31.1", features = ["recovery"] }
 data-encoding = "2.11.0"
 


### PR DESCRIPTION
## Summary
- bump extrema_infra crate version from 0.1.5 to 0.1.6
- refresh direct dependency pins used by the release package: reqwest 0.13.3 to 0.13.4, serde_json 1.0.149 to 1.0.150, sha3 0.11.0 to 0.12.0
- prepare crates.io release for the exchange account settings, derivative symbol conversion, and Gate broker channel id changes merged after 0.1.5

## Detailed Changes Included In This Release

### Binance USD-M account settings APIs (#30)
- Added typed Binance USD-M account configuration support around futures account settings.
- Added position mode inspection/change support so callers can check hedge mode vs one-way mode before smoke trading.
- Added symbol/account configuration surfaces needed by account checkers and orchestration flows.
- Improved Binance REST error response handling so typed responses can parse successful and error bodies consistently.

### OKX account settings APIs (#31)
- Added OKX account configuration APIs used to inspect account mode and position mode.
- Added OKX position mode update support for net/long-short mode flows.
- Added typed schemas for OKX account config and set-position-mode responses.
- This lets account_config trade smoke flows normalize OKX mode before submitting orders.

### Derivative symbol conversion fixes (#32)
- Corrected Binance COIN-M inverse perpetual conversion: BTC_USD_PERP maps to BTCUSD_PERP, not BTC_USD or BTCUSDT-style forms.
- Added a separate Binance COIN-M pair helper for endpoints that require pair format such as BTCUSD.
- Kept Binance COIN-M open-interest history on pair format instead of symbol format.
- Corrected Gate inverse perpetual and delivery conversions: BTC_USD_PERP maps to Gate contract BTC_USD; BTC_USD_FUT_20241227 maps to BTC_USD_20241227.
- Updated Gate settle inference so USD inverse contracts use btc settle instead of an invalid usd settle.
- Corrected OKX futures conversion so BTC_USD_FUT_240329 maps to native instId BTC-USD-240329, while BTC_USDT_PERP still maps to BTC-USDT-SWAP.
- Added focused tests for Binance, Gate, and OKX conversion round-trips.

### Gate API broker channel id support (#33)
- Added REST order support for Gate broker header X-Gate-Channel-Id.
- Added internal OrderParams.extra key gate_channel_id for Gate spot and futures orders.
- The Gate adapter removes gate_channel_id from the extra map before body passthrough, so the broker id is not sent as a JSON body field.
- Spot and futures REST order placement now send the broker channel id as a signed request header when provided.
- Added local validation matching the Gate broker guide: channel id must be non-empty, shorter than 20 characters, and contain only lowercase ASCII letters or digits.
- Existing Gate text/client order id behavior is unchanged and remains separate from broker attribution.

### Dependency Refresh
- reqwest: 0.13.3 to 0.13.4.
- serde_json: 1.0.149 to 1.0.150.
- sha3: 0.11.0 to 0.12.0.
- Verified the sha3 0.12.0 API against the Hyperliquid auth Keccak256 usage: Digest, Keccak256::new, update, and finalize still compile and test successfully.

## Compatibility Notes
- Gate broker support currently covers REST order placement for spot and futures. WebSocket order-place req_header support is not included in this release.
- OKX broker tag support already works through existing OrderParams.extra passthrough; portfolio/orchestrator injection can use extra tag without additional infra changes.
- Binance broker/API-agent attribution is not modeled as a per-order tag and is not changed in this release.
- Binance CM and Gate delivery private order execution are still not newly implemented here; this release fixes conversion helpers and public/private order surfaces already present.

## Verification
- cargo fmt --check
- cargo metadata --no-deps --offline --format-version 1
- cargo check --all-features --offline --quiet
- cargo test --all-features --lib --offline --quiet
- cargo publish --dry-run --all-features
- git diff --check