### PR TITLE
ci: add dependency audit checks

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -80,6 +80,30 @@ jobs:
       - name: Run doctests
         run: cargo test --doc --all-features
 
+  dependency-checks:
+    name: Dependency checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Generate lockfile
+        run: cargo generate-lockfile
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run cargo audit
+        run: cargo audit
+
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+
+      - name: Run cargo deny
+        run: cargo deny check
+
   package:
     name: Package dry-run
     runs-on: ubuntu-latest

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,33 @@
+[graph]
+all-features = true
+
+[advisories]
+ignore = []
+
+[licenses]
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CDLA-Permissive-2.0",
+    "CC0-1.0",
+    "ISC",
+    "MIT",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "allow"
+wildcards = "allow"
+highlight = "all"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/deny.toml
+++ b/deny.toml
@@ -6,25 +6,26 @@ ignore = []
 
 [licenses]
 allow = [
-    "0BSD",
+    "MIT",
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
-    "BSD-2-Clause",
     "BSD-3-Clause",
     "BSL-1.0",
-    "CDLA-Permissive-2.0",
     "CC0-1.0",
     "ISC",
-    "MIT",
     "Unicode-3.0",
     "Unlicense",
     "Zlib",
+]
+exceptions = [
+    { allow = ["CDLA-Permissive-2.0"], crate = "webpki-root-certs" },
+    { allow = ["CDLA-Permissive-2.0"], crate = "webpki-roots" },
 ]
 confidence-threshold = 0.8
 
 [bans]
 multiple-versions = "allow"
-wildcards = "allow"
+wildcards = "deny"
 highlight = "all"
 
 [sources]


### PR DESCRIPTION
## Summary
- add a dependency-checks CI job that generates a lockfile for the library crate
- run cargo-audit against the generated lockfile
- run cargo-deny with all features to enforce advisory, license, source, and wildcard dependency policy
- keep deny.toml concise with common permissive licenses globally allowed and CDLA root-certificate data crates as explicit exceptions

## Verification
- cargo deny check
- cargo audit