### PR TITLE
fix(gate): handle futures delisting and delivery expiry states

### DIFF
--- a/src/arch/market_assets/api_general.rs
+++ b/src/arch/market_assets/api_general.rs
@@ -183,6 +183,37 @@ where
     }
 }
 
+pub fn de_opt_u64_from_string_or_number<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Value::deserialize(deserializer)?;
+    match value {
+        Value::Null => Ok(None),
+        Value::Number(n) => {
+            if let Some(u) = n.as_u64() {
+                Ok((u > 0).then_some(u))
+            } else if let Some(f) = n.as_f64() {
+                let value = f as u64;
+                Ok((value > 0).then_some(value))
+            } else {
+                Err(de::Error::custom("invalid optional u64 number"))
+            }
+        },
+        Value::String(s) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() || trimmed == "0" {
+                return Ok(None);
+            }
+            trimmed.parse::<u64>().map(Some).map_err(de::Error::custom)
+        },
+        other => Err(de::Error::custom(format!(
+            "invalid optional u64 type: {:?}",
+            other
+        ))),
+    }
+}
+
 pub fn de_micros_from_int<'de, D>(deserializer: D) -> Result<u64, D::Error>
 where
     D: Deserializer<'de>,

--- a/src/arch/market_assets/exchange/gate/gate_delivery_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_delivery_cli.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use crate::arch::{
     market_assets::{
         api_data::utils_data::InstrumentInfo,
-        api_general::parse_json_response,
-        base_data::{InstrumentType, TRADING_LOWER},
+        api_general::{get_seconds_timestamp, parse_json_response},
+        base_data::InstrumentType,
     },
     traits::{
         conversion::IntoInfraVec,
@@ -132,18 +132,14 @@ impl GateDeliveryCli {
             ));
         }
 
+        let now_secs = get_seconds_timestamp();
+
         for settle in ["usdt", "btc"] {
             let contracts = self._get_delivery_contracts(settle, None, None).await?;
             data.extend(
                 contracts
                     .into_iter()
-                    .filter(|c| {
-                        if !c.status.is_empty() {
-                            c.status.as_str() == TRADING_LOWER
-                        } else {
-                            !c.in_delisting
-                        }
-                    })
+                    .filter(|c| c.is_live(now_secs))
                     .map(|c| gate_fut_inst_to_cli(&c.name)),
             );
         }

--- a/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
@@ -13,9 +13,7 @@ use crate::arch::{
         api_general::{
             OrderParams, RequestMethod, get_seconds_timestamp, parse_json_response, value_to_f64,
         },
-        base_data::{
-            InstrumentType, MarginMode, OrderSide, OrderType, SUBSCRIBE_LOWER, TRADING_LOWER,
-        },
+        base_data::{InstrumentType, MarginMode, OrderSide, OrderType, SUBSCRIBE_LOWER},
     },
     task_execution::task_ws::{CandleParam, WsChannel},
     traits::{
@@ -417,12 +415,14 @@ impl GateFuturesCli {
     async fn _get_live_instruments(&self, _inst_type: InstrumentType) -> InfraResult<Vec<String>> {
         let mut data: Vec<String> = Vec::new();
 
+        let now_secs = get_seconds_timestamp();
+
         for settle in ["usdt", "btc"] {
             let contracts = self._get_futures_contracts(settle, None, None).await?;
             data.extend(
                 contracts
                     .into_iter()
-                    .filter(|c| c.status.as_str() == TRADING_LOWER)
+                    .filter(|c| c.is_live(now_secs))
                     .map(|c| gate_fut_inst_to_cli(&c.name)),
             );
         }

--- a/src/arch/market_assets/exchange/gate/schemas/delivery_rest/contract_delivery.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/delivery_rest/contract_delivery.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 
 use crate::arch::market_assets::{
     api_data::utils_data::InstrumentInfo,
-    api_general::de_string_from_any,
+    api_general::{de_opt_u64_from_string_or_number, de_string_from_any, get_seconds_timestamp},
     base_data::{InstrumentStatus, InstrumentType},
     exchange::gate::api_utils::gate_fut_inst_to_cli,
 };
@@ -22,6 +22,38 @@ pub struct RestContractGateDelivery {
     #[serde(default, deserialize_with = "de_string_from_any")]
     pub status: String,
     pub in_delisting: bool,
+    #[serde(default, deserialize_with = "de_opt_u64_from_string_or_number")]
+    pub expire_time: Option<u64>,
+}
+
+impl RestContractGateDelivery {
+    pub fn instrument_status(&self, now_secs: u64) -> InstrumentStatus {
+        match self.status.as_str() {
+            "delisted" => return InstrumentStatus::Closed,
+            "delisting" => return InstrumentStatus::Delisting,
+            _ => {},
+        }
+
+        if self
+            .expire_time
+            .is_some_and(|expire_time| expire_time > 0 && now_secs >= expire_time)
+        {
+            return InstrumentStatus::Closed;
+        }
+
+        if self.in_delisting {
+            return InstrumentStatus::Delisting;
+        }
+
+        match self.status.as_str() {
+            "" | "trading" => InstrumentStatus::Live,
+            _ => InstrumentStatus::Unknown,
+        }
+    }
+
+    pub fn is_live(&self, now_secs: u64) -> bool {
+        self.instrument_status(now_secs) == InstrumentStatus::Live
+    }
 }
 
 impl From<RestContractGateDelivery> for InstrumentInfo {
@@ -29,18 +61,7 @@ impl From<RestContractGateDelivery> for InstrumentInfo {
         let lot_size = d.order_size_min.parse().unwrap_or_default();
         let max_size = d.order_size_max.parse().unwrap_or_default();
         let tick_size = d.order_price_round.parse().unwrap_or_default();
-        let state = if !d.status.is_empty() {
-            match d.status.as_str() {
-                "trading" => InstrumentStatus::Live,
-                "delisting" => InstrumentStatus::Delisting,
-                "delisted" => InstrumentStatus::Closed,
-                _ => InstrumentStatus::Unknown,
-            }
-        } else if d.in_delisting {
-            InstrumentStatus::Delisting
-        } else {
-            InstrumentStatus::Live
-        };
+        let state = d.instrument_status(get_seconds_timestamp());
 
         InstrumentInfo {
             inst: gate_fut_inst_to_cli(&d.name),
@@ -57,5 +78,54 @@ impl From<RestContractGateDelivery> for InstrumentInfo {
             contract_multiplier: None,
             state,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn contract(status: &str) -> RestContractGateDelivery {
+        RestContractGateDelivery {
+            name: "LTC_USDT_20260605".to_string(),
+            order_price_round: "0.0001".to_string(),
+            order_size_min: "1".to_string(),
+            order_size_max: "100000".to_string(),
+            quanto_multiplier: "1".to_string(),
+            status: status.to_string(),
+            in_delisting: false,
+            expire_time: None,
+        }
+    }
+
+    #[test]
+    fn delivery_contract_before_expire_time_stays_live() {
+        let mut c = contract("");
+        c.expire_time = Some(1_780_646_400);
+
+        assert_eq!(c.instrument_status(1_780_481_685), InstrumentStatus::Live);
+        assert!(c.is_live(1_780_481_685));
+    }
+
+    #[test]
+    fn delivery_contract_after_expire_time_marks_closed() {
+        let mut c = contract("");
+        c.expire_time = Some(1_780_646_400);
+
+        assert_eq!(c.instrument_status(1_780_646_400), InstrumentStatus::Closed);
+        assert!(!c.is_live(1_780_646_400));
+    }
+
+    #[test]
+    fn delivery_contract_in_delisting_marks_delisting() {
+        let mut c = contract("");
+        c.in_delisting = true;
+        c.expire_time = Some(1_780_646_400);
+
+        assert_eq!(
+            c.instrument_status(1_780_481_685),
+            InstrumentStatus::Delisting
+        );
+        assert!(!c.is_live(1_780_481_685));
     }
 }

--- a/src/arch/market_assets/exchange/gate/schemas/futures_rest/contract_futures.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/futures_rest/contract_futures.rs
@@ -3,7 +3,8 @@ use serde::Deserialize;
 use crate::arch::market_assets::{
     api_data::utils_data::{FundingRateData, FundingRateInfo, InstrumentInfo},
     api_general::{
-        de_string_from_any, de_u64_from_string_or_number, get_micros_timestamp, ts_to_micros,
+        de_opt_u64_from_string_or_number, de_string_from_any, de_u64_from_string_or_number,
+        get_micros_timestamp, get_seconds_timestamp, ts_to_micros,
     },
     base_data::{InstrumentStatus, InstrumentType},
     exchange::gate::api_utils::gate_fut_inst_to_cli,
@@ -25,6 +26,10 @@ pub struct RestContractGateFutures {
     pub status: String,
     #[serde(default)]
     pub in_delisting: bool,
+    #[serde(default, deserialize_with = "de_opt_u64_from_string_or_number")]
+    pub delisting_time: Option<u64>,
+    #[serde(default, deserialize_with = "de_opt_u64_from_string_or_number")]
+    pub delisted_time: Option<u64>,
     #[serde(deserialize_with = "de_string_from_any")]
     pub funding_rate: String,
     #[serde(deserialize_with = "de_u64_from_string_or_number")]
@@ -33,21 +38,46 @@ pub struct RestContractGateFutures {
     pub funding_next_apply: u64,
 }
 
+impl RestContractGateFutures {
+    pub fn instrument_status(&self, now_secs: u64) -> InstrumentStatus {
+        match self.status.as_str() {
+            "delisted" => return InstrumentStatus::Closed,
+            "delisting" => return InstrumentStatus::Delisting,
+            _ => {},
+        }
+
+        if self
+            .delisted_time
+            .is_some_and(|delisted_time| delisted_time > 0 && now_secs >= delisted_time)
+        {
+            return InstrumentStatus::Closed;
+        }
+
+        if self.in_delisting
+            || self
+                .delisting_time
+                .is_some_and(|delisting_time| delisting_time > 0)
+        {
+            return InstrumentStatus::Delisting;
+        }
+
+        match self.status.as_str() {
+            "trading" => InstrumentStatus::Live,
+            _ => InstrumentStatus::Unknown,
+        }
+    }
+
+    pub fn is_live(&self, now_secs: u64) -> bool {
+        self.instrument_status(now_secs) == InstrumentStatus::Live
+    }
+}
+
 impl From<RestContractGateFutures> for InstrumentInfo {
     fn from(d: RestContractGateFutures) -> Self {
         let lot_size = d.order_size_min.parse().unwrap_or_default();
         let max_size = d.order_size_max.parse().unwrap_or_default();
         let tick_size = d.order_price_round.parse().unwrap_or_default();
-        let state = if d.in_delisting {
-            InstrumentStatus::Delisting
-        } else {
-            match d.status.as_str() {
-                "trading" => InstrumentStatus::Live,
-                "delisting" => InstrumentStatus::Delisting,
-                "delisted" => InstrumentStatus::Closed,
-                _ => InstrumentStatus::Unknown,
-            }
-        };
+        let state = d.instrument_status(get_seconds_timestamp());
 
         InstrumentInfo {
             inst: gate_fut_inst_to_cli(&d.name),
@@ -85,5 +115,57 @@ impl From<RestContractGateFutures> for FundingRateInfo {
             inst: gate_fut_inst_to_cli(&d.name),
             funding_interval_sec: d.funding_interval as f64,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn contract(status: &str) -> RestContractGateFutures {
+        RestContractGateFutures {
+            name: "DEGO_USDT".to_string(),
+            order_price_round: "0.0001".to_string(),
+            order_size_min: "1".to_string(),
+            order_size_max: "680000".to_string(),
+            quanto_multiplier: "0.1".to_string(),
+            status: status.to_string(),
+            in_delisting: false,
+            delisting_time: None,
+            delisted_time: None,
+            funding_rate: "0".to_string(),
+            funding_interval: 28_800,
+            funding_next_apply: 0,
+        }
+    }
+
+    #[test]
+    fn scheduled_delisting_time_marks_contract_as_delisting() {
+        let mut c = contract("trading");
+        c.delisting_time = Some(1_780_644_600);
+        c.delisted_time = Some(1_780_646_400);
+
+        assert_eq!(
+            c.instrument_status(1_780_481_685),
+            InstrumentStatus::Delisting
+        );
+        assert!(!c.is_live(1_780_481_685));
+    }
+
+    #[test]
+    fn delisted_time_after_now_marks_contract_as_closed() {
+        let mut c = contract("trading");
+        c.delisting_time = Some(1_780_644_600);
+        c.delisted_time = Some(1_780_646_400);
+
+        assert_eq!(c.instrument_status(1_780_646_400), InstrumentStatus::Closed);
+    }
+
+    #[test]
+    fn trading_without_delisting_time_stays_live() {
+        let c = contract("trading");
+
+        assert_eq!(c.instrument_status(1_780_481_685), InstrumentStatus::Live);
+        assert!(c.is_live(1_780_481_685));
     }
 }


### PR DESCRIPTION
## Summary
- Parse Gate futures delisting_time/delisted_time and map scheduled delists to Delisting/Closed states
- Route Gate futures live-instrument filtering through the normalized instrument status
- Parse Gate delivery expire_time and mark expired contracts Closed while keeping unexpired delivery contracts Live
- Share optional string-or-number u64 deserialization for Gate timestamp fields

## Validation
- Confirmed Gate futures DEGO_USDT/RDNT_USDT URLs return status=trading, in_delisting=false, and future delisting_time/delisted_time
- Confirmed Gate delivery LTC_USDT_20260605 URL returns expire_time with status=null and in_delisting=false
- cargo test --features lob_clients time
- cargo test --features lob_clients delivery_contract