### PR TITLE
docs: clean up example and runtime docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ all = [
     "binance",
     "gate",
     "okx",
+    "lob_clients",
 ]
 
 lob_clients = [
@@ -83,6 +84,9 @@ hyperliquid = []
 binance = []
 gate = []
 okx = []
+
+[package.metadata.docs.rs]
+all-features = true
 
 [[example]]
 name = "empty_strategy_example"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,8 +1,7 @@
 # Extrema Infra Usage Guide
 
-This guide describes the generic shape of an `extrema_infra` application. It is
-based on the real downstream patterns used by signal services, portfolio
-orchestrators, exchange websocket checkers, and account/order utilities.
+This guide covers common runtime wiring for strategy modules, tasks, broadcast
+channels, and command handles.
 
 ## Runtime Model
 
@@ -105,9 +104,8 @@ markets used by the binary:
 extrema_infra = { path = "../extrema_infra", features = ["binance", "okx"] }
 ```
 
-Use `features = ["lob_clients"]` when a process needs the `LobClients`
-aggregate helper. Use `features = ["all"]` when it only needs all individual
-exchange modules.
+Use `features = ["lob_clients"]` for the `LobClients` aggregate helper.
+Use `features = ["all"]` for every exchange module and `LobClients`.
 
 ## Strategy Module Checklist
 

--- a/examples/complex_strategy_example.rs
+++ b/examples/complex_strategy_example.rs
@@ -24,14 +24,7 @@ use extrema_infra::{
     prelude::*,
 };
 
-/// -------------------------------------
-/// High Frequency Trading (HFT) Strategy
-/// -------------------------------------
-/// Responsibilities:
-/// 1. Receive market data events (e.g., trades)
-/// 2. Generate trading signals & features
-/// 3. Receive predictions from model (message from python)
-/// 4. Send order execution commands to AccountModule
+/// Signal module for public trades and model predictions.
 #[derive(Clone)]
 struct HFTStrategy {
     command_registry: Arc<CommandRegistry>,
@@ -46,14 +39,12 @@ impl HFTStrategy {
         }
     }
 
-    /// Generate a signal from market trades.
-    /// In this example, it creates a simple AltMatrix.
+    /// Build an `AltTensor` feature batch from market trades.
     async fn generate_signal(&mut self, msg: InfraMsg<Vec<WsTrade>>) -> InfraResult<()> {
         if msg.data.is_empty() {
             return Err(InfraError::Msg("empty infra data".to_string()));
         }
 
-        // Build feature matrix
         let n_rows = msg.data.len();
         let n_cols = 1;
 
@@ -73,13 +64,12 @@ impl HFTStrategy {
 
         let matrix_b = matrix_a.clone();
 
-        // Send features to two different models
         self.send_feat_to_model_a(matrix_a).await?;
         self.send_feat_to_model_b(matrix_b).await?;
         Ok(())
     }
 
-    /// Send feature matrix to model A
+    /// Send features to model A.
     async fn send_feat_to_model_a(&mut self, feat: AltTensor) -> InfraResult<()> {
         if let Some(handle) =
             self.find_alt_handle(&AltTaskType::ModelPreds(ModelRunner::Zmq(1111)), 1111)
@@ -92,7 +82,7 @@ impl HFTStrategy {
         Ok(())
     }
 
-    /// Send feature matrix to model B
+    /// Send features to model B.
     async fn send_feat_to_model_b(&mut self, feat: AltTensor) -> InfraResult<()> {
         if let Some(handle) =
             self.find_alt_handle(&AltTaskType::ModelPreds(ModelRunner::Zmq(2222)), 2222)
@@ -105,8 +95,7 @@ impl HFTStrategy {
         Ok(())
     }
 
-    /// Send order(s) to the order execution task
-    /// Orders are sent via CommandHandle, not directly to the exchange
+    /// Forward orders to the order execution task.
     async fn send_order(&mut self, orders: Vec<AltOrder>) -> InfraResult<()> {
         if let Some(handle) = self.find_alt_handle(&AltTaskType::OrderExecution, 1) {
             let cmd = TaskCommand::OrderExecute(orders);
@@ -121,7 +110,6 @@ impl HFTStrategy {
         if let Some(handle) = self.find_ws_handle(channel, task_id) {
             info!("Sending connect to {:?}", handle);
 
-            // Step 1: Request connection URL
             let ws_url = self.api_cli.get_public_connect_msg(channel).await?;
             let (tx, rx) = oneshot::channel();
             let cmd = TaskCommand::WsConnect {
@@ -132,14 +120,13 @@ impl HFTStrategy {
                 .send_command(cmd, Some((AckStatus::WsConnect, rx)))
                 .await?;
 
-            // Step 2: Subscribe to BTC/USDT perpetual trade updates
             let ws_msg = self
                 .api_cli
                 .get_public_sub_msg(channel, Some(&["BTC_USDT_PERP".into()]))
                 .await?;
             let cmd = TaskCommand::WsMessage {
                 msg: ws_msg,
-                ack: AckHandle::none(), // no need to wait for ack
+                ack: AckHandle::none(),
             };
             handle.send_command(cmd, None).await?;
         } else {
@@ -210,7 +197,7 @@ impl EventHandler for HFTStrategy {
         }
     }
 
-    /// Subscribe and react to public trades via WebSocket
+    /// Handle public trade batches.
     async fn on_trade(&mut self, msg: InfraMsg<Vec<WsTrade>>) {
         if let Err(e) = self.generate_signal(msg).await {
             error!("Error generating signal: {:?}", e);
@@ -218,13 +205,7 @@ impl EventHandler for HFTStrategy {
     }
 }
 
-/// -------------------------------------
-/// Account Module
-/// -------------------------------------
-/// Responsibilities:
-/// 1. Manage exchange connection and authentication
-/// 2. Execute orders sent from strategies
-/// 3. Receive account/order updates from exchange
+/// Account module for private websocket updates and execution requests.
 #[derive(Clone)]
 struct AccountModule {
     command_registry: Arc<CommandRegistry>,
@@ -239,16 +220,9 @@ impl AccountModule {
         }
     }
 
-    /// Connect and authenticate to OKX private WebSocket channels.
-    /// This function performs multiple sequential async requests:
-    /// - Connect
-    /// - Login
-    /// - Subscribe to account/order updates
-    ///
-    /// This is an IO-heavy path and should not block signal-processing tasks.
+    /// Connect, log in, and subscribe to the OKX private account channel.
     pub async fn connect_acc_channel(&mut self, channel: &WsChannel) -> InfraResult<()> {
         if let Some(handle) = self.find_ws_handle(channel, 1) {
-            // Step 1: Connect
             let ws_url = self.api_cli.get_private_connect_msg(channel).await?;
             let (tx, rx) = oneshot::channel();
             let cmd = TaskCommand::WsConnect {
@@ -259,7 +233,6 @@ impl AccountModule {
                 .send_command(cmd, Some((AckStatus::WsConnect, rx)))
                 .await?;
 
-            // Step 2: Login
             let login_msg = self.api_cli.ws_login_msg()?;
             let (tx, rx) = oneshot::channel();
             let cmd = TaskCommand::WsMessage {
@@ -270,7 +243,6 @@ impl AccountModule {
                 .send_command(cmd, Some((AckStatus::WsMessage, rx)))
                 .await?;
 
-            // Step 3: Subscribe to private account/order updates
             let ws_msg = self.api_cli.get_private_sub_msg(channel).await?;
             let (tx, rx) = oneshot::channel();
             let cmd = TaskCommand::WsMessage {
@@ -309,18 +281,10 @@ impl EventHandler for AccountModule {
         EventMask::WS_EVENT | EventMask::ORDER_EXECUTION | EventMask::ACC_ORDER
     }
 
-    /// Handle incoming order execution requests from strategies.
-    /// This places the order on OKX via REST/WebSocket API.
+    /// Receive order execution requests.
     async fn on_order_execution(&mut self, msg: InfraMsg<Vec<AltOrder>>) {
         info!("Received model order execution, task id: {}", msg.task_id);
-        // Then use api_cli to sending order to exchange
-        // 1. REST API order placement
-        //    Using `api_cli` to asynchronously send a REST order request
-        //    (non-blocking; the task awaits the exchange's REST response).
-        //
-        // 2. WebSocket order placement
-        //    Constructing a WS order message.
-        //    Using Task command to send ws message to private ws channel.
+        // Order submission is intentionally omitted in this example.
     }
 
     /// Handle private account WebSocket events.

--- a/examples/empty_strategy_example.rs
+++ b/examples/empty_strategy_example.rs
@@ -30,6 +30,7 @@ impl CommandEmitter for EmptyStrategy {
     }
 
     fn command_registry(&self) -> Arc<CommandRegistry> {
+        // Safe here because this example never sends commands.
         Arc::new(CommandRegistry::default())
     }
 }

--- a/examples/multi_strategy_example.rs
+++ b/examples/multi_strategy_example.rs
@@ -1,9 +1,6 @@
 //! Multiple strategy modules in one runtime.
 //!
-//! This example wires an empty scheduler-driven strategy together with a Binance
-//! public websocket strategy. It demonstrates how multiple modules share one
-//! `EnvBuilder`, receive independent callbacks, and send websocket commands
-//! through task handles.
+//! Runs a scheduler module and a Binance public candle module in one runtime.
 //!
 //! Run it with:
 //!
@@ -17,14 +14,7 @@ use tracing::{error, info, warn};
 
 use extrema_infra::{arch::market_assets::exchange::prelude::*, prelude::*};
 
-///---------------------------------------------------------
-/// Empty Strategy
-///---------------------------------------------------------
-/// This is a placeholder strategy that:
-/// - Initializes but does not trade
-/// - Logs incoming events (candles, schedules)
-///
-/// Useful for testing system wiring without executing orders.
+/// Scheduler and candle logger.
 #[derive(Clone)]
 struct EmptyStrategy;
 
@@ -39,7 +29,7 @@ impl Strategy for EmptyStrategy {
 }
 
 impl CommandEmitter for EmptyStrategy {
-    /// Register command channel (not used in EmptyStrategy).
+    /// Command registry is not used by this logger.
     fn command_init(&mut self, _registry: Arc<CommandRegistry>) {
         info!(
             "[EmptyStrategy] Command channel registered: {:?}",
@@ -47,33 +37,22 @@ impl CommandEmitter for EmptyStrategy {
         );
     }
 
-    /// No commands in this strategy.
     fn command_registry(&self) -> Arc<CommandRegistry> {
         Arc::new(CommandRegistry::default())
     }
 }
 
 impl EventHandler for EmptyStrategy {
-    /// Called periodically if scheduled tasks are configured.
     async fn on_schedule(&mut self, msg: InfraMsg<AltScheduleEvent>) {
         info!("[EmptyStrategy] AltEventHandler: {:?}", msg);
     }
 
-    /// Called when new candles are broadcasted.
     async fn on_candle(&mut self, msg: InfraMsg<Vec<WsCandle>>) {
         info!("[EmptyStrategy] Candle event: {:?}", msg);
     }
 }
 
-///---------------------------------------------------------
-/// Binance Strategy
-///---------------------------------------------------------
-/// This strategy demonstrates:
-/// - Connecting to Binance UM Futures public WebSocket (candles, trades, etc.)
-/// - Subscribing to BTC/USDT perpetual candles
-/// - Receiving and logging events
-///
-/// Note: This strategy only listens/logs data, does not trade.
+/// Binance public candle subscriber.
 #[derive(Clone)]
 struct BinanceStrategy {
     command_registry: Arc<CommandRegistry>,
@@ -88,13 +67,11 @@ impl BinanceStrategy {
         }
     }
 
-    /// Connect to Binance WebSocket channel and send subscription.
-    /// This runs only when a LOB event is received that signals the channel is ready.
+    /// Connect after the websocket task emits `on_ws_event`.
     async fn connect_channel(&self, channel: &WsChannel) -> InfraResult<()> {
         if let Some(handle) = self.find_ws_handle(channel, 1) {
             info!("[BinanceStrategy] Sending connect to {:?}", handle);
 
-            // Step 1: Request connection URL
             let ws_url = self.binance_um_cli.get_public_connect_msg(channel).await?;
             let (tx, rx) = oneshot::channel();
             let cmd = TaskCommand::WsConnect {
@@ -105,7 +82,6 @@ impl BinanceStrategy {
                 .send_command(cmd, Some((AckStatus::WsConnect, rx)))
                 .await?;
 
-            // Step 2: Subscribe to BTC/USDT perpetual candle updates
             let ws_msg = self
                 .binance_um_cli
                 .get_public_sub_msg(channel, Some(&["BTC_USDT_PERP".into()]))
@@ -113,7 +89,7 @@ impl BinanceStrategy {
 
             let cmd = TaskCommand::WsMessage {
                 msg: ws_msg,
-                ack: AckHandle::none(), // no need to wait for ack
+                ack: AckHandle::none(),
             };
             handle.send_command(cmd, None).await?;
         } else {
@@ -152,9 +128,7 @@ impl EventHandler for BinanceStrategy {
         info!("[BinanceStrategy] AltEventHandler: {:?}", msg);
     }
 
-    /// Triggered when a new WebSocket task is ready.
-    /// Example: After creating WsTaskInfo for Binance Candle, this event will be fired
-    /// and connect_channel() will be executed.
+    /// Start the websocket relay after its task handle is registered.
     async fn on_ws_event(&mut self, msg: InfraMsg<WsTaskInfo>) {
         info!(
             "[BinanceStrategy] Triggering connect for channel: {:?}",
@@ -165,20 +139,13 @@ impl EventHandler for BinanceStrategy {
         }
     }
 
-    /// Handle incoming Binance candle data (1-minute candles here).
+    /// Handle Binance candle batches.
     async fn on_candle(&mut self, msg: InfraMsg<Vec<WsCandle>>) {
         info!("[BinanceStrategy] Candle event: {:?}", msg);
     }
 }
 
-///---------------------------------------------------------
-/// Main Entry Point
-///---------------------------------------------------------
-/// - Initializes logging
-/// - Creates strategies (EmptyStrategy + BinanceStrategy)
-/// - Creates tasks (Binance candle WebSocket, Alt scheduler)
-/// - Wires everything into EnvBuilder (pub/sub channels, strategies, tasks)
-/// - Executes mediator event loop
+/// Run the example runtime.
 #[tokio::main]
 async fn main() {
     rustls::crypto::aws_lc_rs::default_provider()
@@ -188,7 +155,7 @@ async fn main() {
     tracing_subscriber::fmt::init();
     info!("Logger initialized");
 
-    // WebSocket Task: Binance Candle (1-minute)
+    // Binance 1-minute candle stream.
     let binance_ws_candle = WsTaskInfo {
         market: Market::BinanceUmFutures,
         ws_channel: WsChannel::Candles(Some(CandleParam::OneMinute)),
@@ -197,17 +164,13 @@ async fn main() {
         task_base_id: None,
     };
 
-    // Alt Task: Time Scheduler (fires every 5 seconds)
+    // Five-second scheduler.
     let alt_task = AltTaskInfo {
         alt_task_type: AltTaskType::TimeScheduler(Duration::from_secs(5)),
         chunk: 1,
         task_base_id: None,
     };
 
-    // EnvBuilder builds the full runtime:
-    // - Register broadcast channels (pub/sub message passing)
-    // - Register strategy modules
-    // - Register tasks
     let env = EnvBuilder::new()
         .with_board_cast_channel(BoardCastChannel::default_alt_event())
         .with_board_cast_channel(BoardCastChannel::default_ws_event())
@@ -220,6 +183,5 @@ async fn main() {
         .with_strategy_module(BinanceStrategy::new())
         .build();
 
-    // Start event loop (spawns all tasks, connects strategies, begins message flow)
     env.execute().await;
 }

--- a/examples/websocket_private_account_example.rs
+++ b/examples/websocket_private_account_example.rs
@@ -1,8 +1,8 @@
 //! Private account websocket example.
 //!
-//! This example shows how a strategy module connects private account websocket
-//! relays for Binance UM futures and OKX, sends connect/login/subscribe
-//! commands, and receives account balance/position updates through callbacks.
+//! This example wires private account websocket relays for Binance UM futures
+//! and OKX. Binance UM uses a listen-key websocket URL, while OKX connects,
+//! logs in, and subscribes over the private websocket.
 //!
 //! Run it with:
 //!
@@ -54,7 +54,6 @@ impl AccountModule {
 
     pub async fn connect_okx_acc_channel(&mut self, channel: &WsChannel) -> InfraResult<()> {
         if let Some(handle) = self.find_ws_handle(channel, 1002) {
-            // Step 1: Connect
             let ws_url = self.okx_cli.get_private_connect_msg(channel).await?;
             let (tx, rx) = oneshot::channel();
             let cmd = TaskCommand::WsConnect {
@@ -65,7 +64,6 @@ impl AccountModule {
                 .send_command(cmd, Some((AckStatus::WsConnect, rx)))
                 .await?;
 
-            // Step 2: Login
             let login_msg = self.okx_cli.ws_login_msg()?;
             let (tx, rx) = oneshot::channel();
             let cmd = TaskCommand::WsMessage {
@@ -76,7 +74,6 @@ impl AccountModule {
                 .send_command(cmd, Some((AckStatus::WsMessage, rx)))
                 .await?;
 
-            // Step 3: Subscribe to private account/order updates
             let ws_msg = self.okx_cli.get_private_sub_msg(channel).await?;
             let (tx, rx) = oneshot::channel();
             let cmd = TaskCommand::WsMessage {

--- a/src/arch/infra_core/env_mediator.rs
+++ b/src/arch/infra_core/env_mediator.rs
@@ -15,8 +15,8 @@ use crate::arch::{
 /// Executable runtime produced by [`EnvBuilder`].
 ///
 /// The mediator initializes strategies, registers tasks, provides the command
-/// registry to strategies, asks strategies to spawn any extra background work,
-/// and then keeps the runtime alive.
+/// registry to strategies, spawns strategy event loops, and then keeps the
+/// runtime alive.
 ///
 /// [`EnvBuilder`]: crate::arch::infra_core::env_builder::EnvBuilder
 pub struct EnvMediator<S> {

--- a/src/arch/strategy_base/command/command_core.rs
+++ b/src/arch/strategy_base/command/command_core.rs
@@ -16,6 +16,8 @@ use crate::errors::{InfraError, InfraResult};
 /// commands are routed by `(WsChannel, task_id)`. The market is part of the
 /// task descriptor, but it is not part of the command key, so task ids must be
 /// unique when several tasks share the same task type or websocket channel.
+/// For `AltTaskType::ModelPreds`, the `ModelRunner` value is also part of the
+/// key.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum CommandKey {
     /// Command key for a non-websocket task.
@@ -83,7 +85,8 @@ impl CommandRegistry {
     /// Finds a non-websocket task handle.
     ///
     /// Use this for `TaskCommand::OrderExecute`, `TaskCommand::InstIntent`, or
-    /// `TaskCommand::FeatInput` depending on the task type.
+    /// `TaskCommand::FeatInput` depending on the task type. Model task lookups
+    /// must use the exact registered `ModelRunner` value.
     pub fn find_alt_handle(
         &self,
         alt_task_type: &AltTaskType,

--- a/src/arch/traits/strategy.rs
+++ b/src/arch/traits/strategy.rs
@@ -189,6 +189,7 @@ pub trait CommandEmitter: Clone + Send + Sync + 'static {
 /// | [`EventHandler::on_preds`] | `TaskCommand::FeatInput` to a model task | `BoardCastChannel::default_model_preds()` | `EventMask::MODEL_PREDS` |
 /// | [`EventHandler::on_ws_event`] | websocket relay startup/control | `BoardCastChannel::default_ws_event()` | `EventMask::WS_EVENT` |
 /// | [`EventHandler::on_trade`] | public trade websocket relay | `BoardCastChannel::default_trade()` | `EventMask::TRADE` |
+/// | [`EventHandler::on_lob`] | public LOB websocket relay | `BoardCastChannel::default_lob()` | `EventMask::LOB` |
 /// | [`EventHandler::on_candle`] | public candle websocket relay | `BoardCastChannel::default_candle()` | `EventMask::CANDLE` |
 /// | [`EventHandler::on_acc_order`] | private account-order websocket relay | `BoardCastChannel::default_account_order()` | `EventMask::ACC_ORDER` |
 /// | [`EventHandler::on_acc_bal_pos`] | private balance/position websocket relay | `BoardCastChannel::default_account_bal_pos()` | `EventMask::ACC_BAL_POS` |
@@ -218,7 +219,8 @@ pub trait EventHandler {
     ///
     /// The default is [`EventMask::ALL`] so existing strategies keep receiving
     /// every registered broadcast channel. Override this in latency-sensitive
-    /// modules to avoid receiver creation and wakeups for unused callbacks.
+    /// modules to avoid receiver creation and wakeups for unused callbacks. This
+    /// is read once when the strategy event loop starts.
     fn event_mask(&self) -> EventMask {
         EventMask::ALL
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,29 +25,19 @@
 //!   strategies. Add only the channels your process needs to consume or publish.
 //! - [`prelude`] re-exports the common types used by strategy binaries.
 //!
-//! # Why Events Drive Strategies
+//! # Event Model
 //!
-//! Trading systems are naturally event-driven. Market data arrives whenever an
-//! exchange pushes a websocket frame. Private account streams update after
-//! fills, cancellations, balance changes, and position changes. Timers trigger
-//! periodic tasks such as refresh, rebalancing, risk checks, model inference, or
-//! state snapshots. These inputs do not share one clean loop cadence, and they
-//! should not force every strategy module to poll every data source.
+//! Runtime tasks own IO, timers, model workers, and order relays. They publish
+//! normalized `InfraMsg<T>` values into typed broadcast channels.
 //!
-//! `extrema_infra` separates those responsibilities:
+//! Strategy modules use [`EventMask`] to subscribe to the streams they consume,
+//! handle those streams through async callbacks, and send `TaskCommand` values
+//! back through command handles when they need active work such as websocket
+//! connect/subscribe or order execution.
 //!
-//! - Runtime tasks own IO, timers, model workers, and order relays.
-//! - Tasks publish normalized messages into typed broadcast channels.
-//! - Strategy modules use [`EventMask`] to subscribe to the streams they care
-//!   about and implement the matching event callbacks.
-//! - Strategy modules send commands back to tasks through command handles when
-//!   they need active work such as websocket connect/subscribe or order
-//!   execution.
-//!
-//! That shape keeps strategy logic reactive and local: a portfolio module can
-//! handle account-position events, an allocator can handle target-weight
-//! intents, an execution module can handle order batches, and all of them can
-//! live in the same runtime without owning duplicate websocket or timer loops.
+//! Market data, account updates, timers, model outputs, and order relays can
+//! run on independent cadences without forcing one polling loop or one module
+//! to own duplicate IO.
 //!
 //! # Core Trait Responsibilities
 //!


### PR DESCRIPTION
## Summary
- remove tutorial-style comments and stale wording from examples
- clarify Binance UM listen-key flow versus OKX private websocket flow
- tighten crate docs, usage guide, EventMask docs, and docs.rs metadata

## Tests
- cargo fmt
- cargo check --offline --features all --example complex_strategy_example
- cargo check --offline --features binance --example multi_strategy_example
- cargo check --offline --features binance,okx --example websocket_private_account_example
- cargo doc --offline --no-deps --all-features
- cargo test --offline --doc --all-features