### PR TITLE
chore: bump version to 0.1.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 
 readme = "README.md"


### PR DESCRIPTION
Summary:
- Bump crate version from 0.1.10 to 0.1.11

Verification:
- cargo metadata --no-deps --format-version 1
- git diff --check