### PR TITLE
feat(strategy): add event mask subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Explore state-of-the-art example usages, architecture walkthroughs, and communit
 - **Broadcast-based Data Distribution**
   - Subscribe once, broadcast to many.
   - Multiple strategies consume the same feed without extra I/O.
+  - Strategy modules can narrow their runtime subscriptions with `EventMask`.
 
 - **Static Efficiency**
   - Strategy registration avoids `Box<dyn Strategy>` and dynamic dispatch at the strategy-list boundary.
@@ -83,6 +84,7 @@ With **HList**:
 ## Strategy Execution Model
 
 - Trait-driven: `on_trade`, `on_candle`, `on_lob`.
+- Optional `EventMask` lets modules subscribe only to callbacks they use.
 - HList ensures safe registration of multiple strategy types.
 - All infra timestamps are unified to microseconds (µs).
 - All instrument names returned by the internal API are automatically normalized.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,8 +11,9 @@ An application usually has four layers:
 1. **Strategy modules** implement business logic.
 2. **Tasks** own long-running work such as timers, model workers,
    order-execution relays, and websocket relays.
-3. **Broadcast channels** publish task output to all registered strategy
-   modules.
+3. **Broadcast channels** make task output streams available to strategy
+   modules. A module can override `EventHandler::event_mask()` to subscribe
+   only to the streams it consumes.
 4. **Command handles** let strategies send commands back to tasks after the
    runtime has spawned them.
 
@@ -141,7 +142,26 @@ impl EventHandler for MyModule {}
 
 Use `initialize` for startup-only work. Use `command_init` only to store the
 runtime-provided command registry. Implement only the event callbacks your
-module needs; all other callbacks default to no-op.
+module needs; all other callbacks default to no-op. By default, a module
+subscribes to every registered broadcast channel for backwards compatibility.
+Override `event_mask()` when you want to avoid receiver creation and wakeups for
+unused callbacks:
+
+```rust,ignore
+impl EventHandler for MyModule {
+    fn event_mask(&self) -> EventMask {
+        EventMask::SCHEDULE | EventMask::ORDER_EXECUTION
+    }
+
+    async fn on_schedule(&mut self, msg: InfraMsg<AltScheduleEvent>) {
+        let _ = msg;
+    }
+
+    async fn on_order_execution(&mut self, msg: InfraMsg<Vec<AltOrder>>) {
+        let _ = msg;
+    }
+}
+```
 
 ## Scheduler and Intent Tasks
 
@@ -224,6 +244,10 @@ use extrema_infra::prelude::*;
 struct MyPublicWsModule;
 
 impl EventHandler for MyPublicWsModule {
+    fn event_mask(&self) -> EventMask {
+        EventMask::WS_EVENT | EventMask::TRADE
+    }
+
     async fn on_ws_event(&mut self, msg: InfraMsg<WsTaskInfo>) {
         // Find the Ws handle, connect, and subscribe.
         let _ = msg;
@@ -371,7 +395,10 @@ let env = EnvBuilder::new()
 
 `EnvBuilder` stores strategy modules in a heterogeneous list. This keeps each
 module as its concrete type instead of forcing all modules into
-`Box<dyn Strategy>`.
+`Box<dyn Strategy>`. Each module has its own event loop and can independently
+override `event_mask()`; for example, a signal module can subscribe to market
+data and model predictions while an account module subscribes only to account
+and order-execution streams.
 
 ## Task IDs and Chunks
 
@@ -395,7 +422,9 @@ accounts.
 
 Only add channels that the process needs. `EnvBuilder` skips duplicate channel
 variants, so adding `BoardCastChannel::default_trade()` twice still results in
-one trade broadcast channel.
+one trade broadcast channel. `BoardCastChannel` controls which streams exist in
+the runtime; `EventMask` controls which of those streams a particular strategy
+module subscribes to.
 
 Common channel pairs:
 

--- a/examples/complex_strategy_example.rs
+++ b/examples/complex_strategy_example.rs
@@ -169,6 +169,10 @@ impl CommandEmitter for HFTStrategy {
 }
 
 impl EventHandler for HFTStrategy {
+    fn event_mask(&self) -> EventMask {
+        EventMask::WS_EVENT | EventMask::TRADE | EventMask::MODEL_PREDS
+    }
+
     /// Handle predictions from models and generate orders.
     async fn on_preds(&mut self, msg: InfraMsg<AltTensor>) {
         info!("Received model prediction, task id: {}", msg.task_id);
@@ -301,6 +305,10 @@ impl CommandEmitter for AccountModule {
 }
 
 impl EventHandler for AccountModule {
+    fn event_mask(&self) -> EventMask {
+        EventMask::WS_EVENT | EventMask::ORDER_EXECUTION | EventMask::ACC_ORDER
+    }
+
     /// Handle incoming order execution requests from strategies.
     /// This places the order on OKX via REST/WebSocket API.
     async fn on_order_execution(&mut self, msg: InfraMsg<Vec<AltOrder>>) {

--- a/src/arch/infra_core/env_builder.rs
+++ b/src/arch/infra_core/env_builder.rs
@@ -111,9 +111,11 @@ impl<HeadList> EnvBuilder<HeadList> {
 
     /// Registers one strategy module.
     ///
-    /// Calling this method repeatedly creates a static module chain. All modules
-    /// receive the same broadcast events and may independently send commands to
-    /// the tasks they care about.
+    /// Calling this method repeatedly creates a static module chain. By default,
+    /// modules subscribe to every registered broadcast event for backwards
+    /// compatibility. Modules that override `EventHandler::event_mask` subscribe
+    /// only to their selected event streams. All modules may independently send
+    /// commands to the tasks they care about.
     pub fn with_strategy_module<S>(self, strategy: S) -> EnvBuilder<HCons<S, HeadList>>
     where
         S: Strategy + Clone,

--- a/src/arch/strategy_base/handler.rs
+++ b/src/arch/strategy_base/handler.rs
@@ -1,3 +1,4 @@
 pub mod alt_events;
+pub mod event_mask;
 pub mod handler_core;
 pub mod lob_events;

--- a/src/arch/strategy_base/handler/event_mask.rs
+++ b/src/arch/strategy_base/handler/event_mask.rs
@@ -1,0 +1,96 @@
+/// Bitmask describing which runtime event streams a strategy module consumes.
+///
+/// Strategies default to [`EventMask::ALL`] for backwards compatibility. A
+/// latency-sensitive module can override
+/// [`EventHandler::event_mask`](crate::arch::traits::strategy::EventHandler::event_mask)
+/// to subscribe only to the broadcast channels it actually handles.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct EventMask(u32);
+
+impl EventMask {
+    /// Subscribe to no runtime event streams.
+    pub const NONE: Self = Self(0);
+
+    /// Generic alt-task lifecycle/control events.
+    pub const ALT_EVENT: Self = Self(1 << 0);
+    /// Generic websocket-task lifecycle/control events.
+    pub const WS_EVENT: Self = Self(1 << 1);
+    /// Order execution batches.
+    pub const ORDER_EXECUTION: Self = Self(1 << 2);
+    /// Instrument or portfolio target intents.
+    pub const INST_INTENT: Self = Self(1 << 3);
+    /// Model prediction tensors.
+    pub const MODEL_PREDS: Self = Self(1 << 4);
+    /// Periodic scheduler ticks.
+    pub const SCHEDULE: Self = Self(1 << 5);
+    /// Public trade batches.
+    pub const TRADE: Self = Self(1 << 6);
+    /// Public order book updates.
+    pub const LOB: Self = Self(1 << 7);
+    /// Public candle batches.
+    pub const CANDLE: Self = Self(1 << 8);
+    /// Private account order updates.
+    pub const ACC_ORDER: Self = Self(1 << 9);
+    /// Private balance and position updates.
+    pub const ACC_BAL_POS: Self = Self(1 << 10);
+    /// Private position-only updates.
+    pub const ACC_POS: Self = Self(1 << 11);
+
+    /// Subscribe to every runtime event stream.
+    pub const ALL: Self = Self((1 << 12) - 1);
+
+    /// Returns [`EventMask::NONE`].
+    pub const fn none() -> Self {
+        Self::NONE
+    }
+
+    /// Returns [`EventMask::ALL`].
+    pub const fn all() -> Self {
+        Self::ALL
+    }
+
+    /// Returns true when all bits in `other` are present in this mask.
+    pub const fn contains(self, other: Self) -> bool {
+        (self.0 & other.0) == other.0
+    }
+}
+
+impl std::ops::BitOr for EventMask {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl std::ops::BitOrAssign for EventMask {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EventMask;
+
+    #[test]
+    fn contains_combined_event_bits() {
+        let mask = EventMask::TRADE | EventMask::ACC_BAL_POS | EventMask::MODEL_PREDS;
+
+        assert!(mask.contains(EventMask::TRADE));
+        assert!(mask.contains(EventMask::ACC_BAL_POS));
+        assert!(mask.contains(EventMask::MODEL_PREDS));
+        assert!(!mask.contains(EventMask::CANDLE));
+    }
+
+    #[test]
+    fn supports_bit_or_assignment() {
+        let mut mask = EventMask::none();
+        mask |= EventMask::WS_EVENT;
+        mask |= EventMask::TRADE;
+
+        assert!(mask.contains(EventMask::WS_EVENT));
+        assert!(mask.contains(EventMask::TRADE));
+        assert!(!mask.contains(EventMask::ALT_EVENT));
+    }
+}

--- a/src/arch/strategy_base/handler/handler_core.rs
+++ b/src/arch/strategy_base/handler/handler_core.rs
@@ -4,7 +4,7 @@ use tokio::sync::broadcast;
 use tracing::error;
 
 use crate::arch::{
-    strategy_base::handler::{alt_events::*, lob_events::*},
+    strategy_base::handler::{alt_events::*, event_mask::EventMask, lob_events::*},
     task_execution::{task_alt::AltTaskInfo, task_ws::WsTaskInfo},
     traits::strategy::Strategy,
 };
@@ -12,7 +12,7 @@ use crate::arch::{
 /// Message envelope published through runtime broadcast channels.
 ///
 /// `task_id` identifies the task instance that produced the event. `data` is
-/// reference-counted so every subscribed strategy module can receive the same
+/// reference-counted so every interested strategy module can receive the same
 /// payload without copying the full event body.
 #[derive(Clone, Debug)]
 pub struct InfraMsg<T> {
@@ -26,7 +26,9 @@ pub struct InfraMsg<T> {
 ///
 /// Add the variants a process needs with
 /// [`EnvBuilder::with_board_cast_channel`]. Each variant maps to one callback
-/// on [`EventHandler`].
+/// on [`EventHandler`]. Strategy modules can narrow which registered channels
+/// they subscribe to by overriding
+/// [`EventHandler::event_mask`](crate::arch::traits::strategy::EventHandler::event_mask).
 ///
 /// [`EnvBuilder::with_board_cast_channel`]: crate::arch::infra_core::env_builder::EnvBuilder::with_board_cast_channel
 /// [`EventHandler`]: crate::arch::traits::strategy::EventHandler
@@ -129,31 +131,62 @@ async fn recv_or_pending<T: Clone>(
     }
 }
 
+fn subscribe_if<T, Find>(
+    mask: EventMask,
+    event: EventMask,
+    find_sender: Find,
+) -> Option<broadcast::Receiver<T>>
+where
+    T: Clone,
+    Find: FnOnce() -> Option<broadcast::Sender<T>>,
+{
+    if mask.contains(event) {
+        find_sender().map(|tx| tx.subscribe())
+    } else {
+        None
+    }
+}
+
 pub(crate) async fn strategy_handler_loop<S>(
     mut strategies: S,
     channels: &Arc<Vec<BoardCastChannel>>,
 ) where
     S: Strategy,
 {
+    let event_mask = strategies.event_mask();
+
     // Event init
-    let mut rx_alt_event = find_alt_event(channels).map(|tx| tx.subscribe());
-    let mut rx_ws_event = find_ws_event(channels).map(|tx| tx.subscribe());
+    let mut rx_alt_event = subscribe_if(event_mask, EventMask::ALT_EVENT, || {
+        find_alt_event(channels)
+    });
+    let mut rx_ws_event = subscribe_if(event_mask, EventMask::WS_EVENT, || find_ws_event(channels));
 
     // Alt event
-    let mut rx_order_execute = find_order_execution(channels).map(|tx| tx.subscribe());
-    let mut rx_inst_intent = find_inst_intent(channels).map(|tx| tx.subscribe());
-    let mut rx_preds = find_model_preds(channels).map(|tx| tx.subscribe());
-    let mut rx_schedule = find_scheduler(channels).map(|tx| tx.subscribe());
+    let mut rx_order_execute = subscribe_if(event_mask, EventMask::ORDER_EXECUTION, || {
+        find_order_execution(channels)
+    });
+    let mut rx_inst_intent = subscribe_if(event_mask, EventMask::INST_INTENT, || {
+        find_inst_intent(channels)
+    });
+    let mut rx_preds = subscribe_if(event_mask, EventMask::MODEL_PREDS, || {
+        find_model_preds(channels)
+    });
+    let mut rx_schedule =
+        subscribe_if(event_mask, EventMask::SCHEDULE, || find_scheduler(channels));
 
     // Ws pub event
-    let mut rx_trade = find_trade(channels).map(|tx| tx.subscribe());
-    let mut rx_lob = find_lob(channels).map(|tx| tx.subscribe());
-    let mut rx_candle = find_candle(channels).map(|tx| tx.subscribe());
+    let mut rx_trade = subscribe_if(event_mask, EventMask::TRADE, || find_trade(channels));
+    let mut rx_lob = subscribe_if(event_mask, EventMask::LOB, || find_lob(channels));
+    let mut rx_candle = subscribe_if(event_mask, EventMask::CANDLE, || find_candle(channels));
 
     // Ws pri event
-    let mut rx_acc_order = find_acc_order(channels).map(|tx| tx.subscribe());
-    let mut rx_acc_bal_pos = find_acc_bal_pos(channels).map(|tx| tx.subscribe());
-    let mut rx_acc_pos = find_acc_pos(channels).map(|tx| tx.subscribe());
+    let mut rx_acc_order = subscribe_if(event_mask, EventMask::ACC_ORDER, || {
+        find_acc_order(channels)
+    });
+    let mut rx_acc_bal_pos = subscribe_if(event_mask, EventMask::ACC_BAL_POS, || {
+        find_acc_bal_pos(channels)
+    });
+    let mut rx_acc_pos = subscribe_if(event_mask, EventMask::ACC_POS, || find_acc_pos(channels));
 
     loop {
         tokio::select! {
@@ -164,7 +197,8 @@ pub(crate) async fn strategy_handler_loop<S>(
                     Ok(msg) => strategies.on_trade(msg).await,
                     Err(e) => {
                         error!("rx_trade err: {:?}, reconnecting...", e);
-                        rx_trade = find_trade(channels).map(|tx| tx.subscribe());
+                        rx_trade =
+                            subscribe_if(event_mask, EventMask::TRADE, || find_trade(channels));
                     },
                 };
             },
@@ -173,7 +207,7 @@ pub(crate) async fn strategy_handler_loop<S>(
                     Ok(msg) => strategies.on_lob(msg).await,
                     Err(e) => {
                         error!("rx_lob err: {:?}, reconnecting...", e);
-                        rx_lob = find_lob(channels).map(|tx| tx.subscribe());
+                        rx_lob = subscribe_if(event_mask, EventMask::LOB, || find_lob(channels));
                     },
                 };
             },
@@ -182,7 +216,8 @@ pub(crate) async fn strategy_handler_loop<S>(
                     Ok(msg) => strategies.on_candle(msg).await,
                     Err(e) => {
                         error!("rx_candle err: {:?}, reconnecting...", e);
-                        rx_candle = find_candle(channels).map(|tx| tx.subscribe());
+                        rx_candle =
+                            subscribe_if(event_mask, EventMask::CANDLE, || find_candle(channels));
                     },
                 };
             },
@@ -191,7 +226,9 @@ pub(crate) async fn strategy_handler_loop<S>(
                     Ok(msg) => strategies.on_acc_order(msg).await,
                     Err(e) => {
                         error!("rx_acc_order err: {:?}, reconnecting...", e);
-                        rx_acc_order = find_acc_order(channels).map(|tx| tx.subscribe());
+                        rx_acc_order = subscribe_if(event_mask, EventMask::ACC_ORDER, || {
+                            find_acc_order(channels)
+                        });
                     },
                 };
             },
@@ -200,7 +237,9 @@ pub(crate) async fn strategy_handler_loop<S>(
                     Ok(msg) => strategies.on_acc_bal_pos(msg).await,
                     Err(e) => {
                         error!("rx_acc_bal_pos err: {:?}, reconnecting...", e);
-                        rx_acc_bal_pos = find_acc_bal_pos(channels).map(|tx| tx.subscribe());
+                        rx_acc_bal_pos = subscribe_if(event_mask, EventMask::ACC_BAL_POS, || {
+                            find_acc_bal_pos(channels)
+                        });
                     },
                 };
             },
@@ -209,7 +248,8 @@ pub(crate) async fn strategy_handler_loop<S>(
                     Ok(msg) => strategies.on_acc_pos(msg).await,
                     Err(e) => {
                         error!("rx_acc_pos err: {:?}, reconnecting...", e);
-                        rx_acc_pos = find_acc_pos(channels).map(|tx| tx.subscribe());
+                        rx_acc_pos =
+                            subscribe_if(event_mask, EventMask::ACC_POS, || find_acc_pos(channels));
                     },
                 };
             },
@@ -218,7 +258,10 @@ pub(crate) async fn strategy_handler_loop<S>(
                     Ok(msg) => strategies.on_order_execution(msg).await,
                     Err(e) => {
                         error!("rx_order_execute err: {:?}, reconnecting...", e);
-                        rx_order_execute = find_order_execution(channels).map(|tx| tx.subscribe());
+                        rx_order_execute =
+                            subscribe_if(event_mask, EventMask::ORDER_EXECUTION, || {
+                                find_order_execution(channels)
+                            });
                     },
                 };
             },
@@ -227,7 +270,9 @@ pub(crate) async fn strategy_handler_loop<S>(
                     Ok(msg) => strategies.on_inst_intent(msg).await,
                     Err(e) => {
                         error!("rx_inst_intent err: {:?}, reconnecting...", e);
-                        rx_inst_intent = find_inst_intent(channels).map(|tx| tx.subscribe());
+                        rx_inst_intent = subscribe_if(event_mask, EventMask::INST_INTENT, || {
+                            find_inst_intent(channels)
+                        });
                     },
                 };
             },
@@ -236,7 +281,9 @@ pub(crate) async fn strategy_handler_loop<S>(
                     Ok(msg) => strategies.on_preds(msg).await,
                     Err(e) => {
                         error!("rx_preds err: {:?}, reconnecting...", e);
-                        rx_preds = find_model_preds(channels).map(|tx| tx.subscribe());
+                        rx_preds = subscribe_if(event_mask, EventMask::MODEL_PREDS, || {
+                            find_model_preds(channels)
+                        });
                     },
                 };
             },
@@ -245,7 +292,9 @@ pub(crate) async fn strategy_handler_loop<S>(
                     Ok(msg) => strategies.on_schedule(msg).await,
                     Err(e) => {
                         error!("rx_schedule err: {:?}, reconnecting...", e);
-                        rx_schedule = find_scheduler(channels).map(|tx| tx.subscribe());
+                        rx_schedule = subscribe_if(event_mask, EventMask::SCHEDULE, || {
+                            find_scheduler(channels)
+                        });
                     },
                 };
             },
@@ -254,7 +303,9 @@ pub(crate) async fn strategy_handler_loop<S>(
                     Ok(msg) => strategies.on_alt_event(msg).await,
                     Err(e) => {
                         error!("rx_alt_event err: {:?}, reconnecting...", e);
-                        rx_alt_event = find_alt_event(channels).map(|tx| tx.subscribe());
+                        rx_alt_event = subscribe_if(event_mask, EventMask::ALT_EVENT, || {
+                            find_alt_event(channels)
+                        });
                     },
                 };
             },
@@ -263,7 +314,9 @@ pub(crate) async fn strategy_handler_loop<S>(
                     Ok(msg) => strategies.on_ws_event(msg).await,
                     Err(e) => {
                         error!("rx_ws_event err: {:?}, reconnecting...", e);
-                        rx_ws_event = find_ws_event(channels).map(|tx| tx.subscribe());
+                        rx_ws_event = subscribe_if(event_mask, EventMask::WS_EVENT, || {
+                            find_ws_event(channels)
+                        });
                     },
                 };
             },

--- a/src/arch/traits/strategy.rs
+++ b/src/arch/traits/strategy.rs
@@ -5,6 +5,7 @@ use crate::arch::{
         command::command_core::{CommandHandle, CommandRegistry},
         handler::{
             alt_events::*,
+            event_mask::EventMask,
             handler_core::{BoardCastChannel, InfraMsg},
             lob_events::*,
         },
@@ -161,9 +162,12 @@ pub trait CommandEmitter: Clone + Send + Sync + 'static {
 /// - model prediction tasks emit when inference finishes;
 /// - order and intent tasks emit when another module sends a command.
 ///
-/// A strategy module implements only the callbacks it consumes. Every method
+/// A strategy module implements only the callbacks it consumes. Every callback
 /// defaults to no-op, so a module can be as narrow as "only account positions"
-/// or as broad as "schedule + prices + account + orders".
+/// or as broad as "schedule + prices + account + orders". By default,
+/// [`EventHandler::event_mask`] subscribes to every registered channel for
+/// backwards compatibility; latency-sensitive modules can override it to avoid
+/// receiver creation and wakeups for unused callbacks.
 ///
 /// Each callback receives an [`InfraMsg<T>`]. The payload is shared through
 /// `Arc<T>`, and `msg.task_id` identifies the task instance that emitted the
@@ -177,18 +181,18 @@ pub trait CommandEmitter: Clone + Send + Sync + 'static {
 ///
 /// Common callback/channel pairs:
 ///
-/// | Callback | Typical source | Required broadcast channel |
-/// | --- | --- | --- |
-/// | [`EventHandler::on_schedule`] | `AltTaskType::TimeScheduler` | `BoardCastChannel::default_scheduler()` |
-/// | [`EventHandler::on_inst_intent`] | `TaskCommand::InstIntent` | `BoardCastChannel::default_inst_intent()` |
-/// | [`EventHandler::on_order_execution`] | `TaskCommand::OrderExecute` | `BoardCastChannel::default_order_execution()` |
-/// | [`EventHandler::on_preds`] | `TaskCommand::FeatInput` to a model task | `BoardCastChannel::default_model_preds()` |
-/// | [`EventHandler::on_ws_event`] | websocket relay startup/control | `BoardCastChannel::default_ws_event()` |
-/// | [`EventHandler::on_trade`] | public trade websocket relay | `BoardCastChannel::default_trade()` |
-/// | [`EventHandler::on_candle`] | public candle websocket relay | `BoardCastChannel::default_candle()` |
-/// | [`EventHandler::on_acc_order`] | private account-order websocket relay | `BoardCastChannel::default_account_order()` |
-/// | [`EventHandler::on_acc_bal_pos`] | private balance/position websocket relay | `BoardCastChannel::default_account_bal_pos()` |
-/// | [`EventHandler::on_acc_pos`] | private position websocket relay | `BoardCastChannel::default_account_pos()` |
+/// | Callback | Typical source | Required channel | Event mask |
+/// | --- | --- | --- | --- |
+/// | [`EventHandler::on_schedule`] | `AltTaskType::TimeScheduler` | `BoardCastChannel::default_scheduler()` | `EventMask::SCHEDULE` |
+/// | [`EventHandler::on_inst_intent`] | `TaskCommand::InstIntent` | `BoardCastChannel::default_inst_intent()` | `EventMask::INST_INTENT` |
+/// | [`EventHandler::on_order_execution`] | `TaskCommand::OrderExecute` | `BoardCastChannel::default_order_execution()` | `EventMask::ORDER_EXECUTION` |
+/// | [`EventHandler::on_preds`] | `TaskCommand::FeatInput` to a model task | `BoardCastChannel::default_model_preds()` | `EventMask::MODEL_PREDS` |
+/// | [`EventHandler::on_ws_event`] | websocket relay startup/control | `BoardCastChannel::default_ws_event()` | `EventMask::WS_EVENT` |
+/// | [`EventHandler::on_trade`] | public trade websocket relay | `BoardCastChannel::default_trade()` | `EventMask::TRADE` |
+/// | [`EventHandler::on_candle`] | public candle websocket relay | `BoardCastChannel::default_candle()` | `EventMask::CANDLE` |
+/// | [`EventHandler::on_acc_order`] | private account-order websocket relay | `BoardCastChannel::default_account_order()` | `EventMask::ACC_ORDER` |
+/// | [`EventHandler::on_acc_bal_pos`] | private balance/position websocket relay | `BoardCastChannel::default_account_bal_pos()` | `EventMask::ACC_BAL_POS` |
+/// | [`EventHandler::on_acc_pos`] | private position websocket relay | `BoardCastChannel::default_account_pos()` | `EventMask::ACC_POS` |
 ///
 /// ```rust
 /// use extrema_infra::prelude::*;
@@ -196,6 +200,10 @@ pub trait CommandEmitter: Clone + Send + Sync + 'static {
 /// struct PositionLogger;
 ///
 /// impl EventHandler for PositionLogger {
+///     fn event_mask(&self) -> EventMask {
+///         EventMask::ACC_POS
+///     }
+///
 ///     async fn on_acc_pos(&mut self, msg: InfraMsg<Vec<WsAccPosition>>) {
 ///         println!(
 ///             "task_id={} positions={}",
@@ -206,6 +214,15 @@ pub trait CommandEmitter: Clone + Send + Sync + 'static {
 /// }
 /// ```
 pub trait EventHandler {
+    /// Declares which runtime event streams this module wants to subscribe to.
+    ///
+    /// The default is [`EventMask::ALL`] so existing strategies keep receiving
+    /// every registered broadcast channel. Override this in latency-sensitive
+    /// modules to avoid receiver creation and wakeups for unused callbacks.
+    fn event_mask(&self) -> EventMask {
+        EventMask::ALL
+    }
+
     /// Receives generic alt-task lifecycle/control events.
     ///
     /// Alt tasks emit this event before entering their main task distribution

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,14 +13,16 @@
 //!   strategy module or several independent modules in the same runtime.
 //! - [`EventHandler`] contains async callbacks for schedule ticks, model
 //!   predictions, order execution intents, trades, LOB updates, candles, and
-//!   private account updates. All callbacks default to no-op.
+//!   private account updates. All callbacks default to no-op, and
+//!   [`EventMask`] can be used to subscribe only to the event streams a module
+//!   actually handles.
 //! - [`CommandEmitter`] gives a strategy access to task command handles after
 //!   the runtime has spawned those tasks.
 //! - [`TaskInfo`] declares work that the runtime owns, such as [`AltTaskInfo`]
 //!   for scheduler/model/order-intent work or [`WsTaskInfo`] for websocket
 //!   relays.
 //! - [`BoardCastChannel`] declares which event streams are available to
-//!   strategies. Add only the channels you want to consume or publish.
+//!   strategies. Add only the channels your process needs to consume or publish.
 //! - [`prelude`] re-exports the common types used by strategy binaries.
 //!
 //! # Why Events Drive Strategies
@@ -36,8 +38,8 @@
 //!
 //! - Runtime tasks own IO, timers, model workers, and order relays.
 //! - Tasks publish normalized messages into typed broadcast channels.
-//! - Strategy modules implement event callbacks for only the streams they care
-//!   about.
+//! - Strategy modules use [`EventMask`] to subscribe to the streams they care
+//!   about and implement the matching event callbacks.
 //! - Strategy modules send commands back to tasks through command handles when
 //!   they need active work such as websocket connect/subscribe or order
 //!   execution.
@@ -56,7 +58,9 @@
 //! [`EventHandler`] is the inbound event surface. Its methods are callbacks:
 //! `on_schedule`, `on_trade`, `on_candle`, `on_acc_pos`, `on_inst_intent`,
 //! `on_order_execution`, and so on. Every callback defaults to no-op, so modules
-//! stay narrow and only implement the events that matter to them.
+//! stay narrow and only implement the events that matter to them. Existing
+//! modules receive every registered channel by default; override
+//! `event_mask()` to avoid receiver creation and wakeups for unused callbacks.
 //!
 //! [`CommandEmitter`] is the outbound command surface. After tasks are spawned,
 //! the runtime supplies a [`CommandRegistry`]. Strategy modules store that
@@ -82,6 +86,7 @@
 //!       -> spawn AltTask/WsTask workers
 //!       -> CommandEmitter::command_init()
 //!       -> spawn strategy event loops
+//!       -> strategy loops subscribe according to EventHandler::event_mask()
 //!       -> tasks publish InfraMsg<T>
 //!       -> EventHandler callbacks react
 //!       -> strategies send TaskCommand through CommandHandle when needed
@@ -175,6 +180,7 @@
 //!
 //! [`Strategy`]: crate::arch::traits::strategy::Strategy
 //! [`EventHandler`]: crate::arch::traits::strategy::EventHandler
+//! [`EventMask`]: crate::arch::strategy_base::handler::event_mask::EventMask
 //! [`CommandEmitter`]: crate::arch::traits::strategy::CommandEmitter
 //! [`EnvBuilder`]: crate::arch::infra_core::env_builder::EnvBuilder
 //! [`EnvMediator::execute`]: crate::arch::infra_core::env_mediator::EnvMediator::execute

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,10 +7,10 @@
 //! ```
 //!
 //! The prelude contains the runtime builder, strategy traits, task descriptors,
-//! broadcast channel types, command handles, normalized market data structures,
-//! and shared error/result aliases. Exchange-specific client structs remain
-//! available under `arch::market_assets::exchange::prelude` when the matching
-//! feature is enabled.
+//! broadcast channel types, event masks, command handles, normalized market
+//! data structures, and shared error/result aliases. Exchange-specific client
+//! structs remain available under `arch::market_assets::exchange::prelude` when
+//! the matching feature is enabled.
 pub use crate::errors::{InfraError, InfraResult};
 
 pub use crate::arch::{
@@ -24,7 +24,7 @@ pub use crate::arch::{
             ack_handle::{AckHandle, AckStatus},
             command_core::*,
         },
-        handler::{alt_events::*, handler_core::*, lob_events::*},
+        handler::{alt_events::*, event_mask::*, handler_core::*, lob_events::*},
     },
     task_execution::{task_alt::*, task_general::TaskInfo, task_ws::*},
     traits::{conversion::*, market_lob::*, strategy::*},


### PR DESCRIPTION
## Summary
- add an EventMask bitmask for strategy modules to opt into only the event streams they consume
- use EventHandler::event_mask() in the strategy handler loop to skip unused broadcast receiver subscriptions
- update docs and complex example to show event masks while keeping the minimal example simple

## Tests
- cargo test --offline --no-default-features
- cargo check --offline --no-default-features --example empty_strategy_example
- cargo check --offline --features okx --example complex_strategy_example