### PR TITLE
feat: add Hyperliquid LOB websocket support

### DIFF
--- a/src/arch/market_assets/exchange/binance/binance_cm_futures_cli.rs
+++ b/src/arch/market_assets/exchange/binance/binance_cm_futures_cli.rs
@@ -298,7 +298,7 @@ impl BinanceCmCli {
             WsChannel::Candles(channel) => self._ws_subscribe_candle(channel, insts),
             WsChannel::Trades(_) => Err(InfraError::Unimplemented),
             WsChannel::Tick => Err(InfraError::Unimplemented),
-            WsChannel::Lob => Err(InfraError::Unimplemented),
+            WsChannel::Lob(_) => Err(InfraError::Unimplemented),
             _ => Err(InfraError::Unimplemented),
         }
     }
@@ -306,7 +306,7 @@ impl BinanceCmCli {
     fn _get_public_connect_msg(&self, channel: &WsChannel) -> InfraResult<String> {
         let url = match channel {
             WsChannel::Candles(_) | WsChannel::Trades(_) => BINANCE_CM_FUTURES_WS_MKT,
-            WsChannel::Tick | WsChannel::Lob => BINANCE_CM_FUTURES_WS_PUB,
+            WsChannel::Tick | WsChannel::Lob(_) => BINANCE_CM_FUTURES_WS_PUB,
             _ => return Err(InfraError::Unimplemented),
         };
 

--- a/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
+++ b/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
@@ -789,7 +789,7 @@ impl BinanceUmCli {
             WsChannel::Candles(channel) => self._ws_subscribe_candle(channel, insts),
             WsChannel::Trades(_) => self._ws_subscribe_aggtrade(insts),
             WsChannel::Tick => Err(InfraError::Unimplemented),
-            WsChannel::Lob => Err(InfraError::Unimplemented),
+            WsChannel::Lob(_) => Err(InfraError::Unimplemented),
             _ => Err(InfraError::Unimplemented),
         }
     }
@@ -797,7 +797,7 @@ impl BinanceUmCli {
     fn _get_public_connect_msg(&self, channel: &WsChannel) -> InfraResult<String> {
         let url = match channel {
             WsChannel::Candles(_) | WsChannel::Trades(_) => BINANCE_UM_FUTURES_WS_MKT,
-            WsChannel::Tick | WsChannel::Lob => BINANCE_UM_FUTURES_WS_PUB,
+            WsChannel::Tick | WsChannel::Lob(_) => BINANCE_UM_FUTURES_WS_PUB,
             _ => return Err(InfraError::Unimplemented),
         };
 

--- a/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
@@ -634,7 +634,7 @@ impl GateFuturesCli {
         match ws_channel {
             WsChannel::Candles(channel) => self._ws_subscribe_candle(channel, insts),
             WsChannel::Trades(_) => self._ws_subscribe_trades(insts),
-            WsChannel::Tick | WsChannel::Lob => Err(InfraError::Unimplemented),
+            WsChannel::Tick | WsChannel::Lob(_) => Err(InfraError::Unimplemented),
             _ => Err(InfraError::Unimplemented),
         }
     }

--- a/src/arch/market_assets/exchange/hyperliquid/api_utils.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/api_utils.rs
@@ -1,9 +1,12 @@
 use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 
-use crate::arch::market_assets::{
-    api_general::OrderParams,
-    base_data::{InstrumentType, OrderSide, OrderType, TimeInForce},
+use crate::arch::{
+    market_assets::{
+        api_general::OrderParams,
+        base_data::{InstrumentType, OrderSide, OrderType, TimeInForce},
+    },
+    task_execution::task_ws::{LobFrequency, LobParam},
 };
 use crate::errors::{InfraError, InfraResult};
 
@@ -63,6 +66,35 @@ pub fn hyperliquid_dex_from_scope_extra(extra: Option<&str>) -> Option<String> {
         .map(str::trim)
         .filter(|dex| !dex.is_empty())
         .map(ToString::to_string)
+}
+
+pub(crate) fn hyperliquid_lob_subscription_type(
+    lob_param: &Option<LobParam>,
+) -> InfraResult<&'static str> {
+    match lob_param {
+        None => Ok("l2Book"),
+        Some(LobParam::Bbo { frequency }) => match frequency {
+            None | Some(LobFrequency::Realtime) => Ok("bbo"),
+            Some(freq) => Err(InfraError::ApiCliError(format!(
+                "Hyperliquid bbo does not support requested frequency: {:?}",
+                freq
+            ))),
+        },
+        Some(LobParam::Snapshot { depth, frequency }) => {
+            if depth.is_none() && frequency.is_none() {
+                Ok("l2Book")
+            } else {
+                Err(InfraError::ApiCliError(format!(
+                    "Hyperliquid l2Book does not support depth/frequency: depth={:?}, frequency={:?}",
+                    depth, frequency
+                )))
+            }
+        },
+        Some(LobParam::Incremental { depth, frequency }) => Err(InfraError::ApiCliError(format!(
+            "Hyperliquid does not support incremental LOB updates: depth={:?}, frequency={:?}",
+            depth, frequency
+        ))),
+    }
 }
 
 pub fn hyperliquid_spot_asset_id(index: u32) -> String {

--- a/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
@@ -13,7 +13,7 @@ use crate::arch::{
         api_general::{OrderParams, get_micros_timestamp, parse_json_response},
         base_data::{InstrumentType, MarginMode},
     },
-    task_execution::task_ws::{TradesParam, WsChannel},
+    task_execution::task_ws::{LobParam, TradesParam, WsChannel},
     traits::{
         conversion::IntoInfraVec,
         market_lob::{LobPrivateRest, LobPublicRest, LobWebsocket, MarketLobApi},
@@ -615,7 +615,8 @@ impl HyperliquidCli {
         match channel {
             WsChannel::Trades(Some(TradesParam::AggTrades))
             | WsChannel::Trades(Some(TradesParam::AllTrades))
-            | WsChannel::Trades(None) => Ok(HYPERLIQUID_WS.into()),
+            | WsChannel::Trades(None)
+            | WsChannel::Lob(_) => Ok(HYPERLIQUID_WS.into()),
             _ => Err(InfraError::Unimplemented),
         }
     }
@@ -636,6 +637,7 @@ impl HyperliquidCli {
             WsChannel::Trades(Some(TradesParam::AggTrades))
             | WsChannel::Trades(Some(TradesParam::AllTrades))
             | WsChannel::Trades(None) => self._ws_subscribe_trades(insts),
+            WsChannel::Lob(lob_param) => self._ws_subscribe_lob(lob_param, insts),
             _ => Err(InfraError::Unimplemented),
         }
     }
@@ -684,6 +686,40 @@ impl HyperliquidCli {
                     "method": "subscribe",
                     "subscription": {
                         "type": "trades",
+                        "coin": coin.to_string(),
+                    }
+                })
+                .to_string())
+            })
+            .collect();
+
+        Ok(msgs?.join("\n"))
+    }
+
+    fn _ws_subscribe_lob(
+        &self,
+        lob_param: &Option<LobParam>,
+        insts: Option<&[String]>,
+    ) -> InfraResult<String> {
+        let insts = insts.ok_or_else(|| {
+            InfraError::ApiCliError("Hyperliquid lob ws requires at least one instrument".into())
+        })?;
+
+        if insts.is_empty() {
+            return Err(InfraError::ApiCliError(
+                "Hyperliquid lob ws requires at least one instrument".into(),
+            ));
+        }
+
+        let subscription_type = hyperliquid_lob_subscription_type(lob_param)?;
+        let msgs: InfraResult<Vec<String>> = insts
+            .iter()
+            .map(|inst| {
+                let coin = self._inst_to_trade_coin(inst)?;
+                Ok(json!({
+                    "method": "subscribe",
+                    "subscription": {
+                        "type": subscription_type,
                         "coin": coin.to_string(),
                     }
                 })

--- a/src/arch/market_assets/exchange/hyperliquid/hyperliquid_ws_msg.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/hyperliquid_ws_msg.rs
@@ -20,8 +20,9 @@ pub struct HyperliquidWsChannel<T> {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(untagged)]
 pub enum HyperliquidWsState<T> {
-    Batch(Vec<T>),
+    ChannelBatch(Vec<T>),
     Clearinghouse(WsAccountPositionMsgHyperliquid<T>),
+    ChannelSingle(T),
 }
 
 #[allow(non_snake_case)]
@@ -56,13 +57,16 @@ where
     fn into_ws(self) -> Self::Output {
         match self {
             HyperliquidWsData::Channel(c) => match c.data {
-                HyperliquidWsState::Batch(data) => data.into_iter().map(|d| d.into_ws()).collect(),
+                HyperliquidWsState::ChannelBatch(data) => {
+                    data.into_iter().map(|d| d.into_ws()).collect()
+                },
                 HyperliquidWsState::Clearinghouse(msg) => msg
                     .clearinghouseState
                     .assetPositions
                     .into_iter()
                     .map(|position| position.into_ws())
                     .collect(),
+                HyperliquidWsState::ChannelSingle(data) => vec![data.into_ws()],
             },
             HyperliquidWsData::Event(event) => {
                 if !matches!(event.channel.as_deref(), Some("pong")) {

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/ws.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/ws.rs
@@ -1,3 +1,4 @@
 pub mod account_order;
 pub mod account_position;
+pub mod lob;
 pub mod trades;

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/ws/lob.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/ws/lob.rs
@@ -1,0 +1,159 @@
+use serde::Deserialize;
+
+use crate::arch::{
+    market_assets::{
+        api_general::ts_to_micros, exchange::hyperliquid::api_utils::hyperliquid_inst_to_cli,
+        market_core::Market,
+    },
+    strategy_base::handler::lob_events::{LobEventKind, LobLevel, LobLevelAction, WsLob},
+    traits::conversion::IntoWsData,
+};
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum WsLobHyperliquid {
+    Book(WsBookHyperliquid),
+    Bbo(WsBboHyperliquid),
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct WsBookHyperliquid {
+    coin: String,
+    levels: Vec<Vec<WsLevelHyperliquid>>,
+    time: u64,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct WsBboHyperliquid {
+    coin: String,
+    bbo: Vec<Option<WsLevelHyperliquid>>,
+    time: u64,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct WsLevelHyperliquid {
+    px: String,
+    sz: String,
+    n: u64,
+}
+
+impl IntoWsData for WsLobHyperliquid {
+    type Output = WsLob;
+
+    fn into_ws(self) -> Self::Output {
+        match self {
+            WsLobHyperliquid::Book(book) => book.into_ws_lob(),
+            WsLobHyperliquid::Bbo(bbo) => bbo.into_ws_lob(),
+        }
+    }
+}
+
+impl WsBookHyperliquid {
+    fn into_ws_lob(self) -> WsLob {
+        let mut levels = self.levels.into_iter();
+        let bids = levels.next().unwrap_or_default();
+        let asks = levels.next().unwrap_or_default();
+
+        WsLob {
+            timestamp: ts_to_micros(self.time),
+            market: Market::HyperLiquid,
+            inst: hyperliquid_inst_to_cli(&self.coin),
+            event: LobEventKind::Snapshot,
+            bids: bids.into_iter().map(Into::into).collect(),
+            asks: asks.into_iter().map(Into::into).collect(),
+            seq: None,
+            checksum: None,
+        }
+    }
+}
+
+impl WsBboHyperliquid {
+    fn into_ws_lob(self) -> WsLob {
+        let bid = self.bbo.first().cloned().flatten();
+        let ask = self.bbo.get(1).cloned().flatten();
+
+        WsLob {
+            timestamp: ts_to_micros(self.time),
+            market: Market::HyperLiquid,
+            inst: hyperliquid_inst_to_cli(&self.coin),
+            event: LobEventKind::Bbo,
+            bids: bid.into_iter().map(Into::into).collect(),
+            asks: ask.into_iter().map(Into::into).collect(),
+            seq: None,
+            checksum: None,
+        }
+    }
+}
+
+impl From<WsLevelHyperliquid> for LobLevel {
+    fn from(level: WsLevelHyperliquid) -> Self {
+        LobLevel {
+            price: level.px.parse().unwrap_or_default(),
+            size: level.sz.parse().unwrap_or_default(),
+            action: LobLevelAction::Upsert,
+            order_count: Some(level.n),
+            level_update_id: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::arch::{
+        market_assets::exchange::hyperliquid::hyperliquid_ws_msg::HyperliquidWsData,
+        strategy_base::handler::lob_events::LobEventKind, traits::conversion::IntoWsData,
+    };
+
+    use super::*;
+
+    #[test]
+    fn parses_l2_book_payload() {
+        let raw = r#"{
+            "channel": "l2Book",
+            "data": {
+                "coin": "BTC",
+                "time": 1780540000123,
+                "levels": [
+                    [{"px": "63900.0", "sz": "1.25", "n": 3}],
+                    [{"px": "63901.0", "sz": "0.75", "n": 2}]
+                ]
+            }
+        }"#;
+
+        let parsed: HyperliquidWsData<WsLobHyperliquid> = serde_json::from_str(raw).unwrap();
+        let lob = parsed.into_ws();
+
+        assert_eq!(lob.len(), 1);
+        assert!(matches!(lob[0].event, LobEventKind::Snapshot));
+        assert_eq!(lob[0].inst, "BTC_USDC_PERP");
+        assert_eq!(lob[0].bids[0].price, 63900.0);
+        assert_eq!(lob[0].bids[0].order_count, Some(3));
+        assert_eq!(lob[0].asks[0].price, 63901.0);
+        assert_eq!(lob[0].asks[0].order_count, Some(2));
+    }
+
+    #[test]
+    fn parses_bbo_payload() {
+        let raw = r#"{
+            "channel": "bbo",
+            "data": {
+                "coin": "BTC",
+                "time": 1780540000456,
+                "bbo": [
+                    {"px": "63899.0", "sz": "0.5", "n": 1},
+                    {"px": "63900.0", "sz": "0.8", "n": 4}
+                ]
+            }
+        }"#;
+
+        let parsed: HyperliquidWsData<WsLobHyperliquid> = serde_json::from_str(raw).unwrap();
+        let lob = parsed.into_ws();
+
+        assert_eq!(lob.len(), 1);
+        assert!(matches!(lob[0].event, LobEventKind::Bbo));
+        assert_eq!(lob[0].bids[0].price, 63899.0);
+        assert_eq!(lob[0].bids[0].order_count, Some(1));
+        assert_eq!(lob[0].asks[0].price, 63900.0);
+        assert_eq!(lob[0].asks[0].order_count, Some(4));
+    }
+}

--- a/src/arch/market_assets/exchange/okx/okx_cli.rs
+++ b/src/arch/market_assets/exchange/okx/okx_cli.rs
@@ -1095,9 +1095,10 @@ impl OkxCli {
                 TradesParam::AggTrades => OKX_WS_PUB,
                 TradesParam::AllTrades => OKX_WS_BUS,
             },
-            WsChannel::Candles(_) | WsChannel::Tick | WsChannel::Lob | WsChannel::Trades(None) => {
-                OKX_WS_PUB
-            },
+            WsChannel::Candles(_)
+            | WsChannel::Tick
+            | WsChannel::Lob(_)
+            | WsChannel::Trades(None) => OKX_WS_PUB,
             WsChannel::Other(s) if s == "instruments" || s == "funding-rate" => OKX_WS_BUS,
             _ => return Err(InfraError::Unimplemented),
         };
@@ -1114,7 +1115,7 @@ impl OkxCli {
             WsChannel::Candles(channel) => self._ws_subscribe_candle(channel, insts),
             WsChannel::Trades(trades_param) => self._ws_subscribe_trades(trades_param, insts),
             WsChannel::Tick => Err(InfraError::Unimplemented),
-            WsChannel::Lob => Err(InfraError::Unimplemented),
+            WsChannel::Lob(_) => Err(InfraError::Unimplemented),
             _ => Err(InfraError::Unimplemented),
         }
     }

--- a/src/arch/strategy_base/handler/lob_events.rs
+++ b/src/arch/strategy_base/handler/lob_events.rs
@@ -28,9 +28,9 @@ pub struct WsLob {
 
 #[derive(Clone, Debug)]
 pub enum LobEventKind {
-    Snapshot,
-    Delta,
     Bbo,
+    Snapshot,
+    Incremental,
     Heartbeat,
 }
 

--- a/src/arch/task_execution/register_ws/hyperliquid.rs
+++ b/src/arch/task_execution/register_ws/hyperliquid.rs
@@ -3,10 +3,11 @@ use crate::arch::{
         hyperliquid_ws_msg::HyperliquidWsData,
         schemas::ws::{
             account_order::WsAccountOrderHyperliquid,
-            account_position::WsAccountPositionHyperliquid, trades::WsTradeHyperliquid,
+            account_position::WsAccountPositionHyperliquid, lob::WsLobHyperliquid,
+            trades::WsTradeHyperliquid,
         },
     },
-    strategy_base::handler::handler_core::{find_acc_order, find_acc_pos, find_trade},
+    strategy_base::handler::handler_core::{find_acc_order, find_acc_pos, find_lob, find_trade},
     task_execution::{task_general::LogLevel, task_ws::WsChannel},
 };
 
@@ -45,6 +46,17 @@ impl WsTaskBuilder {
                     self.log(
                         LogLevel::Warn,
                         "No broadcast channel found for Hyperliquid Acc Position",
+                    );
+                }
+            },
+            WsChannel::Lob(..) => {
+                if let Some(tx) = find_lob(&self.board_cast_channel) {
+                    self.ws_loop::<HyperliquidWsData<WsLobHyperliquid>>(tx, ws_stream)
+                        .await;
+                } else {
+                    self.log(
+                        LogLevel::Warn,
+                        "No broadcast channel found for Hyperliquid LOB",
                     );
                 }
             },

--- a/src/arch/task_execution/task_ws.rs
+++ b/src/arch/task_execution/task_ws.rs
@@ -39,8 +39,8 @@ pub enum WsChannel {
     Trades(Option<TradesParam>),
     /// Public ticker stream.
     Tick,
-    /// Public order book stream.
-    Lob,
+    /// Public order book stream, optionally parameterized by feed shape.
+    Lob(Option<LobParam>),
     /// Public market-by-order order book stream.
     LobMbo,
     /// Exchange-specific or custom stream.
@@ -59,13 +59,6 @@ pub enum CandleParam {
     OneDay,
     OneWeek,
     Custom(String),
-}
-
-/// Trade stream variant for exchanges that expose several trade feeds.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub enum TradesParam {
-    AggTrades,
-    AllTrades,
 }
 
 impl CandleParam {
@@ -98,4 +91,56 @@ impl CandleParam {
             CandleParam::Custom(s) => s.as_str(),
         }
     }
+}
+
+/// Trade stream variant for exchanges that expose several trade feeds.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum TradesParam {
+    /// Aggregated or compressed trade stream.
+    AggTrades,
+    /// Raw trade stream when the exchange exposes one.
+    AllTrades,
+}
+
+/// Order book feed variant for exchanges that expose several book streams.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum LobParam {
+    /// Best bid/offer stream.
+    Bbo {
+        /// Optional feed update frequency.
+        frequency: Option<LobFrequency>,
+    },
+    /// Limited-depth book snapshot stream.
+    Snapshot {
+        /// Optional number of price levels to request.
+        depth: Option<u16>,
+        /// Optional feed update frequency.
+        frequency: Option<LobFrequency>,
+    },
+    /// Incremental book update stream for maintaining a local book.
+    Incremental {
+        /// Optional number of price levels to request.
+        depth: Option<u16>,
+        /// Optional feed update frequency.
+        frequency: Option<LobFrequency>,
+    },
+}
+
+/// Order book feed update frequency.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum LobFrequency {
+    /// Push updates as soon as the exchange publishes them.
+    Realtime,
+    /// Ten millisecond updates.
+    Ms10,
+    /// One hundred millisecond updates.
+    Ms100,
+    /// Two hundred fifty millisecond updates.
+    Ms250,
+    /// Five hundred millisecond updates.
+    Ms500,
+    /// One second updates.
+    Ms1000,
+    /// Exchange-specific frequency string.
+    Custom(String),
 }


### PR DESCRIPTION
## Summary
- add a parameterized LOB websocket channel model with BBO, snapshot, incremental, and frequency descriptors
- normalize Hyperliquid l2Book and bbo websocket payloads into WsLob
- route Hyperliquid WsChannel::Lob through the websocket relay and default LOB broadcast channel
- keep unsupported Hyperliquid LOB params as explicit configuration errors

## Validation
- cargo fmt --check
- cargo check --all-features
- cargo test --all-features
- cargo clippy --all-features --all-targets
- live checked from api_checkers: hyperliquid_ws_lob BTC_USDC_PERP and hyperliquid_ws_lob bbo BTC_USDC_PERP