### PR TITLE
feat(exchange): add sub-account transfer APIs

### DIFF
--- a/src/arch/market_assets/exchange/binance/api_utils.rs
+++ b/src/arch/market_assets/exchange/binance/api_utils.rs
@@ -5,6 +5,7 @@ use std::{collections::HashMap, sync::Arc};
 use tracing::warn;
 
 use crate::arch::market_assets::base_data::SUBSCRIBE;
+use crate::errors::{InfraError, InfraResult};
 
 use super::api_key::BinanceKey;
 
@@ -137,6 +138,136 @@ impl BinanceUniversalTransferHistoryReq {
         }
 
         parts.join("&")
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BinanceSubAccountTransferAccountType {
+    Spot,
+    UsdtFuture,
+    CoinFuture,
+    Margin,
+    IsolatedMargin,
+    Alpha,
+}
+
+impl BinanceSubAccountTransferAccountType {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Spot => "SPOT",
+            Self::UsdtFuture => "USDT_FUTURE",
+            Self::CoinFuture => "COIN_FUTURE",
+            Self::Margin => "MARGIN",
+            Self::IsolatedMargin => "ISOLATED_MARGIN",
+            Self::Alpha => "ALPHA",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BinanceSubAccountUniversalTransferReq {
+    pub from_email: Option<String>,
+    pub to_email: Option<String>,
+    pub from_account_type: BinanceSubAccountTransferAccountType,
+    pub to_account_type: BinanceSubAccountTransferAccountType,
+    pub client_tran_id: Option<String>,
+    pub symbol: Option<String>,
+    pub asset: String,
+    pub amount: String,
+    pub recv_window: Option<u64>,
+}
+
+impl BinanceSubAccountUniversalTransferReq {
+    pub(crate) fn to_query_string(&self) -> InfraResult<String> {
+        if self.from_account_type == self.to_account_type
+            && self.from_email.is_none()
+            && self.to_email.is_none()
+        {
+            return Err(InfraError::ApiCliError(
+                "Binance sub-account universal transfer requires fromEmail or toEmail when account types are the same".into(),
+            ));
+        }
+
+        let mut parts = vec![
+            format!("fromAccountType={}", self.from_account_type.as_str()),
+            format!("toAccountType={}", self.to_account_type.as_str()),
+            format!("asset={}", self.asset.to_uppercase()),
+            format!("amount={}", self.amount),
+        ];
+
+        if let Some(from_email) = self.from_email.as_deref() {
+            parts.push(format!("fromEmail={from_email}"));
+        }
+        if let Some(to_email) = self.to_email.as_deref() {
+            parts.push(format!("toEmail={to_email}"));
+        }
+        if let Some(client_tran_id) = self.client_tran_id.as_deref() {
+            parts.push(format!("clientTranId={client_tran_id}"));
+        }
+        if let Some(symbol) = self.symbol.as_deref() {
+            parts.push(format!("symbol={symbol}"));
+        }
+        if let Some(recv_window) = self.recv_window {
+            parts.push(format!("recvWindow={recv_window}"));
+        }
+
+        Ok(parts.join("&"))
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BinanceSubAccountUniversalTransferHistoryReq {
+    pub from_email: Option<String>,
+    pub to_email: Option<String>,
+    pub client_tran_id: Option<String>,
+    pub start_time: Option<u64>,
+    pub end_time: Option<u64>,
+    pub page: Option<u32>,
+    pub limit: Option<u32>,
+    pub recv_window: Option<u64>,
+}
+
+impl BinanceSubAccountUniversalTransferHistoryReq {
+    pub(crate) fn to_query_string(&self) -> InfraResult<Option<String>> {
+        if self.from_email.is_some() && self.to_email.is_some() {
+            return Err(InfraError::ApiCliError(
+                "Binance sub-account transfer history cannot send fromEmail and toEmail together"
+                    .into(),
+            ));
+        }
+
+        let mut parts: Vec<String> = Vec::new();
+
+        if let Some(from_email) = self.from_email.as_deref() {
+            parts.push(format!("fromEmail={from_email}"));
+        }
+        if let Some(to_email) = self.to_email.as_deref() {
+            parts.push(format!("toEmail={to_email}"));
+        }
+        if let Some(client_tran_id) = self.client_tran_id.as_deref() {
+            parts.push(format!("clientTranId={client_tran_id}"));
+        }
+        if let Some(start_time) = self.start_time {
+            parts.push(format!("startTime={start_time}"));
+        }
+        if let Some(end_time) = self.end_time {
+            parts.push(format!("endTime={end_time}"));
+        }
+        if let Some(page) = self.page {
+            parts.push(format!("page={page}"));
+        }
+        if let Some(limit) = self.limit {
+            parts.push(format!("limit={limit}"));
+        }
+        if let Some(recv_window) = self.recv_window {
+            parts.push(format!("recvWindow={recv_window}"));
+        }
+
+        if parts.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(parts.join("&")))
+        }
     }
 }
 
@@ -460,5 +591,77 @@ mod tests {
         assert_eq!(cli_perp_to_binance_cm_pair("BTC_USD_PERP"), "BTCUSD");
         assert_eq!(cli_perp_to_binance_cm_pair("BTC_USDT_PERP"), "BTCUSD");
         assert_eq!(cli_perp_to_binance_cm_pair("BTC_USD_FUT_240329"), "BTCUSD");
+    }
+
+    #[test]
+    fn builds_binance_sub_account_universal_transfer_query() {
+        let req = BinanceSubAccountUniversalTransferReq {
+            from_email: None,
+            to_email: Some("sub@example.com".into()),
+            from_account_type: BinanceSubAccountTransferAccountType::Spot,
+            to_account_type: BinanceSubAccountTransferAccountType::UsdtFuture,
+            client_tran_id: Some("client-1".into()),
+            symbol: None,
+            asset: "usdt".into(),
+            amount: "1.25".into(),
+            recv_window: Some(5_000),
+        };
+
+        assert_eq!(
+            req.to_query_string().unwrap(),
+            "fromAccountType=SPOT&toAccountType=USDT_FUTURE&asset=USDT&amount=1.25&toEmail=sub@example.com&clientTranId=client-1&recvWindow=5000"
+        );
+    }
+
+    #[test]
+    fn rejects_binance_same_account_type_transfer_without_email() {
+        let req = BinanceSubAccountUniversalTransferReq {
+            from_email: None,
+            to_email: None,
+            from_account_type: BinanceSubAccountTransferAccountType::Spot,
+            to_account_type: BinanceSubAccountTransferAccountType::Spot,
+            client_tran_id: None,
+            symbol: None,
+            asset: "USDT".into(),
+            amount: "1".into(),
+            recv_window: None,
+        };
+
+        assert!(req.to_query_string().is_err());
+    }
+
+    #[test]
+    fn builds_binance_sub_account_transfer_history_query() {
+        let empty_req = BinanceSubAccountUniversalTransferHistoryReq::default();
+        assert_eq!(empty_req.to_query_string().unwrap(), None);
+
+        let req = BinanceSubAccountUniversalTransferHistoryReq {
+            from_email: Some("from@example.com".into()),
+            to_email: None,
+            client_tran_id: Some("client-2".into()),
+            start_time: Some(1),
+            end_time: Some(2),
+            page: Some(3),
+            limit: Some(4),
+            recv_window: None,
+        };
+
+        assert_eq!(
+            req.to_query_string().unwrap().as_deref(),
+            Some(
+                "fromEmail=from@example.com&clientTranId=client-2&startTime=1&endTime=2&page=3&limit=4"
+            )
+        );
+    }
+
+    #[test]
+    fn rejects_binance_sub_account_transfer_history_with_both_emails() {
+        let req = BinanceSubAccountUniversalTransferHistoryReq {
+            from_email: Some("from@example.com".into()),
+            to_email: Some("to@example.com".into()),
+            ..Default::default()
+        };
+
+        assert!(req.to_query_string().is_err());
     }
 }

--- a/src/arch/market_assets/exchange/binance/binance_spot_cli.rs
+++ b/src/arch/market_assets/exchange/binance/binance_spot_cli.rs
@@ -32,7 +32,10 @@ use super::{
             all_coins_info::RestCapitalConfigCoinBinance,
             deposit_address::RestDepositAddressBinance,
             deposit_address_list::RestDepositAddressListBinance,
-            deposit_history::RestDepositHistoryBinance, transfer::RestUserUniversalTransferBinance,
+            deposit_history::RestDepositHistoryBinance,
+            sub_account_transfer::RestSubAccountUniversalTransferBinance,
+            sub_account_transfer_history::RestSubAccountTransferHistoryBinance,
+            transfer::RestUserUniversalTransferBinance,
             transfer_history::RestTransferHistoryBinance, withdraw::RestWithdrawBinance,
             withdraw_address_list::RestWithdrawAddressBinance,
             withdraw_history::RestWithdrawHistoryBinance,
@@ -147,6 +150,35 @@ impl BinanceSpotCli {
         Ok(data)
     }
 
+    pub async fn sub_account_universal_transfer(
+        &self,
+        req: BinanceSubAccountUniversalTransferReq,
+    ) -> InfraResult<RestSubAccountUniversalTransferBinance> {
+        let query = req.to_query_string()?;
+        let res: RestResBinance<RestSubAccountUniversalTransferBinance> = self
+            .api_key
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_signed_request(
+                &self.client,
+                RequestMethod::Post,
+                Some(&query),
+                BINANCE_SPOT_BASE_URL,
+                BINANCE_SUB_ACCOUNT_UNIVERSAL_TRANSFER,
+            )
+            .await?;
+
+        let data = res
+            .into_vec()?
+            .into_iter()
+            .next()
+            .ok_or(InfraError::ApiCliError(
+                "No sub-account transfer response data returned".into(),
+            ))?;
+
+        Ok(data)
+    }
+
     pub async fn transfer_spot_to_um(
         &self,
         asset: &str,
@@ -231,6 +263,35 @@ impl BinanceSpotCli {
             .next()
             .ok_or(InfraError::ApiCliError(
                 "No transfer history data returned".into(),
+            ))?;
+
+        Ok(data)
+    }
+
+    pub async fn get_sub_account_universal_transfer_history(
+        &self,
+        req: BinanceSubAccountUniversalTransferHistoryReq,
+    ) -> InfraResult<RestSubAccountTransferHistoryBinance> {
+        let query = req.to_query_string()?;
+        let res: RestResBinance<RestSubAccountTransferHistoryBinance> = self
+            .api_key
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_signed_request(
+                &self.client,
+                RequestMethod::Get,
+                query.as_deref(),
+                BINANCE_SPOT_BASE_URL,
+                BINANCE_SUB_ACCOUNT_UNIVERSAL_TRANSFER,
+            )
+            .await?;
+
+        let data = res
+            .into_vec()?
+            .into_iter()
+            .next()
+            .ok_or(InfraError::ApiCliError(
+                "No sub-account transfer history data returned".into(),
             ))?;
 
         Ok(data)

--- a/src/arch/market_assets/exchange/binance/config_assets.rs
+++ b/src/arch/market_assets/exchange/binance/config_assets.rs
@@ -9,6 +9,7 @@ pub const BINANCE_SPOT_ACCOUNT_INFO: &str = "/api/v3/account";
 pub const BINANCE_SPOT_MY_TRADES: &str = "/api/v3/myTrades";
 pub const SPOT_USER_DATA_STREAM: &str = "/api/v3/userDataStream";
 pub const BINANCE_USER_UNIVERSAL_TRANSFER: &str = "/sapi/v1/asset/transfer";
+pub const BINANCE_SUB_ACCOUNT_UNIVERSAL_TRANSFER: &str = "/sapi/v1/sub-account/universalTransfer";
 pub const BINANCE_CAPITAL_CONFIG_GETALL: &str = "/sapi/v1/capital/config/getall";
 pub const BINANCE_DEPOSIT_ADDRESS: &str = "/sapi/v1/capital/deposit/address";
 pub const BINANCE_DEPOSIT_ADDRESS_LIST: &str = "/sapi/v1/capital/deposit/address/list";

--- a/src/arch/market_assets/exchange/binance/schemas/wallet_rest.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/wallet_rest.rs
@@ -2,6 +2,8 @@ pub mod all_coins_info;
 pub mod deposit_address;
 pub mod deposit_address_list;
 pub mod deposit_history;
+pub mod sub_account_transfer;
+pub mod sub_account_transfer_history;
 pub mod transfer;
 pub mod transfer_history;
 pub mod withdraw;

--- a/src/arch/market_assets/exchange/binance/schemas/wallet_rest/sub_account_transfer.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/wallet_rest/sub_account_transfer.rs
@@ -1,0 +1,16 @@
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::HashMap;
+
+use crate::arch::market_assets::api_general::de_u64_from_string_or_number;
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct RestSubAccountUniversalTransferBinance {
+    #[serde(default, deserialize_with = "de_u64_from_string_or_number")]
+    pub tranId: u64,
+    #[serde(default)]
+    pub clientTranId: String,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}

--- a/src/arch/market_assets/exchange/binance/schemas/wallet_rest/sub_account_transfer_history.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/wallet_rest/sub_account_transfer_history.rs
@@ -1,0 +1,41 @@
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::HashMap;
+
+use crate::arch::market_assets::api_general::{de_micros_from_int, de_u64_from_string_or_number};
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct RestSubAccountTransferHistoryRowBinance {
+    #[serde(default, deserialize_with = "de_u64_from_string_or_number")]
+    pub tranId: u64,
+    #[serde(default)]
+    pub fromEmail: String,
+    #[serde(default)]
+    pub toEmail: String,
+    #[serde(default)]
+    pub asset: String,
+    #[serde(default)]
+    pub amount: String,
+    #[serde(default, deserialize_with = "de_micros_from_int")]
+    pub createTimeStamp: u64,
+    #[serde(default)]
+    pub fromAccountType: String,
+    #[serde(default)]
+    pub toAccountType: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub clientTranId: String,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct RestSubAccountTransferHistoryBinance {
+    #[serde(default)]
+    pub result: Vec<RestSubAccountTransferHistoryRowBinance>,
+    #[serde(default, deserialize_with = "de_u64_from_string_or_number")]
+    pub totalCount: u64,
+}

--- a/src/arch/market_assets/exchange/gate/api_utils.rs
+++ b/src/arch/market_assets/exchange/gate/api_utils.rs
@@ -229,6 +229,175 @@ impl GateWithdrawReq {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum GateSubAccountTransferAccountType {
+    Spot,
+    Futures,
+    CrossMargin,
+    Delivery,
+    Options,
+}
+
+impl GateSubAccountTransferAccountType {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Spot => "spot",
+            Self::Futures => "futures",
+            Self::CrossMargin => "cross_margin",
+            Self::Delivery => "delivery",
+            Self::Options => "options",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum GateSubAccountToSubAccountTransferAccountType {
+    Spot,
+    Futures,
+    Delivery,
+}
+
+impl GateSubAccountToSubAccountTransferAccountType {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Spot => "spot",
+            Self::Futures => "futures",
+            Self::Delivery => "delivery",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum GateSubAccountTransferDirection {
+    To,
+    From,
+}
+
+impl GateSubAccountTransferDirection {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::To => "to",
+            Self::From => "from",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GateSubAccountTransferReq {
+    pub sub_account: String,
+    pub sub_account_type: Option<GateSubAccountTransferAccountType>,
+    pub currency: String,
+    pub amount: String,
+    pub direction: GateSubAccountTransferDirection,
+    pub client_order_id: Option<String>,
+}
+
+impl GateSubAccountTransferReq {
+    pub(crate) fn to_body_string(&self) -> String {
+        let mut body = json!({
+            "sub_account": self.sub_account,
+            "currency": self.currency.to_uppercase(),
+            "amount": self.amount,
+            "direction": self.direction.as_str(),
+        });
+
+        if let Some(sub_account_type) = self.sub_account_type.as_ref() {
+            body["sub_account_type"] = json!(sub_account_type.as_str());
+        }
+        if let Some(client_order_id) = self.client_order_id.as_deref() {
+            body["client_order_id"] = json!(client_order_id);
+        }
+
+        body.to_string()
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GateSubAccountTransferHistoryReq {
+    pub sub_uid: Option<String>,
+    pub from: Option<u64>,
+    pub to: Option<u64>,
+    pub limit: Option<u32>,
+    pub offset: Option<u32>,
+}
+
+impl GateSubAccountTransferHistoryReq {
+    pub(crate) fn to_query_string(&self) -> Option<String> {
+        let mut parts: Vec<String> = Vec::new();
+
+        if let Some(sub_uid) = self.sub_uid.as_deref() {
+            parts.push(format!("sub_uid={sub_uid}"));
+        }
+        if let Some(from) = self.from {
+            parts.push(format!("from={from}"));
+        }
+        if let Some(to) = self.to {
+            parts.push(format!("to={to}"));
+        }
+        if let Some(limit) = self.limit {
+            parts.push(format!("limit={limit}"));
+        }
+        if let Some(offset) = self.offset {
+            parts.push(format!("offset={offset}"));
+        }
+
+        if parts.is_empty() {
+            None
+        } else {
+            Some(parts.join("&"))
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GateSubAccountToSubAccountTransferReq {
+    pub currency: String,
+    pub sub_account_from: String,
+    pub sub_account_from_type: GateSubAccountToSubAccountTransferAccountType,
+    pub sub_account_to: String,
+    pub sub_account_to_type: GateSubAccountToSubAccountTransferAccountType,
+    pub amount: String,
+}
+
+impl GateSubAccountToSubAccountTransferReq {
+    pub(crate) fn to_body_string(&self) -> String {
+        json!({
+            "currency": self.currency.to_uppercase(),
+            "sub_account_from": self.sub_account_from,
+            "sub_account_from_type": self.sub_account_from_type.as_str(),
+            "sub_account_to": self.sub_account_to,
+            "sub_account_to_type": self.sub_account_to_type.as_str(),
+            "amount": self.amount,
+        })
+        .to_string()
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GateTransferOrderStatusReq {
+    pub client_order_id: Option<String>,
+    pub tx_id: Option<String>,
+}
+
+impl GateTransferOrderStatusReq {
+    pub(crate) fn to_query_string(&self) -> Option<String> {
+        let mut parts: Vec<String> = Vec::new();
+
+        if let Some(client_order_id) = self.client_order_id.as_deref() {
+            parts.push(format!("client_order_id={client_order_id}"));
+        }
+        if let Some(tx_id) = self.tx_id.as_deref() {
+            parts.push(format!("tx_id={tx_id}"));
+        }
+
+        if parts.is_empty() {
+            None
+        } else {
+            Some(parts.join("&"))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -281,5 +450,82 @@ mod tests {
             )]);
             assert!(take_gate_channel_id(&mut extra).is_err());
         }
+    }
+
+    #[test]
+    fn builds_gate_sub_account_transfer_body() {
+        let req = GateSubAccountTransferReq {
+            sub_account: "10001".into(),
+            sub_account_type: Some(GateSubAccountTransferAccountType::Futures),
+            currency: "usdt".into(),
+            amount: "10".into(),
+            direction: GateSubAccountTransferDirection::To,
+            client_order_id: Some("order-1".into()),
+        };
+
+        let body: serde_json::Value = serde_json::from_str(&req.to_body_string()).unwrap();
+        assert_eq!(body["sub_account"], "10001");
+        assert_eq!(body["sub_account_type"], "futures");
+        assert_eq!(body["currency"], "USDT");
+        assert_eq!(body["amount"], "10");
+        assert_eq!(body["direction"], "to");
+        assert_eq!(body["client_order_id"], "order-1");
+    }
+
+    #[test]
+    fn builds_gate_sub_account_to_sub_account_transfer_body() {
+        let req = GateSubAccountToSubAccountTransferReq {
+            currency: "btc".into(),
+            sub_account_from: "10001".into(),
+            sub_account_from_type: GateSubAccountToSubAccountTransferAccountType::Spot,
+            sub_account_to: "10002".into(),
+            sub_account_to_type: GateSubAccountToSubAccountTransferAccountType::Delivery,
+            amount: "0.1".into(),
+        };
+
+        let body: serde_json::Value = serde_json::from_str(&req.to_body_string()).unwrap();
+        assert_eq!(body["currency"], "BTC");
+        assert_eq!(body["sub_account_from"], "10001");
+        assert_eq!(body["sub_account_from_type"], "spot");
+        assert_eq!(body["sub_account_to"], "10002");
+        assert_eq!(body["sub_account_to_type"], "delivery");
+        assert_eq!(body["amount"], "0.1");
+    }
+
+    #[test]
+    fn builds_gate_transfer_query_strings() {
+        assert_eq!(
+            GateSubAccountTransferAccountType::CrossMargin.as_str(),
+            "cross_margin"
+        );
+        assert_eq!(
+            GateSubAccountTransferAccountType::Options.as_str(),
+            "options"
+        );
+        assert_eq!(
+            GateSubAccountToSubAccountTransferAccountType::Futures.as_str(),
+            "futures"
+        );
+
+        let history_req = GateSubAccountTransferHistoryReq {
+            sub_uid: Some("10001".into()),
+            from: Some(1),
+            to: Some(2),
+            limit: Some(3),
+            offset: Some(4),
+        };
+        assert_eq!(
+            history_req.to_query_string().as_deref(),
+            Some("sub_uid=10001&from=1&to=2&limit=3&offset=4")
+        );
+
+        let status_req = GateTransferOrderStatusReq {
+            client_order_id: Some("order-1".into()),
+            tx_id: Some("tx-1".into()),
+        };
+        assert_eq!(
+            status_req.to_query_string().as_deref(),
+            Some("client_order_id=order-1&tx_id=tx-1")
+        );
     }
 }

--- a/src/arch/market_assets/exchange/gate/config_assets.rs
+++ b/src/arch/market_assets/exchange/gate/config_assets.rs
@@ -58,6 +58,10 @@ pub const GATE_ACCOUNT_MAIN_KEYS: &str = "/api/v4/account/main_keys";
 pub const GATE_WALLET_CURRENCY_CHAINS: &str = "/api/v4/wallet/currency_chains";
 pub const GATE_WALLET_DEPOSIT_ADDRESS: &str = "/api/v4/wallet/deposit_address";
 pub const GATE_WALLET_SAVED_ADDRESS: &str = "/api/v4/wallet/saved_address";
+pub const GATE_WALLET_SUB_ACCOUNT_TRANSFERS: &str = "/api/v4/wallet/sub_account_transfers";
+pub const GATE_WALLET_SUB_ACCOUNT_TO_SUB_ACCOUNT: &str =
+    "/api/v4/wallet/sub_account_to_sub_account";
+pub const GATE_WALLET_ORDER_STATUS: &str = "/api/v4/wallet/order_status";
 pub const GATE_WITHDRAWALS: &str = "/api/v4/withdrawals";
 pub const GATE_WALLET_WITHDRAWALS_LIST: &str = "/api/v4/wallet/withdrawals";
 pub const GATE_WALLET_DEPOSITS_LIST: &str = "/api/v4/wallet/deposits";

--- a/src/arch/market_assets/exchange/gate/gate_spot_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_spot_cli.rs
@@ -21,8 +21,15 @@ use crate::arch::{
                 wallet_rest::{
                     currency_chains::RestCurrencyChainGate,
                     deposit_address::RestDepositAddressGate,
-                    deposit_history::RestDepositHistoryGate, saved_address::RestSavedAddressGate,
-                    withdraw::RestWithdrawGate, withdraw_history::RestWithdrawHistoryGate,
+                    deposit_history::RestDepositHistoryGate,
+                    saved_address::RestSavedAddressGate,
+                    sub_account_to_sub_account::RestSubAccountToSubAccountTransferGate,
+                    sub_account_transfer::{
+                        RestSubAccountTransferGate, RestSubAccountTransferHistoryGate,
+                    },
+                    transfer_order_status::RestTransferOrderStatusGate,
+                    withdraw::RestWithdrawGate,
+                    withdraw_history::RestWithdrawHistoryGate,
                 },
             },
         },
@@ -180,6 +187,122 @@ impl GateSpotCli {
             .await?;
 
         res.into_vec()
+    }
+
+    pub async fn sub_account_transfer(
+        &self,
+        req: GateSubAccountTransferReq,
+    ) -> InfraResult<RestSubAccountTransferGate> {
+        let res: RestResGate<RestSubAccountTransferGate> = self
+            .api_key
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_signed_request(
+                &self.client,
+                RequestMethod::Post,
+                None,
+                Some(&req.to_body_string()),
+                GATE_BASE_URL,
+                GATE_WALLET_SUB_ACCOUNT_TRANSFERS,
+            )
+            .await?;
+
+        let data = res
+            .into_vec()?
+            .into_iter()
+            .next()
+            .ok_or(InfraError::ApiCliError(
+                "No sub-account transfer response data returned".into(),
+            ))?;
+
+        Ok(data)
+    }
+
+    pub async fn get_sub_account_transfer_history(
+        &self,
+        req: GateSubAccountTransferHistoryReq,
+    ) -> InfraResult<Vec<RestSubAccountTransferHistoryGate>> {
+        let query = req.to_query_string();
+
+        let res: RestResGate<RestSubAccountTransferHistoryGate> = self
+            .api_key
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_signed_request(
+                &self.client,
+                RequestMethod::Get,
+                query.as_deref(),
+                None,
+                GATE_BASE_URL,
+                GATE_WALLET_SUB_ACCOUNT_TRANSFERS,
+            )
+            .await?;
+
+        res.into_vec()
+    }
+
+    pub async fn sub_account_to_sub_account_transfer(
+        &self,
+        req: GateSubAccountToSubAccountTransferReq,
+    ) -> InfraResult<RestSubAccountToSubAccountTransferGate> {
+        let res: RestResGate<RestSubAccountToSubAccountTransferGate> = self
+            .api_key
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_signed_request(
+                &self.client,
+                RequestMethod::Post,
+                None,
+                Some(&req.to_body_string()),
+                GATE_BASE_URL,
+                GATE_WALLET_SUB_ACCOUNT_TO_SUB_ACCOUNT,
+            )
+            .await?;
+
+        let data = res
+            .into_vec()?
+            .into_iter()
+            .next()
+            .ok_or(InfraError::ApiCliError(
+                "No sub-account to sub-account transfer data returned".into(),
+            ))?;
+
+        Ok(data)
+    }
+
+    pub async fn get_transfer_order_status(
+        &self,
+        req: GateTransferOrderStatusReq,
+    ) -> InfraResult<RestTransferOrderStatusGate> {
+        let query = req.to_query_string().ok_or_else(|| {
+            InfraError::ApiCliError(
+                "Gate wallet/order_status requires client_order_id or tx_id".into(),
+            )
+        })?;
+
+        let res: RestResGate<RestTransferOrderStatusGate> = self
+            .api_key
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_signed_request(
+                &self.client,
+                RequestMethod::Get,
+                Some(&query),
+                None,
+                GATE_BASE_URL,
+                GATE_WALLET_ORDER_STATUS,
+            )
+            .await?;
+
+        let data = res
+            .into_vec()?
+            .into_iter()
+            .next()
+            .ok_or(InfraError::ApiCliError(
+                "No transfer order status data returned".into(),
+            ))?;
+
+        Ok(data)
     }
 
     pub async fn get_currency_chains(

--- a/src/arch/market_assets/exchange/gate/schemas/wallet_rest.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/wallet_rest.rs
@@ -2,5 +2,8 @@ pub mod currency_chains;
 pub mod deposit_address;
 pub mod deposit_history;
 pub mod saved_address;
+pub mod sub_account_to_sub_account;
+pub mod sub_account_transfer;
+pub mod transfer_order_status;
 pub mod withdraw;
 pub mod withdraw_history;

--- a/src/arch/market_assets/exchange/gate/schemas/wallet_rest/sub_account_to_sub_account.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/wallet_rest/sub_account_to_sub_account.rs
@@ -1,0 +1,9 @@
+use serde::Deserialize;
+
+use crate::arch::market_assets::api_general::de_string_from_any;
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct RestSubAccountToSubAccountTransferGate {
+    #[serde(default, deserialize_with = "de_string_from_any")]
+    pub tx_id: String,
+}

--- a/src/arch/market_assets/exchange/gate/schemas/wallet_rest/sub_account_transfer.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/wallet_rest/sub_account_transfer.rs
@@ -1,0 +1,33 @@
+use serde::Deserialize;
+
+use crate::arch::market_assets::api_general::{de_micros_from_int, de_string_from_any};
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct RestSubAccountTransferGate {
+    #[serde(default, deserialize_with = "de_string_from_any")]
+    pub tx_id: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct RestSubAccountTransferHistoryGate {
+    #[serde(default, deserialize_with = "de_micros_from_int")]
+    pub timest: u64,
+    #[serde(default, deserialize_with = "de_string_from_any")]
+    pub uid: String,
+    #[serde(default, deserialize_with = "de_string_from_any")]
+    pub sub_account: String,
+    #[serde(default)]
+    pub sub_account_type: String,
+    #[serde(default)]
+    pub currency: String,
+    #[serde(default)]
+    pub amount: String,
+    #[serde(default)]
+    pub direction: String,
+    #[serde(default)]
+    pub source: String,
+    #[serde(default, deserialize_with = "de_string_from_any")]
+    pub client_order_id: String,
+    #[serde(default)]
+    pub status: String,
+}

--- a/src/arch/market_assets/exchange/gate/schemas/wallet_rest/transfer_order_status.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/wallet_rest/transfer_order_status.rs
@@ -1,0 +1,11 @@
+use serde::Deserialize;
+
+use crate::arch::market_assets::api_general::de_string_from_any;
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct RestTransferOrderStatusGate {
+    #[serde(default, deserialize_with = "de_string_from_any")]
+    pub tx_id: String,
+    #[serde(default)]
+    pub status: String,
+}


### PR DESCRIPTION
## Summary
- add Binance sub-account universal transfer and history REST support
- add Gate main/sub, sub/sub transfer, and transfer status REST support
- add Binance request validation for official sub-account transfer constraints and endpoint-specific Gate account type enums

## Verification
- cargo fmt
- git diff --check
- cargo test --all-features