### PR TITLE
feat: add LOB MBO channel and broadcast capacity controls

### DIFF
--- a/examples/multi_strategy_example.rs
+++ b/examples/multi_strategy_example.rs
@@ -174,8 +174,8 @@ async fn main() {
     let env = EnvBuilder::new()
         .with_board_cast_channel(BoardCastChannel::default_alt_event())
         .with_board_cast_channel(BoardCastChannel::default_ws_event())
-        .with_board_cast_channel(BoardCastChannel::default_candle())
-        .with_board_cast_channel(BoardCastChannel::default_candle()) // duplicated skip (can be removed)
+        // Use *_with_capacity when a stream needs a larger broadcast buffer.
+        .with_board_cast_channel(BoardCastChannel::candle_with_capacity(4_096))
         .with_board_cast_channel(BoardCastChannel::default_scheduler())
         .with_task(TaskInfo::WsTask(Arc::new(binance_ws_candle)))
         .with_task(TaskInfo::AltTask(Arc::new(alt_task)))

--- a/src/arch/strategy_base/handler/event_mask.rs
+++ b/src/arch/strategy_base/handler/event_mask.rs
@@ -35,9 +35,10 @@ impl EventMask {
     pub const ACC_BAL_POS: Self = Self(1 << 10);
     /// Private position-only updates.
     pub const ACC_POS: Self = Self(1 << 11);
-
+    /// Public market-by-order order book updates.
+    pub const LOB_MBO: Self = Self(1 << 12);
     /// Subscribe to every runtime event stream.
-    pub const ALL: Self = Self((1 << 12) - 1);
+    pub const ALL: Self = Self((1 << 13) - 1);
 
     /// Returns [`EventMask::NONE`].
     pub const fn none() -> Self {
@@ -75,11 +76,13 @@ mod tests {
 
     #[test]
     fn contains_combined_event_bits() {
-        let mask = EventMask::TRADE | EventMask::ACC_BAL_POS | EventMask::MODEL_PREDS;
+        let mask =
+            EventMask::TRADE | EventMask::ACC_BAL_POS | EventMask::MODEL_PREDS | EventMask::LOB_MBO;
 
         assert!(mask.contains(EventMask::TRADE));
         assert!(mask.contains(EventMask::ACC_BAL_POS));
         assert!(mask.contains(EventMask::MODEL_PREDS));
+        assert!(mask.contains(EventMask::LOB_MBO));
         assert!(!mask.contains(EventMask::CANDLE));
     }
 

--- a/src/arch/strategy_base/handler/handler_core.rs
+++ b/src/arch/strategy_base/handler/handler_core.rs
@@ -9,6 +9,33 @@ use crate::arch::{
     traits::strategy::Strategy,
 };
 
+/// Default generic alt-task channel capacity, measured in messages.
+pub const ALT_EVENT_CHANNEL_CAPACITY: usize = 2_048;
+/// Default generic websocket-task channel capacity, measured in messages.
+pub const WS_EVENT_CHANNEL_CAPACITY: usize = 2_048;
+/// Default order execution channel capacity, measured in messages.
+pub const ORDER_EXECUTION_CHANNEL_CAPACITY: usize = 8_192;
+/// Default instrument intent channel capacity, measured in messages.
+pub const INST_INTENT_CHANNEL_CAPACITY: usize = 2_048;
+/// Default model prediction channel capacity, measured in messages.
+pub const MODEL_PREDS_CHANNEL_CAPACITY: usize = 8_192;
+/// Default scheduler channel capacity, measured in messages.
+pub const SCHEDULE_CHANNEL_CAPACITY: usize = 1_024;
+/// Default public trade channel capacity, measured in messages.
+pub const TRADE_CHANNEL_CAPACITY: usize = 8_192;
+/// Default public order book channel capacity, measured in messages.
+pub const LOB_CHANNEL_CAPACITY: usize = 16_384;
+/// Default public market-by-order order book channel capacity, measured in messages.
+pub const LOB_MBO_CHANNEL_CAPACITY: usize = 65_536;
+/// Default public candle channel capacity, measured in messages.
+pub const CANDLE_CHANNEL_CAPACITY: usize = 2_048;
+/// Default private account order channel capacity, measured in messages.
+pub const ACC_ORDER_CHANNEL_CAPACITY: usize = 8_192;
+/// Default private balance/position channel capacity, measured in messages.
+pub const ACC_BAL_POS_CHANNEL_CAPACITY: usize = 8_192;
+/// Default private account position channel capacity, measured in messages.
+pub const ACC_POS_CHANNEL_CAPACITY: usize = 8_192;
+
 /// Message envelope published through runtime broadcast channels.
 ///
 /// `task_id` identifies the task instance that produced the event. `data` is
@@ -50,6 +77,8 @@ pub enum BoardCastChannel {
     Trade(broadcast::Sender<InfraMsg<Vec<WsTrade>>>),
     /// Public order book updates.
     Lob(broadcast::Sender<InfraMsg<Vec<WsLob>>>),
+    /// Public market-by-order order book updates.
+    LobMbo(broadcast::Sender<InfraMsg<Vec<WsLobMbo>>>),
     /// Public candle batches.
     Candle(broadcast::Sender<InfraMsg<Vec<WsCandle>>>),
     /// Private account order updates.
@@ -63,62 +92,132 @@ pub enum BoardCastChannel {
 impl BoardCastChannel {
     /// Creates the default generic alt-task event channel.
     pub fn default_alt_event() -> Self {
-        BoardCastChannel::Alt(broadcast::channel(2048).0)
+        Self::alt_event_with_capacity(ALT_EVENT_CHANNEL_CAPACITY)
+    }
+
+    /// Creates a generic alt-task event channel with a custom capacity.
+    pub fn alt_event_with_capacity(capacity: usize) -> Self {
+        BoardCastChannel::Alt(broadcast::channel(capacity).0)
     }
 
     /// Creates the default generic websocket-task event channel.
     pub fn default_ws_event() -> Self {
-        BoardCastChannel::Ws(broadcast::channel(2048).0)
+        Self::ws_event_with_capacity(WS_EVENT_CHANNEL_CAPACITY)
+    }
+
+    /// Creates a generic websocket-task event channel with a custom capacity.
+    pub fn ws_event_with_capacity(capacity: usize) -> Self {
+        BoardCastChannel::Ws(broadcast::channel(capacity).0)
     }
 
     /// Creates the default order execution channel.
     pub fn default_order_execution() -> Self {
-        BoardCastChannel::OrderExecute(broadcast::channel(2048).0)
+        Self::order_execution_with_capacity(ORDER_EXECUTION_CHANNEL_CAPACITY)
+    }
+
+    /// Creates an order execution channel with a custom capacity.
+    pub fn order_execution_with_capacity(capacity: usize) -> Self {
+        BoardCastChannel::OrderExecute(broadcast::channel(capacity).0)
     }
 
     /// Creates the default instrument intent channel.
     pub fn default_inst_intent() -> Self {
-        BoardCastChannel::InstIntent(broadcast::channel(2048).0)
+        Self::inst_intent_with_capacity(INST_INTENT_CHANNEL_CAPACITY)
+    }
+
+    /// Creates an instrument intent channel with a custom capacity.
+    pub fn inst_intent_with_capacity(capacity: usize) -> Self {
+        BoardCastChannel::InstIntent(broadcast::channel(capacity).0)
     }
 
     /// Creates the default model prediction channel.
     pub fn default_model_preds() -> Self {
-        BoardCastChannel::ModelPreds(broadcast::channel(2048).0)
+        Self::model_preds_with_capacity(MODEL_PREDS_CHANNEL_CAPACITY)
+    }
+
+    /// Creates a model prediction channel with a custom capacity.
+    pub fn model_preds_with_capacity(capacity: usize) -> Self {
+        BoardCastChannel::ModelPreds(broadcast::channel(capacity).0)
     }
 
     /// Creates the default scheduler channel.
     pub fn default_scheduler() -> Self {
-        BoardCastChannel::Schedule(broadcast::channel(2048).0)
+        Self::scheduler_with_capacity(SCHEDULE_CHANNEL_CAPACITY)
+    }
+
+    /// Creates a scheduler channel with a custom capacity.
+    pub fn scheduler_with_capacity(capacity: usize) -> Self {
+        BoardCastChannel::Schedule(broadcast::channel(capacity).0)
     }
 
     /// Creates the default public trade channel.
     pub fn default_trade() -> Self {
-        BoardCastChannel::Trade(broadcast::channel(2048).0)
+        Self::trade_with_capacity(TRADE_CHANNEL_CAPACITY)
+    }
+
+    /// Creates a public trade channel with a custom capacity.
+    pub fn trade_with_capacity(capacity: usize) -> Self {
+        BoardCastChannel::Trade(broadcast::channel(capacity).0)
     }
 
     /// Creates the default public order book channel.
     pub fn default_lob() -> Self {
-        BoardCastChannel::Lob(broadcast::channel(2048).0)
+        Self::lob_with_capacity(LOB_CHANNEL_CAPACITY)
+    }
+
+    /// Creates a public order book channel with a custom capacity.
+    pub fn lob_with_capacity(capacity: usize) -> Self {
+        BoardCastChannel::Lob(broadcast::channel(capacity).0)
+    }
+
+    /// Creates the default public market-by-order order book channel.
+    pub fn default_lob_mbo() -> Self {
+        Self::lob_mbo_with_capacity(LOB_MBO_CHANNEL_CAPACITY)
+    }
+
+    /// Creates a public market-by-order order book channel with a custom capacity.
+    pub fn lob_mbo_with_capacity(capacity: usize) -> Self {
+        BoardCastChannel::LobMbo(broadcast::channel(capacity).0)
     }
 
     /// Creates the default public candle channel.
     pub fn default_candle() -> Self {
-        BoardCastChannel::Candle(broadcast::channel(2048).0)
+        Self::candle_with_capacity(CANDLE_CHANNEL_CAPACITY)
+    }
+
+    /// Creates a public candle channel with a custom capacity.
+    pub fn candle_with_capacity(capacity: usize) -> Self {
+        BoardCastChannel::Candle(broadcast::channel(capacity).0)
     }
 
     /// Creates the default private account order channel.
     pub fn default_account_order() -> Self {
-        BoardCastChannel::AccOrder(broadcast::channel(2048).0)
+        Self::account_order_with_capacity(ACC_ORDER_CHANNEL_CAPACITY)
+    }
+
+    /// Creates a private account order channel with a custom capacity.
+    pub fn account_order_with_capacity(capacity: usize) -> Self {
+        BoardCastChannel::AccOrder(broadcast::channel(capacity).0)
     }
 
     /// Creates the default private balance/position channel.
     pub fn default_account_bal_pos() -> Self {
-        BoardCastChannel::AccBalPos(broadcast::channel(2048).0)
+        Self::account_bal_pos_with_capacity(ACC_BAL_POS_CHANNEL_CAPACITY)
+    }
+
+    /// Creates a private balance/position channel with a custom capacity.
+    pub fn account_bal_pos_with_capacity(capacity: usize) -> Self {
+        BoardCastChannel::AccBalPos(broadcast::channel(capacity).0)
     }
 
     /// Creates the default private account position channel.
     pub fn default_account_pos() -> Self {
-        BoardCastChannel::AccPos(broadcast::channel(2048).0)
+        Self::account_pos_with_capacity(ACC_POS_CHANNEL_CAPACITY)
+    }
+
+    /// Creates a private account position channel with a custom capacity.
+    pub fn account_pos_with_capacity(capacity: usize) -> Self {
+        BoardCastChannel::AccPos(broadcast::channel(capacity).0)
     }
 }
 
@@ -177,6 +276,7 @@ pub(crate) async fn strategy_handler_loop<S>(
     // Ws pub event
     let mut rx_trade = subscribe_if(event_mask, EventMask::TRADE, || find_trade(channels));
     let mut rx_lob = subscribe_if(event_mask, EventMask::LOB, || find_lob(channels));
+    let mut rx_lob_mbo = subscribe_if(event_mask, EventMask::LOB_MBO, || find_lob_mbo(channels));
     let mut rx_candle = subscribe_if(event_mask, EventMask::CANDLE, || find_candle(channels));
 
     // Ws pri event
@@ -208,6 +308,16 @@ pub(crate) async fn strategy_handler_loop<S>(
                     Err(e) => {
                         error!("rx_lob err: {:?}, reconnecting...", e);
                         rx_lob = subscribe_if(event_mask, EventMask::LOB, || find_lob(channels));
+                    },
+                };
+            },
+            msg = recv_or_pending(&mut rx_lob_mbo) => {
+                match msg {
+                    Ok(msg) => strategies.on_lob_mbo(msg).await,
+                    Err(e) => {
+                        error!("rx_lob_mbo err: {:?}, reconnecting...", e);
+                        rx_lob_mbo =
+                            subscribe_if(event_mask, EventMask::LOB_MBO, || find_lob_mbo(channels));
                     },
                 };
             },
@@ -413,6 +523,18 @@ pub(crate) fn find_lob(
 ) -> Option<broadcast::Sender<InfraMsg<Vec<WsLob>>>> {
     channels.iter().find_map(|ch| {
         if let BoardCastChannel::Lob(tx) = ch {
+            Some(tx.clone())
+        } else {
+            None
+        }
+    })
+}
+
+pub(crate) fn find_lob_mbo(
+    channels: &Arc<Vec<BoardCastChannel>>,
+) -> Option<broadcast::Sender<InfraMsg<Vec<WsLobMbo>>>> {
+    channels.iter().find_map(|ch| {
+        if let BoardCastChannel::LobMbo(tx) = ch {
             Some(tx.clone())
         } else {
             None

--- a/src/arch/strategy_base/handler/lob_events.rs
+++ b/src/arch/strategy_base/handler/lob_events.rs
@@ -19,8 +19,71 @@ pub struct WsLob {
     pub timestamp: u64,
     pub market: Market,
     pub inst: String,
-    pub bids: Vec<(f64, f64)>, // (price, size)
-    pub asks: Vec<(f64, f64)>, // (price, size)
+    pub event: LobEventKind,
+    pub bids: Vec<LobLevel>,
+    pub asks: Vec<LobLevel>,
+    pub seq: Option<LobSeq>,
+    pub checksum: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub enum LobEventKind {
+    Snapshot,
+    Delta,
+    Bbo,
+    Heartbeat,
+}
+
+#[derive(Clone, Debug)]
+pub struct LobLevel {
+    pub price: f64,
+    pub size: f64,
+    pub action: LobLevelAction,
+    pub order_count: Option<u64>,
+    pub level_update_id: Option<u64>,
+}
+
+#[derive(Clone, Debug)]
+pub enum LobLevelAction {
+    Upsert,
+    Delete,
+}
+
+#[derive(Clone, Debug)]
+pub struct LobSeq {
+    pub prev: Option<u64>,
+    pub first: Option<u64>,
+    pub last: Option<u64>,
+}
+
+/// Market-by-order Level Three websocket event.
+#[derive(Clone, Debug)]
+pub struct WsLobMbo {
+    pub timestamp: u64,
+    pub market: Market,
+    pub inst: String,
+    pub orders: Vec<MboUpdate>,
+    pub seq: Option<LobSeq>,
+    pub checksum: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct MboUpdate {
+    pub timestamp: u64,
+    pub price: f64,
+    pub size: f64,
+    pub side: OrderSide,
+    pub action: MboAction,
+    pub order_id: Option<String>,
+    pub priority: Option<u64>,
+    pub update_id: Option<u64>,
+}
+
+#[derive(Clone, Debug)]
+pub enum MboAction {
+    Add,
+    Modify,
+    Delete,
 }
 
 #[derive(Clone, Debug)]

--- a/src/arch/strategy_base/hlist_core.rs
+++ b/src/arch/strategy_base/hlist_core.rs
@@ -116,6 +116,12 @@ where
         tokio::join!(fut_head, fut_tail);
     }
 
+    async fn on_lob_mbo(&mut self, msg: InfraMsg<Vec<WsLobMbo>>) {
+        let fut_head = self.head.on_lob_mbo(msg.clone());
+        let fut_tail = self.tail.on_lob_mbo(msg);
+        tokio::join!(fut_head, fut_tail);
+    }
+
     async fn on_candle(&mut self, msg: InfraMsg<Vec<WsCandle>>) {
         let fut_head = self.head.on_candle(msg.clone());
         let fut_tail = self.tail.on_candle(msg);

--- a/src/arch/task_execution/task_ws.rs
+++ b/src/arch/task_execution/task_ws.rs
@@ -41,6 +41,8 @@ pub enum WsChannel {
     Tick,
     /// Public order book stream.
     Lob,
+    /// Public market-by-order order book stream.
+    LobMbo,
     /// Exchange-specific or custom stream.
     Other(String),
 }

--- a/src/arch/traits/strategy.rs
+++ b/src/arch/traits/strategy.rs
@@ -190,6 +190,7 @@ pub trait CommandEmitter: Clone + Send + Sync + 'static {
 /// | [`EventHandler::on_ws_event`] | websocket relay startup/control | `BoardCastChannel::default_ws_event()` | `EventMask::WS_EVENT` |
 /// | [`EventHandler::on_trade`] | public trade websocket relay | `BoardCastChannel::default_trade()` | `EventMask::TRADE` |
 /// | [`EventHandler::on_lob`] | public LOB websocket relay | `BoardCastChannel::default_lob()` | `EventMask::LOB` |
+/// | [`EventHandler::on_lob_mbo`] | public market-by-order websocket relay | `BoardCastChannel::default_lob_mbo()` | `EventMask::LOB_MBO` |
 /// | [`EventHandler::on_candle`] | public candle websocket relay | `BoardCastChannel::default_candle()` | `EventMask::CANDLE` |
 /// | [`EventHandler::on_acc_order`] | private account-order websocket relay | `BoardCastChannel::default_account_order()` | `EventMask::ACC_ORDER` |
 /// | [`EventHandler::on_acc_bal_pos`] | private balance/position websocket relay | `BoardCastChannel::default_account_bal_pos()` | `EventMask::ACC_BAL_POS` |
@@ -294,6 +295,14 @@ pub trait EventHandler {
     /// Emitted by exchange relays that implement [`WsChannel::Lob`] routing and
     /// publish into `BoardCastChannel::default_lob()`.
     fn on_lob(&mut self, _msg: InfraMsg<Vec<WsLob>>) -> impl Future<Output = ()> + Send {
+        ready(())
+    }
+
+    /// Receives normalized market-by-order order book updates.
+    ///
+    /// Emitted by exchange relays that implement [`WsChannel::LobMbo`] routing
+    /// and publish into `BoardCastChannel::default_lob_mbo()`.
+    fn on_lob_mbo(&mut self, _msg: InfraMsg<Vec<WsLobMbo>>) -> impl Future<Output = ()> + Send {
         ready(())
     }
 


### PR DESCRIPTION
## Summary
- expand normalized LOB events with event kind, level actions, sequence metadata, checksum, and MBO update types
- add a dedicated `WsChannel::LobMbo`, `BoardCastChannel::LobMbo`, `EventMask::LOB_MBO`, and `EventHandler::on_lob_mbo` path
- add per-channel default broadcast capacities plus `*_with_capacity` constructors for custom buffers
- update `multi_strategy_example` with a simple capacity configuration example

## Tests
- `cargo fmt --check`
- `cargo check --all-features`
- `cargo test`