### PR TITLE
chore: release extrema_infra 0.1.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 
 readme = "README.md"


### PR DESCRIPTION

## Summary

Release `extrema_infra` `0.1.8`.

This PR only bumps the crate version in `Cargo.toml` from `0.1.7` to `0.1.8`. It follows the existing release pattern from `0.1.7`, where the release PR keeps the package diff minimal and leaves source changes in the feature/docs PRs that already landed on `master`.

## Release contents since `v0.1.7`

### Runtime / strategy API

- Added `EventMask`-based strategy subscriptions in #39.
- Strategies can now opt into only the event streams they consume, avoiding receiver creation and wakeups for unused callbacks.
- Existing strategy modules keep the broad default subscription behavior, so this should be backward-compatible for current users.
- Clarified that `ModelRunner` is part of the model command key used to find model task handles.

### Feature and docs.rs metadata

- `features = ["all"]` now includes `lob_clients`, matching the expected aggregate feature behavior.
- Added `package.metadata.docs.rs.all-features = true`, so docs.rs builds with all optional exchange modules and helper exports enabled.

### Documentation and examples

- Cleaned tutorial-style comments and stale wording from complex and multi-strategy examples in #40.
- Updated private websocket wording to distinguish Binance UM listen-key websocket URLs from OKX connect/login/subscribe flow.
- Reworked the crate-level docs.rs section from a narrative "Why Events Drive Strategies" explanation into a tighter `Event Model` description.
- Tightened the usage guide and runtime mediator docs around strategy event loops, broadcast channels, and command handles.

## Compatibility notes

- Expected release type: patch.
- No breaking API removal is included in this release.
- `EventHandler::event_mask()` defaults preserve existing broad event subscription behavior.
- The `all` feature now enabling `lob_clients` can compile more code for users selecting `all`, but matches the feature name and docs.rs behavior more closely.

## Validation

- `cargo check --offline --all-features`
- `cargo doc --offline --no-deps --all-features`
- `cargo test --offline --doc --all-features`
- `cargo publish --dry-run`

Note: `cargo publish --dry-run --offline` cannot complete because Cargo still makes a crates.io HTTP request during publish validation; the normal dry-run completed successfully and did not publish.

## Post-merge release steps

1. Pull latest `master` after merge.
2. Tag the merge commit as `v0.1.8`.
3. Push the tag.
4. Run the actual `cargo publish` for `extrema_infra` `0.1.8`.
