### PR TITLE
feat: support OKX websocket LOB

### DIFF
--- a/src/arch/market_assets/exchange/binance/binance_cm_futures_cli.rs
+++ b/src/arch/market_assets/exchange/binance/binance_cm_futures_cli.rs
@@ -297,7 +297,6 @@ impl BinanceCmCli {
         match ws_channel {
             WsChannel::Candles(channel) => self._ws_subscribe_candle(channel, insts),
             WsChannel::Trades(_) => Err(InfraError::Unimplemented),
-            WsChannel::Tick => Err(InfraError::Unimplemented),
             WsChannel::Lob(_) => Err(InfraError::Unimplemented),
             _ => Err(InfraError::Unimplemented),
         }
@@ -306,7 +305,7 @@ impl BinanceCmCli {
     fn _get_public_connect_msg(&self, channel: &WsChannel) -> InfraResult<String> {
         let url = match channel {
             WsChannel::Candles(_) | WsChannel::Trades(_) => BINANCE_CM_FUTURES_WS_MKT,
-            WsChannel::Tick | WsChannel::Lob(_) => BINANCE_CM_FUTURES_WS_PUB,
+            WsChannel::Lob(_) => BINANCE_CM_FUTURES_WS_PUB,
             _ => return Err(InfraError::Unimplemented),
         };
 

--- a/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
+++ b/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
@@ -788,7 +788,6 @@ impl BinanceUmCli {
         match ws_channel {
             WsChannel::Candles(channel) => self._ws_subscribe_candle(channel, insts),
             WsChannel::Trades(_) => self._ws_subscribe_aggtrade(insts),
-            WsChannel::Tick => Err(InfraError::Unimplemented),
             WsChannel::Lob(_) => Err(InfraError::Unimplemented),
             _ => Err(InfraError::Unimplemented),
         }
@@ -797,7 +796,7 @@ impl BinanceUmCli {
     fn _get_public_connect_msg(&self, channel: &WsChannel) -> InfraResult<String> {
         let url = match channel {
             WsChannel::Candles(_) | WsChannel::Trades(_) => BINANCE_UM_FUTURES_WS_MKT,
-            WsChannel::Tick | WsChannel::Lob(_) => BINANCE_UM_FUTURES_WS_PUB,
+            WsChannel::Lob(_) => BINANCE_UM_FUTURES_WS_PUB,
             _ => return Err(InfraError::Unimplemented),
         };
 

--- a/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
@@ -634,7 +634,7 @@ impl GateFuturesCli {
         match ws_channel {
             WsChannel::Candles(channel) => self._ws_subscribe_candle(channel, insts),
             WsChannel::Trades(_) => self._ws_subscribe_trades(insts),
-            WsChannel::Tick | WsChannel::Lob(_) => Err(InfraError::Unimplemented),
+            WsChannel::Lob(_) => Err(InfraError::Unimplemented),
             _ => Err(InfraError::Unimplemented),
         }
     }

--- a/src/arch/market_assets/exchange/okx/okx_cli.rs
+++ b/src/arch/market_assets/exchange/okx/okx_cli.rs
@@ -1095,10 +1095,7 @@ impl OkxCli {
                 TradesParam::AggTrades => OKX_WS_PUB,
                 TradesParam::AllTrades => OKX_WS_BUS,
             },
-            WsChannel::Candles(_)
-            | WsChannel::Tick
-            | WsChannel::Lob(_)
-            | WsChannel::Trades(None) => OKX_WS_PUB,
+            WsChannel::Candles(_) | WsChannel::Lob(_) | WsChannel::Trades(None) => OKX_WS_PUB,
             WsChannel::Other(s) if s == "instruments" || s == "funding-rate" => OKX_WS_BUS,
             _ => return Err(InfraError::Unimplemented),
         };
@@ -1114,7 +1111,6 @@ impl OkxCli {
         match ws_channel {
             WsChannel::Candles(channel) => self._ws_subscribe_candle(channel, insts),
             WsChannel::Trades(trades_param) => self._ws_subscribe_trades(trades_param, insts),
-            WsChannel::Tick => Err(InfraError::Unimplemented),
             WsChannel::Lob(lob_param) => self._ws_subscribe_lob(lob_param, insts),
             _ => Err(InfraError::Unimplemented),
         }

--- a/src/arch/market_assets/exchange/okx/okx_cli.rs
+++ b/src/arch/market_assets/exchange/okx/okx_cli.rs
@@ -1115,7 +1115,7 @@ impl OkxCli {
             WsChannel::Candles(channel) => self._ws_subscribe_candle(channel, insts),
             WsChannel::Trades(trades_param) => self._ws_subscribe_trades(trades_param, insts),
             WsChannel::Tick => Err(InfraError::Unimplemented),
-            WsChannel::Lob(_) => Err(InfraError::Unimplemented),
+            WsChannel::Lob(lob_param) => self._ws_subscribe_lob(lob_param, insts),
             _ => Err(InfraError::Unimplemented),
         }
     }
@@ -1130,6 +1130,51 @@ impl OkxCli {
         let channel = format!("candle{}", interval);
 
         Ok(ws_subscribe_msg_okx(&channel, insts))
+    }
+
+    fn _ws_subscribe_lob(
+        &self,
+        lob_param: &Option<LobParam>,
+        insts: Option<&[String]>,
+    ) -> InfraResult<String> {
+        let channel = match lob_param {
+            None => "books",
+            Some(LobParam::Bbo { frequency }) => match frequency {
+                None | Some(LobFrequency::Realtime) | Some(LobFrequency::Ms10) => "bbo-tbt",
+                Some(freq) => {
+                    return Err(InfraError::ApiCliError(format!(
+                        "OKX bbo-tbt does not support requested frequency: {:?}",
+                        freq
+                    )));
+                },
+            },
+            Some(LobParam::Snapshot { depth, frequency }) => match (depth, frequency) {
+                (None | Some(5), None | Some(LobFrequency::Ms100)) => "books5",
+                _ => {
+                    return Err(InfraError::ApiCliError(format!(
+                        "OKX snapshot LOB supports only books5: depth={:?}, frequency={:?}",
+                        depth, frequency
+                    )));
+                },
+            },
+            Some(LobParam::Incremental { depth, frequency }) => match (depth, frequency) {
+                (None | Some(400), None | Some(LobFrequency::Ms100)) => "books",
+                (None | Some(400), Some(LobFrequency::Realtime) | Some(LobFrequency::Ms10)) => {
+                    "books-l2-tbt"
+                },
+                (Some(50), None | Some(LobFrequency::Realtime) | Some(LobFrequency::Ms10)) => {
+                    "books50-l2-tbt"
+                },
+                _ => {
+                    return Err(InfraError::ApiCliError(format!(
+                        "Unsupported OKX incremental LOB request: depth={:?}, frequency={:?}",
+                        depth, frequency
+                    )));
+                },
+            },
+        };
+
+        Ok(ws_subscribe_msg_okx(channel, insts))
     }
 
     fn _ws_subscribe_trades(
@@ -1173,5 +1218,80 @@ impl OkxCli {
         });
 
         Ok(msg.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::Value;
+
+    use super::*;
+
+    #[test]
+    fn builds_okx_lob_subscribe_channels() {
+        let cli = OkxCli::default();
+        let insts = vec!["BTC_USDT_PERP".to_string()];
+        let cases = [
+            (
+                WsChannel::Lob(Some(LobParam::Bbo {
+                    frequency: Some(LobFrequency::Ms10),
+                })),
+                "bbo-tbt",
+            ),
+            (
+                WsChannel::Lob(Some(LobParam::Snapshot {
+                    depth: Some(5),
+                    frequency: Some(LobFrequency::Ms100),
+                })),
+                "books5",
+            ),
+            (
+                WsChannel::Lob(Some(LobParam::Incremental {
+                    depth: Some(400),
+                    frequency: Some(LobFrequency::Ms100),
+                })),
+                "books",
+            ),
+            (
+                WsChannel::Lob(Some(LobParam::Incremental {
+                    depth: Some(50),
+                    frequency: Some(LobFrequency::Ms10),
+                })),
+                "books50-l2-tbt",
+            ),
+            (
+                WsChannel::Lob(Some(LobParam::Incremental {
+                    depth: Some(400),
+                    frequency: Some(LobFrequency::Ms10),
+                })),
+                "books-l2-tbt",
+            ),
+        ];
+
+        for (channel, expected) in cases {
+            let msg = cli._get_public_sub_msg(&channel, Some(&insts)).unwrap();
+            let value: Value = serde_json::from_str(&msg).unwrap();
+
+            assert_eq!(value["op"], "subscribe");
+            assert_eq!(value["args"][0]["channel"], expected);
+            assert_eq!(value["args"][0]["instId"], "BTC-USDT-SWAP");
+        }
+    }
+
+    #[test]
+    fn rejects_unsupported_okx_lob_subscribe_requests() {
+        let cli = OkxCli::default();
+
+        let err = cli
+            ._get_public_sub_msg(
+                &WsChannel::Lob(Some(LobParam::Snapshot {
+                    depth: Some(20),
+                    frequency: None,
+                })),
+                None,
+            )
+            .unwrap_err();
+
+        assert!(matches!(err, InfraError::ApiCliError(_)));
     }
 }

--- a/src/arch/market_assets/exchange/okx/okx_rest_msg.rs
+++ b/src/arch/market_assets/exchange/okx/okx_rest_msg.rs
@@ -14,7 +14,10 @@ pub struct RestResOkx<T> {
 impl<T: std::fmt::Debug> IntoInfraVec<T> for RestResOkx<T> {
     fn into_vec(self) -> InfraResult<Vec<T>> {
         if self.code != "0" {
-            warn!("OKX REST error {}: {:?}, data: {:?}", self.code, self.msg, self.data);
+            warn!(
+                "OKX REST error {}: {:?}, data: {:?}",
+                self.code, self.msg, self.data
+            );
             return Err(InfraError::ApiCliError(format!(
                 "OKX REST error (code={}): {:?}",
                 self.code, self.msg

--- a/src/arch/market_assets/exchange/okx/okx_rest_msg.rs
+++ b/src/arch/market_assets/exchange/okx/okx_rest_msg.rs
@@ -11,10 +11,10 @@ pub struct RestResOkx<T> {
     pub msg: Option<String>,
 }
 
-impl<T> IntoInfraVec<T> for RestResOkx<T> {
+impl<T: std::fmt::Debug> IntoInfraVec<T> for RestResOkx<T> {
     fn into_vec(self) -> InfraResult<Vec<T>> {
         if self.code != "0" {
-            warn!("OKX REST error {}: {:?}", self.code, self.msg);
+            warn!("OKX REST error {}: {:?}, data: {:?}", self.code, self.msg, self.data);
             return Err(InfraError::ApiCliError(format!(
                 "OKX REST error (code={}): {:?}",
                 self.code, self.msg

--- a/src/arch/market_assets/exchange/okx/okx_ws_msg.rs
+++ b/src/arch/market_assets/exchange/okx/okx_ws_msg.rs
@@ -3,16 +3,33 @@ use tracing::{info, warn};
 
 use crate::arch::traits::conversion::IntoWsData;
 
+pub(crate) trait IntoOkxWsData {
+    type Output;
+
+    fn into_ws_with_okx_context(self, arg: &WsArg, action: Option<&str>) -> Self::Output;
+}
+
+impl<T> IntoOkxWsData for T
+where
+    T: IntoWsData,
+{
+    type Output = T::Output;
+
+    fn into_ws_with_okx_context(self, _arg: &WsArg, _action: Option<&str>) -> Self::Output {
+        self.into_ws()
+    }
+}
+
 #[derive(Clone, Debug, Deserialize)]
 #[serde(untagged)]
-pub enum OkxWsData<T> {
+pub(crate) enum OkxWsData<T> {
     ChannelBatch(OkxWsChannel<T>),
     Event(OkxWsEvent),
 }
 
 #[allow(non_snake_case)]
 #[derive(Clone, Debug, Deserialize)]
-pub struct OkxWsEvent {
+pub(crate) struct OkxWsEvent {
     pub event: Option<String>,
     pub code: Option<String>,
     pub msg: Option<String>,
@@ -22,26 +39,34 @@ pub struct OkxWsEvent {
 
 #[allow(non_snake_case)]
 #[derive(Clone, Debug, Deserialize)]
-pub struct WsArg {
+pub(crate) struct WsArg {
     pub channel: Option<String>,
     pub instId: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
-pub struct OkxWsChannel<T> {
+pub(crate) struct OkxWsChannel<T> {
     pub arg: WsArg,
+    pub action: Option<String>,
     pub data: Vec<T>,
 }
 
 impl<T> IntoWsData for OkxWsData<T>
 where
-    T: IntoWsData + for<'de> Deserialize<'de>,
+    T: IntoOkxWsData + for<'de> Deserialize<'de>,
 {
     type Output = Vec<T::Output>;
 
     fn into_ws(self) -> Self::Output {
         match self {
-            OkxWsData::ChannelBatch(c) => c.data.into_iter().map(|d| d.into_ws()).collect(),
+            OkxWsData::ChannelBatch(c) => {
+                let action = c.action.as_deref();
+
+                c.data
+                    .into_iter()
+                    .map(|d| d.into_ws_with_okx_context(&c.arg, action))
+                    .collect()
+            },
             OkxWsData::Event(res) => {
                 if let Some(event) = res.event {
                     match event.as_str() {

--- a/src/arch/market_assets/exchange/okx/schemas/ws.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/ws.rs
@@ -1,4 +1,5 @@
 pub(crate) mod account_bal_and_pos;
 pub(crate) mod account_order;
 pub(crate) mod account_position;
+pub(crate) mod lob;
 pub(crate) mod trades;

--- a/src/arch/market_assets/exchange/okx/schemas/ws/lob.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/ws/lob.rs
@@ -1,0 +1,225 @@
+use serde::{Deserialize, Deserializer};
+
+use crate::arch::{
+    market_assets::{
+        api_general::ts_to_micros,
+        exchange::okx::{
+            api_utils::okx_inst_to_cli,
+            okx_ws_msg::{IntoOkxWsData, WsArg},
+        },
+        market_core::Market,
+    },
+    strategy_base::handler::lob_events::{LobEventKind, LobLevel, LobLevelAction, LobSeq, WsLob},
+};
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct OkxWsLobBook {
+    asks: Vec<OkxLobLevel>,
+    bids: Vec<OkxLobLevel>,
+    ts: String,
+    checksum: Option<i64>,
+    prevSeqId: Option<i64>,
+    seqId: Option<i64>,
+    instId: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+struct OkxLobLevel {
+    price: String,
+    size: String,
+    order_count: String,
+}
+
+impl<'de> Deserialize<'de> for OkxLobLevel {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let [price, size, _deprecated_feature, order_count] =
+            <[String; 4]>::deserialize(deserializer)?;
+
+        Ok(Self {
+            price,
+            size,
+            order_count,
+        })
+    }
+}
+
+impl IntoOkxWsData for OkxWsLobBook {
+    type Output = WsLob;
+
+    fn into_ws_with_okx_context(self, arg: &WsArg, action: Option<&str>) -> Self::Output {
+        let channel_name = arg.channel.as_deref();
+        let event = okx_lob_event_kind(
+            channel_name,
+            action,
+            self.bids.is_empty(),
+            self.asks.is_empty(),
+        );
+        let arg_inst = arg.instId.as_deref();
+        let inst = self.instId.as_deref().or(arg_inst).unwrap_or_default();
+
+        WsLob {
+            timestamp: ts_to_micros(self.ts.parse().unwrap_or_default()),
+            market: Market::Okx,
+            inst: okx_inst_to_cli(inst),
+            event,
+            bids: self.bids.into_iter().map(Into::into).collect(),
+            asks: self.asks.into_iter().map(Into::into).collect(),
+            seq: okx_lob_seq(self.prevSeqId, self.seqId),
+            checksum: self.checksum.map(|checksum| checksum.to_string()),
+        }
+    }
+}
+
+impl From<OkxLobLevel> for LobLevel {
+    fn from(level: OkxLobLevel) -> Self {
+        let size = level.size.parse().unwrap_or_default();
+
+        LobLevel {
+            price: level.price.parse().unwrap_or_default(),
+            size,
+            // OKX incremental book updates delete a price level by sending size = 0.
+            action: if size == 0.0 {
+                LobLevelAction::Delete
+            } else {
+                LobLevelAction::Upsert
+            },
+            order_count: level.order_count.parse().ok(),
+            level_update_id: None,
+        }
+    }
+}
+
+fn okx_lob_event_kind(
+    channel_name: Option<&str>,
+    action: Option<&str>,
+    bids_empty: bool,
+    asks_empty: bool,
+) -> LobEventKind {
+    match (channel_name, action) {
+        (Some("bbo-tbt"), _) => LobEventKind::Bbo,
+        (Some("books5"), _) => LobEventKind::Snapshot,
+        (_, Some("snapshot")) => LobEventKind::Snapshot,
+        (_, Some("update")) if bids_empty && asks_empty => LobEventKind::Heartbeat,
+        (_, Some("update")) => LobEventKind::Incremental,
+        _ => LobEventKind::Incremental,
+    }
+}
+
+fn okx_lob_seq(prev: Option<i64>, seq: Option<i64>) -> Option<LobSeq> {
+    if prev.is_none() && seq.is_none() {
+        return None;
+    }
+
+    let prev = prev.and_then(non_negative_i64_to_u64);
+    let seq = seq.and_then(non_negative_i64_to_u64);
+
+    Some(LobSeq {
+        prev,
+        first: seq,
+        last: seq,
+    })
+}
+
+fn non_negative_i64_to_u64(value: i64) -> Option<u64> {
+    if value >= 0 { Some(value as u64) } else { None }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::arch::{
+        market_assets::exchange::okx::okx_ws_msg::OkxWsData,
+        strategy_base::handler::lob_events::LobEventKind, traits::conversion::IntoWsData,
+    };
+
+    use super::*;
+
+    #[test]
+    fn parses_okx_books_snapshot() {
+        let raw = r#"{
+            "arg": {"channel": "books", "instId": "BTC-USDT-SWAP"},
+            "action": "snapshot",
+            "data": [{
+                "asks": [["8476.98", "415", "0", "13"]],
+                "bids": [["8476.97", "256", "0", "12"]],
+                "ts": "1597026383085",
+                "checksum": -855196043,
+                "prevSeqId": -1,
+                "seqId": 123456
+            }]
+        }"#;
+
+        let parsed: OkxWsData<OkxWsLobBook> = serde_json::from_str(raw).unwrap();
+        let lob = parsed.into_ws();
+
+        assert_eq!(lob.len(), 1);
+        assert!(matches!(lob[0].event, LobEventKind::Snapshot));
+        assert_eq!(lob[0].inst, "BTC_USDT_PERP");
+        assert_eq!(lob[0].seq.as_ref().unwrap().prev, None);
+        assert_eq!(lob[0].seq.as_ref().unwrap().last, Some(123456));
+        assert_eq!(lob[0].checksum.as_deref(), Some("-855196043"));
+        assert_eq!(lob[0].asks[0].order_count, Some(13));
+    }
+
+    #[test]
+    fn parses_okx_bbo_from_arg_inst() {
+        let raw = r#"{
+            "arg": {"channel": "bbo-tbt", "instId": "BCH-USDT-SWAP"},
+            "data": [{
+                "asks": [["111.06", "55154", "0", "2"]],
+                "bids": [["111.05", "57745", "0", "2"]],
+                "ts": "1670324386802",
+                "seqId": 363996337
+            }]
+        }"#;
+
+        let parsed: OkxWsData<OkxWsLobBook> = serde_json::from_str(raw).unwrap();
+        let lob = parsed.into_ws();
+
+        assert_eq!(lob.len(), 1);
+        assert!(matches!(lob[0].event, LobEventKind::Bbo));
+        assert_eq!(lob[0].inst, "BCH_USDT_PERP");
+        assert_eq!(lob[0].seq.as_ref().unwrap().last, Some(363996337));
+        assert_eq!(lob[0].bids[0].price, 111.05);
+    }
+
+    #[test]
+    fn parses_okx_empty_update_as_heartbeat() {
+        let raw = r#"{
+            "arg": {"channel": "books", "instId": "BTC-USDT"},
+            "action": "update",
+            "data": [{
+                "asks": [],
+                "bids": [],
+                "ts": "1597026383085",
+                "prevSeqId": 15,
+                "seqId": 15
+            }]
+        }"#;
+
+        let parsed: OkxWsData<OkxWsLobBook> = serde_json::from_str(raw).unwrap();
+        let lob = parsed.into_ws();
+
+        assert_eq!(lob.len(), 1);
+        assert!(matches!(lob[0].event, LobEventKind::Heartbeat));
+        assert_eq!(lob[0].inst, "BTC_USDT");
+        assert!(lob[0].bids.is_empty());
+        assert!(lob[0].asks.is_empty());
+    }
+
+    #[test]
+    fn okx_lob_event_messages_produce_no_data() {
+        let raw = r#"{
+            "event": "error",
+            "code": "64003",
+            "msg": "Only API users who are VIP4 and above are allowed.",
+            "arg": {"channel": "books-l2-tbt", "instId": "BTC-USDT-SWAP"}
+        }"#;
+
+        let parsed: OkxWsData<OkxWsLobBook> = serde_json::from_str(raw).unwrap();
+        assert!(parsed.into_ws().is_empty());
+    }
+}

--- a/src/arch/task_execution/register_ws/binance.rs
+++ b/src/arch/task_execution/register_ws/binance.rs
@@ -19,28 +19,6 @@ use super::{WsStream, WsTaskBuilder};
 impl WsTaskBuilder {
     pub(super) async fn ws_channel_binance_um(&mut self, ws_stream: &mut WsStream) {
         match &self.ws_info.ws_channel {
-            WsChannel::Trades(..) => {
-                if let Some(tx) = find_trade(&self.board_cast_channel) {
-                    self.ws_loop::<BinanceWsData<WsAggTradeBinanceUM>>(tx, ws_stream)
-                        .await;
-                } else {
-                    self.log(
-                        LogLevel::Warn,
-                        "No broadcast channel found for Binance UmFutures Trades",
-                    );
-                }
-            },
-            WsChannel::Candles(..) => {
-                if let Some(tx) = find_candle(&self.board_cast_channel) {
-                    self.ws_loop::<BinanceWsData<WsCandleBinanceUM>>(tx, ws_stream)
-                        .await;
-                } else {
-                    self.log(
-                        LogLevel::Warn,
-                        "No broadcast channel found for Binance UmFutures Candles",
-                    );
-                }
-            },
             WsChannel::AccountOrders => {
                 if let Some(tx) = find_acc_order(&self.board_cast_channel) {
                     self.ws_loop::<BinanceWsData<WsAccountOrderBinanceUM>>(tx, ws_stream)
@@ -71,6 +49,28 @@ impl WsTaskBuilder {
                     self.log(
                         LogLevel::Warn,
                         "No broadcast channel found for Binance UmFutures Acc Position",
+                    );
+                }
+            },
+            WsChannel::Candles(..) => {
+                if let Some(tx) = find_candle(&self.board_cast_channel) {
+                    self.ws_loop::<BinanceWsData<WsCandleBinanceUM>>(tx, ws_stream)
+                        .await;
+                } else {
+                    self.log(
+                        LogLevel::Warn,
+                        "No broadcast channel found for Binance UmFutures Candles",
+                    );
+                }
+            },
+            WsChannel::Trades(..) => {
+                if let Some(tx) = find_trade(&self.board_cast_channel) {
+                    self.ws_loop::<BinanceWsData<WsAggTradeBinanceUM>>(tx, ws_stream)
+                        .await;
+                } else {
+                    self.log(
+                        LogLevel::Warn,
+                        "No broadcast channel found for Binance UmFutures Trades",
                     );
                 }
             },

--- a/src/arch/task_execution/register_ws/gate.rs
+++ b/src/arch/task_execution/register_ws/gate.rs
@@ -17,28 +17,6 @@ use super::{WsStream, WsTaskBuilder};
 impl WsTaskBuilder {
     pub(super) async fn ws_channel_gate_futures(&mut self, ws_stream: &mut WsStream) {
         match &self.ws_info.ws_channel {
-            WsChannel::Trades(..) => {
-                if let Some(tx) = find_trade(&self.board_cast_channel) {
-                    self.ws_loop::<GateWsData<WsTradeGateFutures>>(tx, ws_stream)
-                        .await;
-                } else {
-                    self.log(
-                        LogLevel::Warn,
-                        "No broadcast channel found for Gate Futures Trades",
-                    );
-                }
-            },
-            WsChannel::Candles(..) => {
-                if let Some(tx) = find_candle(&self.board_cast_channel) {
-                    self.ws_loop::<GateWsData<WsCandleGateFutures>>(tx, ws_stream)
-                        .await;
-                } else {
-                    self.log(
-                        LogLevel::Warn,
-                        "No broadcast channel found for Gate Futures Candles",
-                    );
-                }
-            },
             WsChannel::AccountOrders => {
                 if let Some(tx) = find_acc_order(&self.board_cast_channel) {
                     self.ws_loop::<GateWsData<WsAccountOrderGateFutures>>(tx, ws_stream)
@@ -58,6 +36,28 @@ impl WsTaskBuilder {
                     self.log(
                         LogLevel::Warn,
                         "No broadcast channel found for Gate Futures Acc Position",
+                    );
+                }
+            },
+            WsChannel::Candles(..) => {
+                if let Some(tx) = find_candle(&self.board_cast_channel) {
+                    self.ws_loop::<GateWsData<WsCandleGateFutures>>(tx, ws_stream)
+                        .await;
+                } else {
+                    self.log(
+                        LogLevel::Warn,
+                        "No broadcast channel found for Gate Futures Candles",
+                    );
+                }
+            },
+            WsChannel::Trades(..) => {
+                if let Some(tx) = find_trade(&self.board_cast_channel) {
+                    self.ws_loop::<GateWsData<WsTradeGateFutures>>(tx, ws_stream)
+                        .await;
+                } else {
+                    self.log(
+                        LogLevel::Warn,
+                        "No broadcast channel found for Gate Futures Trades",
                     );
                 }
             },

--- a/src/arch/task_execution/register_ws/hyperliquid.rs
+++ b/src/arch/task_execution/register_ws/hyperliquid.rs
@@ -16,17 +16,6 @@ use super::{WsStream, WsTaskBuilder};
 impl WsTaskBuilder {
     pub(super) async fn ws_channel_hyperliquid(&mut self, ws_stream: &mut WsStream) {
         match &self.ws_info.ws_channel {
-            WsChannel::Trades(..) => {
-                if let Some(tx) = find_trade(&self.board_cast_channel) {
-                    self.ws_loop::<HyperliquidWsData<WsTradeHyperliquid>>(tx, ws_stream)
-                        .await;
-                } else {
-                    self.log(
-                        LogLevel::Warn,
-                        "No broadcast channel found for Hyperliquid Trades",
-                    );
-                }
-            },
             WsChannel::AccountOrders => {
                 if let Some(tx) = find_acc_order(&self.board_cast_channel) {
                     self.ws_loop::<HyperliquidWsData<WsAccountOrderHyperliquid>>(tx, ws_stream)
@@ -46,6 +35,17 @@ impl WsTaskBuilder {
                     self.log(
                         LogLevel::Warn,
                         "No broadcast channel found for Hyperliquid Acc Position",
+                    );
+                }
+            },
+            WsChannel::Trades(..) => {
+                if let Some(tx) = find_trade(&self.board_cast_channel) {
+                    self.ws_loop::<HyperliquidWsData<WsTradeHyperliquid>>(tx, ws_stream)
+                        .await;
+                } else {
+                    self.log(
+                        LogLevel::Warn,
+                        "No broadcast channel found for Hyperliquid Trades",
                     );
                 }
             },

--- a/src/arch/task_execution/register_ws/okx.rs
+++ b/src/arch/task_execution/register_ws/okx.rs
@@ -17,20 +17,6 @@ use super::{WsStream, WsTaskBuilder};
 impl WsTaskBuilder {
     pub(super) async fn ws_channel_okx(&mut self, ws_stream: &mut WsStream) {
         match &self.ws_info.ws_channel {
-            WsChannel::Trades(..) => {
-                if let Some(tx) = find_trade(&self.board_cast_channel) {
-                    self.ws_loop::<OkxWsData<WsTradesOkx>>(tx, ws_stream).await;
-                } else {
-                    self.log(LogLevel::Warn, "No broadcast channel found for Okx Trades");
-                }
-            },
-            WsChannel::Lob(..) => {
-                if let Some(tx) = find_lob(&self.board_cast_channel) {
-                    self.ws_loop::<OkxWsData<OkxWsLobBook>>(tx, ws_stream).await;
-                } else {
-                    self.log(LogLevel::Warn, "No broadcast channel found for Okx LOB");
-                }
-            },
             WsChannel::AccountOrders => {
                 if let Some(tx) = find_acc_order(&self.board_cast_channel) {
                     self.ws_loop::<OkxWsData<WsAccountOrderOkx>>(tx, ws_stream)
@@ -39,6 +25,17 @@ impl WsTaskBuilder {
                     self.log(
                         LogLevel::Warn,
                         "No broadcast channel found for Okx Acc Order",
+                    );
+                }
+            },
+            WsChannel::AccountBalAndPos => {
+                if let Some(tx) = find_acc_bal_pos(&self.board_cast_channel) {
+                    self.ws_loop::<OkxWsData<WsBalAndPosOkx>>(tx, ws_stream)
+                        .await;
+                } else {
+                    self.log(
+                        LogLevel::Warn,
+                        "No broadcast channel found for Okx Acc Bal and Pos",
                     );
                 }
             },
@@ -53,15 +50,18 @@ impl WsTaskBuilder {
                     );
                 }
             },
-            WsChannel::AccountBalAndPos => {
-                if let Some(tx) = find_acc_bal_pos(&self.board_cast_channel) {
-                    self.ws_loop::<OkxWsData<WsBalAndPosOkx>>(tx, ws_stream)
-                        .await;
+            WsChannel::Trades(..) => {
+                if let Some(tx) = find_trade(&self.board_cast_channel) {
+                    self.ws_loop::<OkxWsData<WsTradesOkx>>(tx, ws_stream).await;
                 } else {
-                    self.log(
-                        LogLevel::Warn,
-                        "No broadcast channel found for Okx Acc Bal and Pos",
-                    );
+                    self.log(LogLevel::Warn, "No broadcast channel found for Okx Trades");
+                }
+            },
+            WsChannel::Lob(..) => {
+                if let Some(tx) = find_lob(&self.board_cast_channel) {
+                    self.ws_loop::<OkxWsData<OkxWsLobBook>>(tx, ws_stream).await;
+                } else {
+                    self.log(LogLevel::Warn, "No broadcast channel found for Okx LOB");
                 }
             },
             c => {

--- a/src/arch/task_execution/register_ws/okx.rs
+++ b/src/arch/task_execution/register_ws/okx.rs
@@ -3,11 +3,11 @@ use crate::arch::{
         okx_ws_msg::OkxWsData,
         schemas::ws::{
             account_bal_and_pos::WsBalAndPosOkx, account_order::WsAccountOrderOkx,
-            account_position::WsAccountPositionOkx, trades::WsTradesOkx,
+            account_position::WsAccountPositionOkx, lob::OkxWsLobBook, trades::WsTradesOkx,
         },
     },
     strategy_base::handler::handler_core::{
-        find_acc_bal_pos, find_acc_order, find_acc_pos, find_trade,
+        find_acc_bal_pos, find_acc_order, find_acc_pos, find_lob, find_trade,
     },
     task_execution::{task_general::LogLevel, task_ws::WsChannel},
 };
@@ -22,6 +22,13 @@ impl WsTaskBuilder {
                     self.ws_loop::<OkxWsData<WsTradesOkx>>(tx, ws_stream).await;
                 } else {
                     self.log(LogLevel::Warn, "No broadcast channel found for Okx Trades");
+                }
+            },
+            WsChannel::Lob(..) => {
+                if let Some(tx) = find_lob(&self.board_cast_channel) {
+                    self.ws_loop::<OkxWsData<OkxWsLobBook>>(tx, ws_stream).await;
+                } else {
+                    self.log(LogLevel::Warn, "No broadcast channel found for Okx LOB");
                 }
             },
             WsChannel::AccountOrders => {

--- a/src/arch/task_execution/task_ws.rs
+++ b/src/arch/task_execution/task_ws.rs
@@ -37,8 +37,6 @@ pub enum WsChannel {
     Candles(Option<CandleParam>),
     /// Public trades, optionally parameterized by trade stream type.
     Trades(Option<TradesParam>),
-    /// Public ticker stream.
-    Tick,
     /// Public order book stream, optionally parameterized by feed shape.
     Lob(Option<LobParam>),
     /// Public market-by-order order book stream.


### PR DESCRIPTION
## Summary
- add OKX websocket LOB subscription support for bbo-tbt, books5, books, books-l2-tbt, and books50-l2-tbt through LobParam
- add normalized OKX LOB parsing with context-aware OKX websocket envelope handling
- map OKX level arrays into named price/size/order_count fields, size=0 deletes, seq/checksum, and BBO/snapshot/incremental/heartbeat events
- include OKX REST error data in error logs

## Validation
- cargo test --all-features okx_lob
- cargo test --all-features parses_okx
- cargo check --all-features
- cargo clippy --all-features --all-targets
- git diff --check

## Live check
- OKX api_checker live LOB run observed bbo=true, snapshot=true, incremental=true, level=true, order_count=true, delete=true, seq=true, checksum=true