### PR TITLE
feat(strategy): add bulk strategy module registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,13 +234,13 @@ edition = "2024"
 extrema_infra = { version = "0.1", features = ["all"] }
 
 # Enable exchange clients explicitly when needed.
-# extrema_infra = { version = "0.1", features = ["binance", "okx"] }
+# extrema_infra = { version = "0.1", features = ["hyperliquid", "okx"] }
 # extrema_infra = { version = "0.1", features = ["lob_clients"] }
 
 # For local development.
 # extrema_infra = { path = "../extrema_infra", features = ["all"] }
 
-# Or use the latest main branch directly.
+# Or use the latest default branch directly.
 # extrema_infra = { git = "https://github.com/Lqz13Th/extrema_infra", features = ["all"] }
 
 # Tokio async runtime

--- a/src/arch/infra_core/env_builder.rs
+++ b/src/arch/infra_core/env_builder.rs
@@ -6,6 +6,8 @@ use crate::arch::{
     strategy_base::{
         handler::handler_core::BoardCastChannel,
         hlist_core::{HCons, HNil},
+        strategy_group::InnerStrategyGroup,
+        strategy_module::InnerStrategyModule,
     },
     task_execution::task_general::TaskInfo,
     traits::strategy::Strategy,
@@ -111,24 +113,59 @@ impl<HeadList> EnvBuilder<HeadList> {
 
     /// Registers one strategy module.
     ///
+    /// Use this for a single business module. For multiple same-type modules,
+    /// use [`EnvBuilder::with_strategy_modules`] so every child gets its own
+    /// independent handler loop.
+    ///
     /// Calling this method repeatedly creates a static module chain. By default,
     /// modules subscribe to every registered broadcast event for backwards
     /// compatibility. Modules that override `EventHandler::event_mask` subscribe
     /// only to their selected event streams. All modules may independently send
     /// commands to the tasks they care about.
-    pub fn with_strategy_module<S>(self, strategy: S) -> EnvBuilder<HCons<S, HeadList>>
+    pub fn with_strategy_module<S>(
+        self,
+        strategy: S,
+    ) -> EnvBuilder<HCons<InnerStrategyModule<S>, HeadList>>
     where
         S: Strategy + Clone,
     {
         info!("Adding strategy: {}", strategy.strategy_name());
+        self.with_strategy_node(InnerStrategyModule::new(strategy))
+    }
+
+    fn with_strategy_node<N>(self, node: N) -> EnvBuilder<HCons<N, HeadList>>
+    where
+        N: Strategy + Clone,
+    {
         EnvBuilder {
             strategies: HCons {
-                head: strategy,
+                head: node,
                 tail: self.strategies,
             },
             board_cast_channels: self.board_cast_channels,
             tasks: self.tasks,
         }
+    }
+
+    /// Registers many same-type strategy modules.
+    ///
+    /// The runtime stores the modules in one static HList node, then spawns one
+    /// independent event loop per module. This is useful for account-scoped
+    /// modules such as per-account order executors.
+    ///
+    /// This is the public constructor path for strategy groups; the runtime
+    /// wrapper itself is intentionally not part of the prelude.
+    pub fn with_strategy_modules<S, I>(
+        self,
+        strategies: I,
+    ) -> EnvBuilder<HCons<InnerStrategyGroup<S>, HeadList>>
+    where
+        S: Strategy + Clone,
+        I: IntoIterator<Item = S>,
+    {
+        let group = InnerStrategyGroup::new(strategies);
+        info!("Adding strategy group with {} module(s)", group.len());
+        self.with_strategy_node(group)
     }
 }
 

--- a/src/arch/strategy_base.rs
+++ b/src/arch/strategy_base.rs
@@ -12,3 +12,5 @@
 pub mod command;
 pub mod handler;
 pub mod hlist_core;
+pub mod strategy_group;
+pub mod strategy_module;

--- a/src/arch/strategy_base/hlist_core.rs
+++ b/src/arch/strategy_base/hlist_core.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use tracing::info;
 
 use crate::arch::{
     strategy_base::{
@@ -15,6 +14,8 @@ pub struct HNil;
 
 impl Strategy for HNil {
     async fn initialize(&mut self) {}
+
+    async fn _spawn_strategy_tasks(&self, _channels: &Arc<Vec<BoardCastChannel>>) {}
 }
 impl CommandEmitter for HNil {
     fn command_init(&mut self, _command_handle: Arc<CommandRegistry>) {}
@@ -43,14 +44,7 @@ where
 
     async fn _spawn_strategy_tasks(&self, channels: &Arc<Vec<BoardCastChannel>>) {
         let HCons { head, tail } = self;
-        let ch = channels.clone();
-        let h = head.clone();
-
-        tokio::spawn(async move {
-            info!("Spawned strategy task for {}", h.strategy_name());
-            strategy_handler_loop(h, &ch).await;
-        });
-
+        head._spawn_strategy_tasks(channels).await;
         tail._spawn_strategy_tasks(channels).await;
     }
 }
@@ -144,5 +138,58 @@ where
         let fut_head = self.head.on_acc_pos(msg.clone());
         let fut_tail = self.tail.on_acc_pos(msg);
         tokio::join!(fut_head, fut_tail);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct ProbeStrategy {
+        spawn_count: Arc<AtomicUsize>,
+    }
+
+    impl Strategy for ProbeStrategy {
+        async fn initialize(&mut self) {}
+
+        async fn _spawn_strategy_tasks(&self, _channels: &Arc<Vec<BoardCastChannel>>) {
+            self.spawn_count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    impl CommandEmitter for ProbeStrategy {
+        fn command_init(&mut self, _command_handle: Arc<CommandRegistry>) {}
+
+        fn command_registry(&self) -> Arc<CommandRegistry> {
+            Arc::new(CommandRegistry::default())
+        }
+    }
+
+    impl EventHandler for ProbeStrategy {}
+
+    #[tokio::test]
+    async fn hlist_delegates_spawn_once_per_head() {
+        let spawn_count = Arc::new(AtomicUsize::new(0));
+        let strategies = HCons {
+            head: ProbeStrategy {
+                spawn_count: spawn_count.clone(),
+            },
+            tail: HCons {
+                head: ProbeStrategy {
+                    spawn_count: spawn_count.clone(),
+                },
+                tail: HNil,
+            },
+        };
+
+        strategies._spawn_strategy_tasks(&Arc::new(vec![])).await;
+
+        assert_eq!(spawn_count.load(Ordering::SeqCst), 2);
     }
 }

--- a/src/arch/strategy_base/strategy_group.rs
+++ b/src/arch/strategy_base/strategy_group.rs
@@ -1,0 +1,190 @@
+use std::sync::Arc;
+
+use futures::future;
+use tracing::info;
+
+use crate::arch::{
+    strategy_base::{
+        command::command_core::CommandRegistry,
+        handler::handler_core::{BoardCastChannel, strategy_handler_loop},
+    },
+    traits::strategy::{CommandEmitter, EventHandler, Strategy},
+};
+
+/// Runtime wrapper for registering many same-type strategy modules.
+///
+/// `EnvBuilder::with_strategy_modules` stores the modules in this group so the
+/// HList runtime can keep one static node while still spawning one handler loop
+/// per child module.
+#[derive(Clone)]
+#[doc(hidden)]
+pub struct InnerStrategyGroup<S> {
+    strategies: Vec<S>,
+    command_registry: Arc<CommandRegistry>,
+}
+
+impl<S> InnerStrategyGroup<S> {
+    pub(crate) fn new<I>(strategies: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+    {
+        Self {
+            strategies: strategies.into_iter().collect(),
+            command_registry: Arc::new(CommandRegistry::default()),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.strategies.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.strategies.is_empty()
+    }
+}
+
+impl<S> Strategy for InnerStrategyGroup<S>
+where
+    S: Strategy + Clone + Send + Sync + 'static,
+{
+    async fn initialize(&mut self) {
+        future::join_all(
+            self.strategies
+                .iter_mut()
+                .map(|strategy| strategy.initialize()),
+        )
+        .await;
+        info!(
+            "Initialized strategy group with {} module(s)",
+            self.strategies.len()
+        );
+    }
+
+    fn strategy_name(&self) -> &'static str {
+        "InnerStrategyGroup"
+    }
+
+    async fn _spawn_strategy_tasks(&self, channels: &Arc<Vec<BoardCastChannel>>) {
+        for strategy in self.strategies.iter().cloned() {
+            let channels = channels.clone();
+
+            tokio::spawn(async move {
+                info!("Spawned strategy task for {}", strategy.strategy_name());
+                strategy_handler_loop(strategy, &channels).await;
+            });
+        }
+    }
+}
+
+impl<S> CommandEmitter for InnerStrategyGroup<S>
+where
+    S: Strategy + Clone + Send + Sync + 'static,
+{
+    fn command_init(&mut self, registry: Arc<CommandRegistry>) {
+        self.command_registry = registry.clone();
+        for strategy in &mut self.strategies {
+            strategy.command_init(registry.clone());
+        }
+    }
+
+    fn command_registry(&self) -> Arc<CommandRegistry> {
+        self.command_registry.clone()
+    }
+}
+
+impl<S> EventHandler for InnerStrategyGroup<S> where S: Strategy + Clone + Send + Sync + 'static {}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use crate::arch::strategy_base::handler::event_mask::EventMask;
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct ProbeStrategy {
+        command_init_count: Arc<AtomicUsize>,
+        loop_start_count: Arc<AtomicUsize>,
+    }
+
+    impl Strategy for ProbeStrategy {
+        async fn initialize(&mut self) {}
+
+        fn strategy_name(&self) -> &'static str {
+            "ProbeStrategy"
+        }
+    }
+
+    impl CommandEmitter for ProbeStrategy {
+        fn command_init(&mut self, _command_handle: Arc<CommandRegistry>) {
+            self.command_init_count.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn command_registry(&self) -> Arc<CommandRegistry> {
+            Arc::new(CommandRegistry::default())
+        }
+    }
+
+    impl EventHandler for ProbeStrategy {
+        fn event_mask(&self) -> EventMask {
+            self.loop_start_count.fetch_add(1, Ordering::SeqCst);
+            EventMask::NONE
+        }
+    }
+
+    async fn wait_for_count(counter: &AtomicUsize, expected: usize) {
+        for _ in 0..10 {
+            if counter.load(Ordering::SeqCst) >= expected {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn strategy_group_spawns_each_child_once() {
+        let loop_start_count = Arc::new(AtomicUsize::new(0));
+        let group = InnerStrategyGroup::new(vec![
+            ProbeStrategy {
+                command_init_count: Arc::new(AtomicUsize::new(0)),
+                loop_start_count: loop_start_count.clone(),
+            },
+            ProbeStrategy {
+                command_init_count: Arc::new(AtomicUsize::new(0)),
+                loop_start_count: loop_start_count.clone(),
+            },
+            ProbeStrategy {
+                command_init_count: Arc::new(AtomicUsize::new(0)),
+                loop_start_count: loop_start_count.clone(),
+            },
+        ]);
+
+        group._spawn_strategy_tasks(&Arc::new(vec![])).await;
+        wait_for_count(&loop_start_count, 3).await;
+
+        assert_eq!(loop_start_count.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn strategy_group_forwards_command_init_to_children() {
+        let command_init_count = Arc::new(AtomicUsize::new(0));
+        let mut group = InnerStrategyGroup::new(vec![
+            ProbeStrategy {
+                command_init_count: command_init_count.clone(),
+                loop_start_count: Arc::new(AtomicUsize::new(0)),
+            },
+            ProbeStrategy {
+                command_init_count: command_init_count.clone(),
+                loop_start_count: Arc::new(AtomicUsize::new(0)),
+            },
+        ]);
+
+        group.command_init(Arc::new(CommandRegistry::default()));
+
+        assert_eq!(command_init_count.load(Ordering::SeqCst), 2);
+    }
+}

--- a/src/arch/strategy_base/strategy_module.rs
+++ b/src/arch/strategy_base/strategy_module.rs
@@ -1,0 +1,144 @@
+use std::sync::Arc;
+
+use tracing::info;
+
+use crate::arch::{
+    strategy_base::{
+        command::command_core::CommandRegistry,
+        handler::handler_core::{BoardCastChannel, strategy_handler_loop},
+    },
+    traits::strategy::{CommandEmitter, EventHandler, Strategy},
+};
+
+/// Runtime wrapper for one ordinary strategy module.
+///
+/// The wrapped strategy owns the business callbacks. This node owns the runtime
+/// spawn boundary used by the HList environment.
+#[derive(Clone)]
+#[doc(hidden)]
+pub struct InnerStrategyModule<S> {
+    strategy: S,
+}
+
+impl<S> InnerStrategyModule<S> {
+    pub(crate) fn new(strategy: S) -> Self {
+        Self { strategy }
+    }
+}
+
+impl<S> Strategy for InnerStrategyModule<S>
+where
+    S: Strategy + Clone + Send + Sync + 'static,
+{
+    async fn initialize(&mut self) {
+        self.strategy.initialize().await;
+    }
+
+    fn strategy_name(&self) -> &'static str {
+        self.strategy.strategy_name()
+    }
+
+    async fn _spawn_strategy_tasks(&self, channels: &Arc<Vec<BoardCastChannel>>) {
+        let channels = channels.clone();
+        let strategy = self.strategy.clone();
+
+        tokio::spawn(async move {
+            info!("Spawned strategy task for {}", strategy.strategy_name());
+            strategy_handler_loop(strategy, &channels).await;
+        });
+    }
+}
+
+impl<S> CommandEmitter for InnerStrategyModule<S>
+where
+    S: Strategy + Clone + Send + Sync + 'static,
+{
+    fn command_init(&mut self, registry: Arc<CommandRegistry>) {
+        self.strategy.command_init(registry);
+    }
+
+    fn command_registry(&self) -> Arc<CommandRegistry> {
+        self.strategy.command_registry()
+    }
+}
+
+impl<S> EventHandler for InnerStrategyModule<S> where S: Strategy + Clone + Send + Sync + 'static {}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use crate::arch::strategy_base::handler::event_mask::EventMask;
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct ProbeStrategy {
+        command_init_count: Arc<AtomicUsize>,
+        loop_start_count: Arc<AtomicUsize>,
+    }
+
+    impl Strategy for ProbeStrategy {
+        async fn initialize(&mut self) {}
+
+        fn strategy_name(&self) -> &'static str {
+            "ProbeStrategy"
+        }
+    }
+
+    impl CommandEmitter for ProbeStrategy {
+        fn command_init(&mut self, _command_handle: Arc<CommandRegistry>) {
+            self.command_init_count.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn command_registry(&self) -> Arc<CommandRegistry> {
+            Arc::new(CommandRegistry::default())
+        }
+    }
+
+    impl EventHandler for ProbeStrategy {
+        fn event_mask(&self) -> EventMask {
+            self.loop_start_count.fetch_add(1, Ordering::SeqCst);
+            EventMask::NONE
+        }
+    }
+
+    async fn wait_for_count(counter: &AtomicUsize, expected: usize) {
+        for _ in 0..10 {
+            if counter.load(Ordering::SeqCst) >= expected {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn strategy_module_spawns_wrapped_strategy_once() {
+        let loop_start_count = Arc::new(AtomicUsize::new(0));
+        let module = InnerStrategyModule::new(ProbeStrategy {
+            command_init_count: Arc::new(AtomicUsize::new(0)),
+            loop_start_count: loop_start_count.clone(),
+        });
+
+        module._spawn_strategy_tasks(&Arc::new(vec![])).await;
+        wait_for_count(&loop_start_count, 1).await;
+
+        assert_eq!(loop_start_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn strategy_module_forwards_command_init() {
+        let command_init_count = Arc::new(AtomicUsize::new(0));
+        let mut module = InnerStrategyModule::new(ProbeStrategy {
+            command_init_count: command_init_count.clone(),
+            loop_start_count: Arc::new(AtomicUsize::new(0)),
+        });
+
+        module.command_init(Arc::new(CommandRegistry::default()));
+
+        assert_eq!(command_init_count.load(Ordering::SeqCst), 1);
+    }
+}

--- a/tests/strategy_runtime.rs
+++ b/tests/strategy_runtime.rs
@@ -1,0 +1,151 @@
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use extrema_infra::prelude::*;
+
+#[derive(Clone)]
+struct ProbeStrategy {
+    initialize_count: Arc<AtomicUsize>,
+    command_init_count: Arc<AtomicUsize>,
+    event_mask_count: Arc<AtomicUsize>,
+    registry: Arc<CommandRegistry>,
+}
+
+impl ProbeStrategy {
+    fn new(
+        initialize_count: Arc<AtomicUsize>,
+        command_init_count: Arc<AtomicUsize>,
+        event_mask_count: Arc<AtomicUsize>,
+    ) -> Self {
+        Self {
+            initialize_count,
+            command_init_count,
+            event_mask_count,
+            registry: Arc::new(CommandRegistry::default()),
+        }
+    }
+}
+
+impl Strategy for ProbeStrategy {
+    async fn initialize(&mut self) {
+        self.initialize_count.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn strategy_name(&self) -> &'static str {
+        "ProbeStrategy"
+    }
+}
+
+impl CommandEmitter for ProbeStrategy {
+    fn command_init(&mut self, registry: Arc<CommandRegistry>) {
+        self.command_init_count.fetch_add(1, Ordering::SeqCst);
+        self.registry = registry;
+    }
+
+    fn command_registry(&self) -> Arc<CommandRegistry> {
+        self.registry.clone()
+    }
+}
+
+impl EventHandler for ProbeStrategy {
+    fn event_mask(&self) -> EventMask {
+        self.event_mask_count.fetch_add(1, Ordering::SeqCst);
+        EventMask::NONE
+    }
+}
+
+async fn wait_for_counter(counter: Arc<AtomicUsize>, expected: usize) {
+    tokio::time::timeout(Duration::from_secs(1), async move {
+        loop {
+            if counter.load(Ordering::SeqCst) >= expected {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("strategy runtime did not reach expected count");
+}
+
+#[tokio::test]
+async fn env_builder_starts_single_strategy_handler_loop() {
+    let initialize_count = Arc::new(AtomicUsize::new(0));
+    let command_init_count = Arc::new(AtomicUsize::new(0));
+    let event_mask_count = Arc::new(AtomicUsize::new(0));
+
+    let env = EnvBuilder::new()
+        .with_strategy_module(ProbeStrategy::new(
+            initialize_count.clone(),
+            command_init_count.clone(),
+            event_mask_count.clone(),
+        ))
+        .build();
+
+    let runtime = tokio::spawn(env.execute());
+    wait_for_counter(event_mask_count.clone(), 1).await;
+    runtime.abort();
+
+    assert_eq!(initialize_count.load(Ordering::SeqCst), 1);
+    assert_eq!(command_init_count.load(Ordering::SeqCst), 1);
+    assert_eq!(event_mask_count.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn env_builder_starts_repeated_single_strategy_handler_loops() {
+    let initialize_count = Arc::new(AtomicUsize::new(0));
+    let command_init_count = Arc::new(AtomicUsize::new(0));
+    let event_mask_count = Arc::new(AtomicUsize::new(0));
+
+    let env = EnvBuilder::new()
+        .with_strategy_module(ProbeStrategy::new(
+            initialize_count.clone(),
+            command_init_count.clone(),
+            event_mask_count.clone(),
+        ))
+        .with_strategy_module(ProbeStrategy::new(
+            initialize_count.clone(),
+            command_init_count.clone(),
+            event_mask_count.clone(),
+        ))
+        .build();
+
+    let runtime = tokio::spawn(env.execute());
+    wait_for_counter(event_mask_count.clone(), 2).await;
+    runtime.abort();
+
+    assert_eq!(initialize_count.load(Ordering::SeqCst), 2);
+    assert_eq!(command_init_count.load(Ordering::SeqCst), 2);
+    assert_eq!(event_mask_count.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn env_builder_starts_many_same_type_strategy_handler_loops() {
+    let initialize_count = Arc::new(AtomicUsize::new(0));
+    let command_init_count = Arc::new(AtomicUsize::new(0));
+    let event_mask_count = Arc::new(AtomicUsize::new(0));
+
+    let modules = (0..3)
+        .map(|_| {
+            ProbeStrategy::new(
+                initialize_count.clone(),
+                command_init_count.clone(),
+                event_mask_count.clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let env = EnvBuilder::new().with_strategy_modules(modules).build();
+
+    let runtime = tokio::spawn(env.execute());
+    wait_for_counter(event_mask_count.clone(), 3).await;
+    runtime.abort();
+
+    assert_eq!(initialize_count.load(Ordering::SeqCst), 3);
+    assert_eq!(command_init_count.load(Ordering::SeqCst), 3);
+    assert_eq!(event_mask_count.load(Ordering::SeqCst), 3);
+}


### PR DESCRIPTION

## Summary

Adds bulk registration for same-type strategy modules through `EnvBuilder::with_strategy_modules`.

The runtime now distinguishes between business strategies and runtime strategy nodes:

- `with_strategy_module(strategy)` wraps one business strategy in an internal `InnerStrategyModule` node.
- `with_strategy_modules(strategies)` wraps same-type strategies in an internal `InnerStrategyGroup` node.
- `HCons` delegates spawning to each node, so a normal module starts one handler loop and a group starts one handler loop per child strategy.
- `Strategy` itself keeps `_spawn_strategy_tasks` as a no-op by default, so runtime spawning does not leak into the business trait.

## Why

This supports cases such as registering many per-account or per-symbol order executors without writing a long chain of repeated `with_strategy_module(...)` calls.

Example shape:

```rust
let executors = accounts
    .into_iter()
    .map(OrderExecutor::new)
    .collect::<Vec<_>>();

let env = EnvBuilder::new()
    .with_strategy_modules(executors)
    .build();
```

## Notes

- Internal wrappers are named `InnerStrategyModule` and `InnerStrategyGroup` and are `#[doc(hidden)]`.
- Wrapper constructors are crate-private, so users should use the builder APIs instead of constructing runtime nodes manually.
- README dependency notes are included in this PR as requested.

## Validation

- `cargo fmt --check`
- `cargo check --offline --all-features`
- `cargo test --offline --lib --all-features`
- `cargo test --offline --test strategy_runtime`
- `cargo test --offline --doc --all-features`
- `cargo check --offline --no-default-features`
- `cargo check --offline --features binance --example multi_strategy_example`
