### PR TITLE
chore: make model and data dependencies optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,9 +50,9 @@ data-encoding = "2.11.0"
 rustls = { version = "0.23.40", features = ["aws-lc-rs"] }
 
 # IPC / Model inference / Data processing
-zeromq = "0.6.0"
-tract-onnx = "0.22.1"
-polars = { version = "0.53.0", default-features = false }
+zeromq = { version = "0.6.0", optional = true }
+tract-onnx = { version = "0.23.0", optional = true }
+polars = { version = "0.53.0", default-features = false, optional = true }
 
 # Logging & Tracing
 tracing = "0.1.44"
@@ -71,6 +71,8 @@ all = [
     "gate",
     "okx",
     "lob_clients",
+    "model_runner",
+    "polars",
 ]
 
 lob_clients = [
@@ -85,6 +87,11 @@ binance = []
 gate = []
 okx = []
 
+model_onnx = ["dep:tract-onnx"]
+model_zmq = ["dep:zeromq"]
+model_runner = ["model_onnx", "model_zmq"]
+polars = ["dep:polars"]
+
 [package.metadata.docs.rs]
 all-features = true
 
@@ -97,7 +104,7 @@ required-features = ["hyperliquid"]
 
 [[example]]
 name = "complex_strategy_example"
-required-features = ["okx"]
+required-features = ["okx", "model_zmq"]
 
 [[example]]
 name = "multi_strategy_example"

--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@ With **HList**:
 
 ## Traditional vs HList Approach
 
-| Aspect | Traditional `Vec<Box<dyn Trait>>` | HList-based Extrema Infra |
-| --- | --- | --- |
-| **Dispatch** | Dynamic (runtime `vtable`) | Static (compile-time inlined) |
-| **Type Safety** | Runtime only | Compile-time enforced |
-| **Performance** | Extra indirection, heap alloc | Zero overhead, no heap alloc |
-| **Compile-time Checking** | Limited | Full (trait bounds enforced) |
+| Aspect                    | Traditional `Vec<Box<dyn Trait>>` | HList-based Extrema Infra     |
+|---------------------------|-----------------------------------|-------------------------------|
+| **Dispatch**              | Dynamic (runtime `vtable`)        | Static (compile-time inlined) |
+| **Type Safety**           | Runtime only                      | Compile-time enforced         |
+| **Performance**           | Extra indirection, heap alloc     | Zero overhead, no heap alloc  |
+| **Compile-time Checking** | Limited                           | Full (trait bounds enforced)  |
 
 ---
 
@@ -121,6 +121,7 @@ A minimal strategy must implement at least `Strategy` + `CommandEmitter` + `Even
 ## ONNX Model Runner
 
 `extrema_infra` supports local ONNX inference through `AltTaskType::ModelPreds(ModelRunner::Onnx(...))`.
+Enable the `model_onnx` feature, or `model_runner` / `all`, to make this backend available.
 
 - The ONNX model is loaded once during task initialization.
 - Inference requests are routed through a dedicated worker thread owned by the ONNX task.
@@ -334,7 +335,7 @@ For a practical implementation, see the [complex strategy example](examples/comp
 - **Supporting tasks**
   - Order execution, feature generation, Risk checks, Position management etc.
   - These tasks communicate with the latency-sensitive task via channels (**CommandEmitter** → **OrderExecute**) or Rwlock.
-  - Using **AltTask** for feature extraction, sending data to Torch prediction via command handle, then generating signals to execute orders.
+  - Using **AltTask** for feature extraction, sending data to a ZMQ or ONNX model runner via command handle, then generating signals to execute orders.
 
 Latency-sensitive logic can be decomposed into multiple tasks.
 where each task handles only a subset of instruments for maximum efficiency.

--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,7 @@ allow = [
     "Zlib",
 ]
 exceptions = [
+    { allow = ["MPL-2.0"], crate = "dyn-eq" },
     { allow = ["CDLA-Permissive-2.0"], crate = "webpki-root-certs" },
     { allow = ["CDLA-Permissive-2.0"], crate = "webpki-roots" },
 ]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -97,15 +97,19 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 ```
 
-Exchange clients and websocket routing are feature-gated. Enable only the
-markets used by the binary:
+Exchange clients and websocket routing are controlled by Cargo features. Enable
+only the markets used by the binary:
 
 ```toml
 extrema_infra = { path = "../extrema_infra", features = ["binance", "okx"] }
 ```
 
 Use `features = ["lob_clients"]` for the `LobClients` aggregate helper.
-Use `features = ["all"]` for every exchange module and `LobClients`.
+Use `features = ["model_zmq"]` or `features = ["model_onnx"]` for model
+prediction task variants; `features = ["model_runner"]` enables both. Use
+`features = ["polars"]` only when downstream code needs the Polars error
+conversion. Use `features = ["all"]` for every exchange module, `LobClients`,
+both model runners, and Polars support.
 
 ## Strategy Module Checklist
 
@@ -197,7 +201,9 @@ Common `AltTaskType` values:
   `on_inst_intent`.
 - `OrderExecution`: order batches delivered to `on_order_execution`.
 - `ModelPreds(ModelRunner::Zmq(..))`: external model process integration.
-- `ModelPreds(ModelRunner::Onnx(..))`: in-process ONNX inference.
+  Enable `model_zmq`, `model_runner`, or `all`, to make this variant available.
+- `ModelPreds(ModelRunner::Onnx(..))`: in-process ONNX inference. Enable
+  `model_onnx`, `model_runner`, or `all`, to make this variant available.
 
 Each alt task needs its matching channel and callback: scheduler tasks use
 `BoardCastChannel::default_scheduler()` and `on_schedule`, intent tasks use

--- a/examples/complex_strategy_example.rs
+++ b/examples/complex_strategy_example.rs
@@ -8,7 +8,7 @@
 //! Run it with:
 //!
 //! ```text
-//! cargo run --example complex_strategy_example --features okx
+//! cargo run --example complex_strategy_example --features okx,model_zmq
 //! ```
 
 use std::{collections::HashMap, sync::Arc};

--- a/src/arch/strategy_base/command/command_core.rs
+++ b/src/arch/strategy_base/command/command_core.rs
@@ -16,8 +16,8 @@ use crate::errors::{InfraError, InfraResult};
 /// commands are routed by `(WsChannel, task_id)`. The market is part of the
 /// task descriptor, but it is not part of the command key, so task ids must be
 /// unique when several tasks share the same task type or websocket channel.
-/// For `AltTaskType::ModelPreds`, the `ModelRunner` value is also part of the
-/// key.
+/// When a model-runner feature is enabled, `AltTaskType::ModelPreds` includes
+/// its `ModelRunner` backend value in the key.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum CommandKey {
     /// Command key for a non-websocket task.
@@ -266,8 +266,8 @@ pub enum TaskCommand {
     /// Sends model features to a prediction task.
     ///
     /// The receiving model task runs inference through the configured backend
-    /// (`ModelRunner::Zmq` or `ModelRunner::Onnx`) and later emits predictions
-    /// through `EventHandler::on_preds`.
+    /// and later emits predictions through `EventHandler::on_preds`. Model
+    /// runner variants are available through their matching crate features.
     FeatInput(AltTensor),
 }
 

--- a/src/arch/task_execution/register_alt.rs
+++ b/src/arch/task_execution/register_alt.rs
@@ -1,4 +1,7 @@
+#[cfg(feature = "model_onnx")]
 mod model_onnx;
+
+#[cfg(feature = "model_zmq")]
 mod model_zmq;
 
 use std::{sync::Arc, time::Duration};
@@ -10,8 +13,10 @@ use tokio::{
 
 use tracing::{error, info, warn};
 
+#[cfg(any(feature = "model_onnx", feature = "model_zmq"))]
+use super::task_alt::ModelRunner;
 use super::{
-    task_alt::{AltTaskInfo, AltTaskType, ModelRunner},
+    task_alt::{AltTaskInfo, AltTaskType},
     task_general::LogLevel,
 };
 use crate::arch::{
@@ -35,6 +40,7 @@ pub(crate) struct AltTaskBuilder {
 }
 
 impl AltTaskBuilder {
+    #[allow(dead_code)]
     async fn recv_feat_input(&mut self) -> Option<AltTensor> {
         loop {
             match self.cmd_rx.recv().await {
@@ -48,6 +54,7 @@ impl AltTaskBuilder {
         }
     }
 
+    #[allow(dead_code)]
     fn emit_model_preds(&self, tx: &broadcast::Sender<InfraMsg<AltTensor>>, tensor: AltTensor) {
         let _ = tx.send(InfraMsg {
             task_id: self.task_id,
@@ -147,6 +154,7 @@ impl AltTaskBuilder {
                     );
                 }
             },
+            #[cfg(feature = "model_zmq")]
             AltTaskType::ModelPreds(ModelRunner::Zmq(port)) => {
                 if let Some(tx) = find_model_preds(&self.board_cast_channel) {
                     self.model_preds_zmq(tx, port).await
@@ -157,6 +165,7 @@ impl AltTaskBuilder {
                     );
                 }
             },
+            #[cfg(feature = "model_onnx")]
             AltTaskType::ModelPreds(ModelRunner::Onnx(config_path)) => {
                 if let Some(tx) = find_model_preds(&self.board_cast_channel) {
                     self.model_preds_onnx(tx, config_path).await

--- a/src/arch/task_execution/register_alt/model_onnx.rs
+++ b/src/arch/task_execution/register_alt/model_onnx.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use std::{
     fs,
     path::{Path, PathBuf},
-    sync::mpsc,
+    sync::{Arc, mpsc},
     time::Duration,
 };
 use tokio::{
@@ -11,7 +11,7 @@ use tokio::{
     time::timeout,
 };
 use tract_onnx::prelude::{
-    Framework, InferenceModelExt, IntoTensor, TValue, TypedModel, TypedRunnableModel,
+    Framework, InferenceModelExt, IntoRunnable, IntoTensor, TValue, TypedRunnableModel,
     tract_ndarray::{ArrayD, IxDyn},
     tvec,
 };
@@ -75,7 +75,7 @@ impl OnnxRunnerConfig {
 #[derive(Debug)]
 struct OnnxModelRunner {
     config: OnnxRunnerConfig,
-    model: TypedRunnableModel<TypedModel>,
+    model: Arc<TypedRunnableModel>,
 }
 
 impl OnnxModelRunner {
@@ -189,7 +189,8 @@ fn select_default_output_index(outputs: &[TValue]) -> Option<usize> {
     outputs
         .iter()
         .position(|output| {
-            output.to_array_view::<f32>().is_ok() || output.to_array_view::<f64>().is_ok()
+            output.to_plain_array_view::<f32>().is_ok()
+                || output.to_plain_array_view::<f64>().is_ok()
         })
         .or_else(|| {
             outputs
@@ -199,73 +200,73 @@ fn select_default_output_index(outputs: &[TValue]) -> Option<usize> {
 }
 
 fn decode_output_to_f32(output: &TValue) -> InfraResult<(Vec<f32>, Vec<usize>, &'static str)> {
-    if let Ok(view) = output.to_array_view::<f32>() {
+    if let Ok(view) = output.to_plain_array_view::<f32>() {
         return Ok((view.iter().copied().collect(), view.shape().to_vec(), "f32"));
     }
-    if let Ok(view) = output.to_array_view::<f64>() {
+    if let Ok(view) = output.to_plain_array_view::<f64>() {
         return Ok((
             view.iter().map(|&value| value as f32).collect(),
             view.shape().to_vec(),
             "f64",
         ));
     }
-    if let Ok(view) = output.to_array_view::<i64>() {
+    if let Ok(view) = output.to_plain_array_view::<i64>() {
         return Ok((
             view.iter().map(|&value| value as f32).collect(),
             view.shape().to_vec(),
             "i64",
         ));
     }
-    if let Ok(view) = output.to_array_view::<i32>() {
+    if let Ok(view) = output.to_plain_array_view::<i32>() {
         return Ok((
             view.iter().map(|&value| value as f32).collect(),
             view.shape().to_vec(),
             "i32",
         ));
     }
-    if let Ok(view) = output.to_array_view::<i16>() {
+    if let Ok(view) = output.to_plain_array_view::<i16>() {
         return Ok((
             view.iter().map(|&value| value as f32).collect(),
             view.shape().to_vec(),
             "i16",
         ));
     }
-    if let Ok(view) = output.to_array_view::<i8>() {
+    if let Ok(view) = output.to_plain_array_view::<i8>() {
         return Ok((
             view.iter().map(|&value| value as f32).collect(),
             view.shape().to_vec(),
             "i8",
         ));
     }
-    if let Ok(view) = output.to_array_view::<u64>() {
+    if let Ok(view) = output.to_plain_array_view::<u64>() {
         return Ok((
             view.iter().map(|&value| value as f32).collect(),
             view.shape().to_vec(),
             "u64",
         ));
     }
-    if let Ok(view) = output.to_array_view::<u32>() {
+    if let Ok(view) = output.to_plain_array_view::<u32>() {
         return Ok((
             view.iter().map(|&value| value as f32).collect(),
             view.shape().to_vec(),
             "u32",
         ));
     }
-    if let Ok(view) = output.to_array_view::<u16>() {
+    if let Ok(view) = output.to_plain_array_view::<u16>() {
         return Ok((
             view.iter().map(|&value| value as f32).collect(),
             view.shape().to_vec(),
             "u16",
         ));
     }
-    if let Ok(view) = output.to_array_view::<u8>() {
+    if let Ok(view) = output.to_plain_array_view::<u8>() {
         return Ok((
             view.iter().map(|&value| value as f32).collect(),
             view.shape().to_vec(),
             "u8",
         ));
     }
-    if let Ok(view) = output.to_array_view::<bool>() {
+    if let Ok(view) = output.to_plain_array_view::<bool>() {
         return Ok((
             view.iter()
                 .map(|&value| if value { 1.0 } else { 0.0 })

--- a/src/arch/task_execution/task_alt.rs
+++ b/src/arch/task_execution/task_alt.rs
@@ -23,6 +23,7 @@ pub enum AltTaskType {
     /// Instrument, allocation, or portfolio intent task.
     InstIntent,
     /// Model prediction worker.
+    #[cfg(any(feature = "model_onnx", feature = "model_zmq"))]
     ModelPreds(ModelRunner),
     /// Periodic scheduler task.
     TimeScheduler(Duration),
@@ -32,7 +33,9 @@ pub enum AltTaskType {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum ModelRunner {
     /// External model worker reached over ZeroMQ.
+    #[cfg(feature = "model_zmq")]
     Zmq(u64),
     /// In-process ONNX model loaded from a path or JSON config.
+    #[cfg(feature = "model_onnx")]
     Onnx(String),
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,6 +25,7 @@ pub enum InfraError {
     #[error("JSON parse error (simd): {0}")]
     SimdJson(#[from] simd_json::Error),
 
+    #[cfg(feature = "polars")]
     #[error("Polars error: {0}")]
     Polars(#[from] polars::error::PolarsError),
 


### PR DESCRIPTION
## Summary
- make Polars, ZeroMQ, and ONNX dependencies optional behind explicit Cargo features
- expose model prediction task variants only when their model features are enabled
- update ONNX runner compatibility for tract-onnx 0.23.0
- refresh README, usage docs, and complex strategy example feature instructions

## Verification
- cargo check --no-default-features
- cargo check --no-default-features --features model_zmq
- cargo check --no-default-features --features model_onnx
- cargo check --no-default-features --features polars
- cargo check --no-default-features --features all
- cargo check --examples --all-features
- cargo test --all-features
- cargo package --allow-dirty