### PR TITLE
fix(exchange): redact credentials and correct DELETE requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,12 @@ async fn main() {
 
 ## Example: Spawn example strategy
 
+Install the latest published crate:
+
+```bash
+cargo add extrema_infra --features all
+```
+
 On your strategy Cargo.toml:
 
 ```toml
@@ -223,14 +229,16 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-# Local development for core-only scheduler/model examples.
-extrema_infra = { path = "../extrema_infra" }
+# Added by: cargo add extrema_infra --features all
 
-# Enable exchange clients explicitly when needed.
+# Local development for core-only scheduler/model examples.
+# extrema_infra = { path = "../extrema_infra" }
+
+# Enable exchange clients explicitly when needed during local development.
 # extrema_infra = { path = "../extrema_infra", features = ["binance", "okx"] }
 # extrema_infra = { path = "../extrema_infra", features = ["lob_clients"] }
 
-# Or remote
+# Or use the latest main branch directly.
 # extrema_infra = { git = "https://github.com/Lqz13Th/extrema_infra", features = ["all"] }
 
 # Tokio async runtime

--- a/src/arch/market_assets/exchange.rs
+++ b/src/arch/market_assets/exchange.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 pub mod prelude;
+pub(crate) mod secret;
 
 #[cfg(feature = "hyperliquid")]
 pub mod hyperliquid;

--- a/src/arch/market_assets/exchange/binance/api_key.rs
+++ b/src/arch/market_assets/exchange/binance/api_key.rs
@@ -4,7 +4,10 @@ use hmac::{KeyInit, Mac};
 use reqwest::{Client, Response};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
-use crate::arch::market_assets::api_general::*;
+use crate::arch::market_assets::{
+    api_general::*,
+    exchange::secret::{redact_identifier, redact_secret},
+};
 use crate::errors::{InfraError, InfraResult};
 
 #[allow(dead_code)]
@@ -19,10 +22,19 @@ pub fn read_binance_env_key() -> InfraResult<BinanceKey> {
     Ok(BinanceKey::new(&api_key, &secret_key))
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct BinanceKey {
     pub api_key: String,
     pub secret_key: String,
+}
+
+impl std::fmt::Debug for BinanceKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BinanceKey")
+            .field("api_key", &redact_identifier(&self.api_key))
+            .field("secret_key", &redact_secret())
+            .finish()
+    }
 }
 
 impl BinanceKey {
@@ -188,5 +200,24 @@ fn binance_build_full_url(
             "{}?{}timestamp={}&signature={}",
             url, "", signature.timestamp, signature.signature
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_redacts_binance_key_secrets() {
+        let key = BinanceKey::new(
+            "binance_api_key_1234567890",
+            "binance_secret_key_1234567890",
+        );
+        let debug = format!("{:?}", key);
+
+        assert!(debug.contains("binanc...7890"));
+        assert!(!debug.contains("binance_api_key_1234567890"));
+        assert!(!debug.contains("binance_secret_key_1234567890"));
+        assert!(debug.contains("[REDACTED]"));
     }
 }

--- a/src/arch/market_assets/exchange/gate/api_key.rs
+++ b/src/arch/market_assets/exchange/gate/api_key.rs
@@ -6,7 +6,10 @@ use reqwest::{Client, Response};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::{Value, json};
 
-use crate::arch::market_assets::api_general::*;
+use crate::arch::market_assets::{
+    api_general::*,
+    exchange::secret::{redact_identifier, redact_secret},
+};
 use crate::errors::{InfraError, InfraResult};
 
 use super::api_utils::GATE_CHANNEL_ID_HEADER;
@@ -25,11 +28,21 @@ pub fn read_gate_env_key() -> InfraResult<GateKey> {
     Ok(GateKey::new(&api_key, &secret_key, &user_id))
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct GateKey {
     pub api_key: String,
     pub secret_key: String,
     pub user_id: String,
+}
+
+impl std::fmt::Debug for GateKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GateKey")
+            .field("api_key", &redact_identifier(&self.api_key))
+            .field("secret_key", &redact_secret())
+            .field("user_id", &redact_identifier(&self.user_id))
+            .finish()
+    }
 }
 
 impl GateKey {
@@ -163,6 +176,26 @@ impl GateKey {
         Ok(res)
     }
 
+    pub(crate) async fn delete_request(
+        &self,
+        client: &Client,
+        signature: &Signature<u64>,
+        body: &str,
+        url: &str,
+    ) -> InfraResult<Response> {
+        let res = client
+            .delete(url)
+            .header("KEY", &self.api_key)
+            .header("SIGN", &signature.signature)
+            .header("Timestamp", signature.timestamp.to_string())
+            .header("Content-Type", "application/json")
+            .body(body.to_string())
+            .send()
+            .await?;
+
+        Ok(res)
+    }
+
     pub(crate) async fn send_signed_request<T>(
         &self,
         client: &Client,
@@ -197,7 +230,11 @@ impl GateKey {
                 let body_str = body.unwrap_or("");
                 self.put_request(client, &signature, body_str, &url).await?
             },
-            RequestMethod::Delete => self.get_request(client, &signature, &url).await?,
+            RequestMethod::Delete => {
+                let body_str = body.unwrap_or("");
+                self.delete_request(client, &signature, body_str, &url)
+                    .await?
+            },
         };
 
         let label = format!("Gate {:?} {}", method, endpoint);
@@ -240,5 +277,26 @@ fn gate_build_full_url(base_url: &str, endpoint: &str, query_string: Option<&str
     match query_string {
         Some(query) if !query.is_empty() => format!("{}{}?{}", base_url, endpoint, query),
         _ => [base_url, endpoint].concat(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_redacts_gate_key_secrets() {
+        let key = GateKey::new(
+            "gate_api_key_1234567890",
+            "gate_secret_key_1234567890",
+            "52955084",
+        );
+        let debug = format!("{:?}", key);
+
+        assert!(debug.contains("gate_a...7890"));
+        assert!(!debug.contains("gate_api_key_1234567890"));
+        assert!(!debug.contains("gate_secret_key_1234567890"));
+        assert!(!debug.contains("52955084"));
+        assert!(debug.contains("[REDACTED]"));
     }
 }

--- a/src/arch/market_assets/exchange/hyperliquid/auth.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/auth.rs
@@ -5,9 +5,13 @@ use secp256k1::{Message, Secp256k1, SecretKey};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use sha3::{Digest, Keccak256};
 
-use super::config_assets::*;
-use crate::arch::market_assets::api_general::{get_mills_timestamp, parse_json_response};
+use crate::arch::market_assets::{
+    api_general::{get_mills_timestamp, parse_json_response},
+    exchange::secret::{redact_identifier, redact_secret},
+};
 use crate::errors::{InfraError, InfraResult};
+
+use super::config_assets::*;
 
 pub fn read_hyperliquid_env_auth() -> InfraResult<HyperliquidAuth> {
     let _ = dotenvy::dotenv();
@@ -28,11 +32,24 @@ pub fn read_hyperliquid_env_auth() -> InfraResult<HyperliquidAuth> {
     })
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct HyperliquidAuth {
     pub owner_address: String,
     pub agent_private_key: String,
     pub vault_address: Option<String>,
+}
+
+impl std::fmt::Debug for HyperliquidAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HyperliquidAuth")
+            .field("owner_address", &redact_identifier(&self.owner_address))
+            .field("agent_private_key", &redact_secret())
+            .field(
+                "vault_address",
+                &self.vault_address.as_deref().map(redact_identifier),
+            )
+            .finish()
+    }
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -270,4 +287,32 @@ fn address_to_word(address: [u8; 20]) -> [u8; 32] {
     let mut out = [0u8; 32];
     out[12..].copy_from_slice(&address);
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_redacts_hyperliquid_auth_secrets() {
+        let auth = HyperliquidAuth {
+            owner_address: "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+            agent_private_key:
+                "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+                    .to_string(),
+            vault_address: Some("0xfedcba0987654321fedcba0987654321fedcba09".to_string()),
+        };
+        let debug = format!("{:?}", auth);
+
+        assert!(debug.contains("0x1234...5678"));
+        assert!(debug.contains("0xfedc...ba09"));
+        assert!(!debug.contains("0x1234567890abcdef1234567890abcdef12345678"));
+        assert!(
+            !debug.contains(
+                "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+            )
+        );
+        assert!(!debug.contains("0xfedcba0987654321fedcba0987654321fedcba09"));
+        assert!(debug.contains("[REDACTED]"));
+    }
 }

--- a/src/arch/market_assets/exchange/okx/api_key.rs
+++ b/src/arch/market_assets/exchange/okx/api_key.rs
@@ -5,7 +5,10 @@ use reqwest::{Client, Response};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::Value;
 
-use crate::arch::market_assets::api_general::*;
+use crate::arch::market_assets::{
+    api_general::*,
+    exchange::secret::{redact_identifier, redact_secret},
+};
 use crate::errors::{InfraError, InfraResult};
 
 use super::api_utils::get_okx_timestamp;
@@ -23,11 +26,21 @@ pub fn read_okx_env_key() -> InfraResult<OkxKey> {
     Ok(OkxKey::new(&api_key, &secret_key, &passphrase))
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct OkxKey {
     pub api_key: String,
     pub secret_key: String,
     pub passphrase: String,
+}
+
+impl std::fmt::Debug for OkxKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OkxKey")
+            .field("api_key", &redact_identifier(&self.api_key))
+            .field("secret_key", &redact_secret())
+            .field("passphrase", &redact_secret())
+            .finish()
+    }
 }
 
 impl OkxKey {
@@ -127,6 +140,27 @@ impl OkxKey {
         Ok(res)
     }
 
+    pub(crate) async fn delete_request(
+        &self,
+        client: &Client,
+        signature: &Signature<String>,
+        body: String,
+        url: &str,
+    ) -> InfraResult<Response> {
+        let res = client
+            .delete(url)
+            .header("OK-ACCESS-KEY", &self.api_key)
+            .header("OK-ACCESS-SIGN", &signature.signature)
+            .header("OK-ACCESS-TIMESTAMP", &signature.timestamp)
+            .header("OK-ACCESS-PASSPHRASE", &self.passphrase)
+            .header("Content-Type", "application/json")
+            .body(body)
+            .send()
+            .await?;
+
+        Ok(res)
+    }
+
     pub(crate) async fn send_signed_request<T>(
         &self,
         client: &Client,
@@ -159,7 +193,7 @@ impl OkxKey {
             RequestMethod::Delete => {
                 let url = [base_url, endpoint].concat();
                 let signature = self.sign_now("DELETE", endpoint, Some(&body))?;
-                self.get_request(client, &signature, &url).await?
+                self.delete_request(client, &signature, body, &url).await?
             },
         };
 
@@ -211,4 +245,25 @@ fn okx_normalize_get_query(body: &str) -> InfraResult<Option<String>> {
     }
 
     Ok(Some(trimmed.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_redacts_okx_key_secrets() {
+        let key = OkxKey::new(
+            "okx_api_key_1234567890",
+            "okx_secret_key_1234567890",
+            "passphrase123",
+        );
+        let debug = format!("{:?}", key);
+
+        assert!(debug.contains("okx_ap...7890"));
+        assert!(!debug.contains("okx_api_key_1234567890"));
+        assert!(!debug.contains("okx_secret_key_1234567890"));
+        assert!(!debug.contains("passphrase123"));
+        assert!(debug.contains("[REDACTED]"));
+    }
 }

--- a/src/arch/market_assets/exchange/secret.rs
+++ b/src/arch/market_assets/exchange/secret.rs
@@ -1,0 +1,47 @@
+pub(crate) const REDACTED_SECRET: &str = "[REDACTED]";
+
+pub(crate) fn redact_identifier(value: &str) -> String {
+    let chars: Vec<char> = value.chars().collect();
+
+    match chars.len() {
+        0 => String::new(),
+        1..=8 => REDACTED_SECRET.to_string(),
+        9..=14 => format!(
+            "{}...{}",
+            chars[..3].iter().collect::<String>(),
+            chars[chars.len() - 3..].iter().collect::<String>()
+        ),
+        _ => format!(
+            "{}...{}",
+            chars[..6].iter().collect::<String>(),
+            chars[chars.len() - 4..].iter().collect::<String>()
+        ),
+    }
+}
+
+pub(crate) fn redact_secret() -> &'static str {
+    REDACTED_SECRET
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redact_identifier_masks_short_ids() {
+        assert_eq!(redact_identifier("52955084"), REDACTED_SECRET);
+    }
+
+    #[test]
+    fn redact_identifier_keeps_head_and_tail_for_medium_api_keys() {
+        assert_eq!(redact_identifier("apikey12345"), "api...345");
+    }
+
+    #[test]
+    fn redact_identifier_keeps_head_and_tail_for_addresses() {
+        assert_eq!(
+            redact_identifier("0x1234567890abcdef1234567890abcdef12345678"),
+            "0x1234...5678"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add shared redaction helpers for debug output
- replace derived Debug on BinanceKey, GateKey, OkxKey, and HyperliquidAuth with redacted implementations
- fix Gate and OKX RequestMethod::Delete dispatch to send real HTTP DELETE requests
- document latest published crate installation with cargo add

## Tests
- cargo fmt --check
- cargo test --all-features --lib --offline --quiet
- cargo clippy --all-targets --all-features --offline -- -D warnings
- cargo test --all-features --offline --quiet