### PR TITLE
feat: support Binance websocket LOB

### DIFF
--- a/src/arch/market_assets/exchange/binance/api_utils.rs
+++ b/src/arch/market_assets/exchange/binance/api_utils.rs
@@ -4,7 +4,10 @@ use serde_json::json;
 use std::{collections::HashMap, sync::Arc};
 use tracing::warn;
 
-use crate::arch::market_assets::base_data::SUBSCRIBE;
+use crate::arch::{
+    market_assets::base_data::SUBSCRIBE,
+    task_execution::task_ws::{LobFrequency, LobParam},
+};
 use crate::errors::{InfraError, InfraResult};
 
 use super::api_key::BinanceKey;
@@ -458,6 +461,83 @@ pub fn ws_subscribe_msg_binance(param: &str, insts: Option<&[String]>) -> String
     subscribe_msg.to_string()
 }
 
+pub fn ws_subscribe_msg_binance_cm(param: &str, insts: Option<&[String]>) -> String {
+    let params: Vec<String> = match insts {
+        Some(list) => list
+            .iter()
+            .map(|symbol| {
+                format!(
+                    "{}@{}",
+                    cli_perp_to_binance_cm(symbol).to_lowercase(),
+                    param
+                )
+            })
+            .collect(),
+        None => vec![param.into()],
+    };
+
+    let subscribe_msg = json!({
+        "method": SUBSCRIBE,
+        "params": params,
+        "id": 1
+    });
+
+    subscribe_msg.to_string()
+}
+
+pub fn binance_lob_stream(lob_param: &Option<LobParam>) -> InfraResult<String> {
+    match lob_param {
+        None => Ok(format!("depth{}", binance_lob_frequency_suffix(&None)?)),
+        Some(LobParam::Bbo { frequency }) => match frequency {
+            None | Some(LobFrequency::Realtime) => Ok("bookTicker".into()),
+            Some(freq) => Err(InfraError::ApiCliError(format!(
+                "Binance bookTicker does not support requested frequency: {:?}",
+                freq
+            ))),
+        },
+        Some(LobParam::Snapshot { depth, frequency }) => {
+            let depth = match depth.as_ref().copied() {
+                None => 20,
+                Some(depth @ (5 | 10 | 20)) => depth,
+                Some(depth) => {
+                    return Err(InfraError::ApiCliError(format!(
+                        "Binance partial depth supports only 5, 10, or 20 levels: {}",
+                        depth
+                    )));
+                },
+            };
+
+            Ok(format!(
+                "depth{}{}",
+                depth,
+                binance_lob_frequency_suffix(frequency)?
+            ))
+        },
+        Some(LobParam::Incremental { depth, frequency }) => {
+            if depth.is_some() {
+                return Err(InfraError::ApiCliError(format!(
+                    "Binance diff depth does not support a depth parameter: {:?}",
+                    depth
+                )));
+            }
+
+            Ok(format!("depth{}", binance_lob_frequency_suffix(frequency)?))
+        },
+    }
+}
+
+fn binance_lob_frequency_suffix(frequency: &Option<LobFrequency>) -> InfraResult<&'static str> {
+    match frequency {
+        None | Some(LobFrequency::Ms250) => Ok(""),
+        Some(LobFrequency::Ms100) => Ok("@100ms"),
+        Some(LobFrequency::Ms500) => Ok("@500ms"),
+        Some(freq) => Err(InfraError::ApiCliError(format!(
+            "Binance LOB supports only 100ms, 250ms, or 500ms frequency: {:?}",
+            freq
+        ))),
+    }
+}
+
 pub fn binance_fut_inst_to_cli(symbol: &str) -> String {
     let upper = symbol.to_uppercase();
     let quote_currencies = ["USDT", "USDC", "USD"];
@@ -573,6 +653,8 @@ pub fn cli_spot_to_binance_spot(inst: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use crate::arch::task_execution::task_ws::{LobFrequency, LobParam};
+
     use super::*;
 
     #[test]
@@ -591,6 +673,78 @@ mod tests {
         assert_eq!(cli_perp_to_binance_cm_pair("BTC_USD_PERP"), "BTCUSD");
         assert_eq!(cli_perp_to_binance_cm_pair("BTC_USDT_PERP"), "BTCUSD");
         assert_eq!(cli_perp_to_binance_cm_pair("BTC_USD_FUT_240329"), "BTCUSD");
+    }
+
+    #[test]
+    fn builds_binance_lob_stream_names() {
+        assert_eq!(binance_lob_stream(&None).unwrap(), "depth");
+        assert_eq!(
+            binance_lob_stream(&Some(LobParam::Bbo { frequency: None })).unwrap(),
+            "bookTicker"
+        );
+        assert_eq!(
+            binance_lob_stream(&Some(LobParam::Snapshot {
+                depth: None,
+                frequency: Some(LobFrequency::Ms100),
+            }))
+            .unwrap(),
+            "depth20@100ms"
+        );
+        assert_eq!(
+            binance_lob_stream(&Some(LobParam::Snapshot {
+                depth: Some(10),
+                frequency: Some(LobFrequency::Ms500),
+            }))
+            .unwrap(),
+            "depth10@500ms"
+        );
+        assert_eq!(
+            binance_lob_stream(&Some(LobParam::Incremental {
+                depth: None,
+                frequency: Some(LobFrequency::Ms250),
+            }))
+            .unwrap(),
+            "depth"
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_binance_lob_requests() {
+        assert!(
+            binance_lob_stream(&Some(LobParam::Bbo {
+                frequency: Some(LobFrequency::Ms100),
+            }))
+            .is_err()
+        );
+        assert!(
+            binance_lob_stream(&Some(LobParam::Snapshot {
+                depth: Some(50),
+                frequency: None,
+            }))
+            .is_err()
+        );
+        assert!(
+            binance_lob_stream(&Some(LobParam::Incremental {
+                depth: Some(20),
+                frequency: None,
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn builds_binance_lob_subscribe_symbols() {
+        let um_insts = vec!["BTC_USDT_PERP".into()];
+        let um_msg: serde_json::Value =
+            serde_json::from_str(&ws_subscribe_msg_binance("depth20@100ms", Some(&um_insts)))
+                .unwrap();
+        assert_eq!(um_msg["params"][0], "btcusdt@depth20@100ms");
+
+        let cm_insts = vec!["BTC_USD_PERP".into()];
+        let cm_msg: serde_json::Value =
+            serde_json::from_str(&ws_subscribe_msg_binance_cm("bookTicker", Some(&cm_insts)))
+                .unwrap();
+        assert_eq!(cm_msg["params"][0], "btcusd_perp@bookTicker");
     }
 
     #[test]

--- a/src/arch/market_assets/exchange/binance/binance_cm_futures_cli.rs
+++ b/src/arch/market_assets/exchange/binance/binance_cm_futures_cli.rs
@@ -49,8 +49,8 @@ impl LobPublicRest for BinanceCmCli {
         self._get_instrument_info(inst_type).await
     }
 
-    async fn get_live_instruments(&self, _inst_type: InstrumentType) -> InfraResult<Vec<String>> {
-        self._get_live_instruments().await
+    async fn get_live_instruments(&self, inst_type: InstrumentType) -> InfraResult<Vec<String>> {
+        self._get_live_instruments(inst_type).await
     }
 }
 
@@ -235,28 +235,13 @@ impl BinanceCmCli {
         Ok(data)
     }
 
-    async fn _get_live_instruments(&self) -> InfraResult<Vec<String>> {
-        let url = [
-            BINANCE_CM_FUTURES_BASE_URL,
-            BINANCE_CM_FUTURES_EXCHANGE_INFO,
-        ]
-        .concat();
-
-        let response = self.client.get(url).send().await?;
-        let res: RestResBinance<RestExchangeInfoBinanceCM> =
-            parse_json_response("BinanceCmFutures live_instruments", response).await?;
-
-        let data: Vec<String> = res
-            .into_vec()?
+    async fn _get_live_instruments(&self, inst_type: InstrumentType) -> InfraResult<Vec<String>> {
+        let data = self
+            ._get_instrument_info(inst_type)
+            .await?
             .into_iter()
-            .next()
-            .ok_or(InfraError::ApiCliError(
-                "No CM exchange info data returned".into(),
-            ))?
-            .symbols
-            .into_iter()
-            .filter(|ins| ins.contractType == PERPETUAL && ins.contractStatus == TRADING)
-            .map(|s| binance_fut_inst_to_cli(&s.symbol))
+            .filter(|inst| inst.state == InstrumentStatus::Live)
+            .map(|inst| inst.inst)
             .collect();
 
         Ok(data)
@@ -297,7 +282,7 @@ impl BinanceCmCli {
         match ws_channel {
             WsChannel::Candles(channel) => self._ws_subscribe_candle(channel, insts),
             WsChannel::Trades(_) => Err(InfraError::Unimplemented),
-            WsChannel::Lob(_) => Err(InfraError::Unimplemented),
+            WsChannel::Lob(lob_param) => self._ws_subscribe_lob(lob_param, insts),
             _ => Err(InfraError::Unimplemented),
         }
     }
@@ -337,5 +322,15 @@ impl BinanceCmCli {
         let channel = format!("kline_{}", interval);
 
         Ok(ws_subscribe_msg_binance(&channel, insts))
+    }
+
+    fn _ws_subscribe_lob(
+        &self,
+        lob_param: &Option<LobParam>,
+        insts: Option<&[String]>,
+    ) -> InfraResult<String> {
+        let channel = binance_lob_stream(lob_param)?;
+
+        Ok(ws_subscribe_msg_binance_cm(&channel, insts))
     }
 }

--- a/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
+++ b/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
@@ -70,8 +70,8 @@ impl LobPublicRest for BinanceUmCli {
         self._get_instrument_info(inst_type).await
     }
 
-    async fn get_live_instruments(&self, _inst_type: InstrumentType) -> InfraResult<Vec<String>> {
-        self._get_live_instruments().await
+    async fn get_live_instruments(&self, inst_type: InstrumentType) -> InfraResult<Vec<String>> {
+        self._get_live_instruments(inst_type).await
     }
 }
 
@@ -571,28 +571,13 @@ impl BinanceUmCli {
         Ok(data)
     }
 
-    async fn _get_live_instruments(&self) -> InfraResult<Vec<String>> {
-        let url = [
-            BINANCE_UM_FUTURES_BASE_URL,
-            BINANCE_UM_FUTURES_EXCHANGE_INFO,
-        ]
-        .concat();
-
-        let response = self.client.get(url).send().await?;
-        let res: RestResBinance<RestExchangeInfoBinanceUM> =
-            parse_json_response("BinanceUmFutures live_instruments", response).await?;
-
-        let data: Vec<String> = res
-            .into_vec()?
+    async fn _get_live_instruments(&self, inst_type: InstrumentType) -> InfraResult<Vec<String>> {
+        let data = self
+            ._get_instrument_info(inst_type)
+            .await?
             .into_iter()
-            .next()
-            .ok_or(InfraError::ApiCliError(
-                "No UM exchange info data returned".into(),
-            ))?
-            .symbols
-            .into_iter()
-            .filter(|ins| ins.contractType == PERPETUAL && ins.status == TRADING)
-            .map(|s| binance_fut_inst_to_cli(&s.symbol))
+            .filter(|inst| inst.state == InstrumentStatus::Live)
+            .map(|inst| inst.inst)
             .collect();
 
         Ok(data)
@@ -788,7 +773,7 @@ impl BinanceUmCli {
         match ws_channel {
             WsChannel::Candles(channel) => self._ws_subscribe_candle(channel, insts),
             WsChannel::Trades(_) => self._ws_subscribe_aggtrade(insts),
-            WsChannel::Lob(_) => Err(InfraError::Unimplemented),
+            WsChannel::Lob(lob_param) => self._ws_subscribe_lob(lob_param, insts),
             _ => Err(InfraError::Unimplemented),
         }
     }
@@ -832,5 +817,15 @@ impl BinanceUmCli {
 
     fn _ws_subscribe_aggtrade(&self, insts: Option<&[String]>) -> InfraResult<String> {
         Ok(ws_subscribe_msg_binance("aggTrade", insts))
+    }
+
+    fn _ws_subscribe_lob(
+        &self,
+        lob_param: &Option<LobParam>,
+        insts: Option<&[String]>,
+    ) -> InfraResult<String> {
+        let channel = binance_lob_stream(lob_param)?;
+
+        Ok(ws_subscribe_msg_binance(&channel, insts))
     }
 }

--- a/src/arch/market_assets/exchange/binance/schemas.rs
+++ b/src/arch/market_assets/exchange/binance/schemas.rs
@@ -1,4 +1,5 @@
 pub mod cm_futures_rest;
+pub(crate) mod cm_futures_ws;
 pub mod spot_rest;
 pub mod spot_ws;
 pub mod um_futures_rest;

--- a/src/arch/market_assets/exchange/binance/schemas/cm_futures_ws.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/cm_futures_ws.rs
@@ -1,0 +1,1 @@
+pub(crate) mod lob;

--- a/src/arch/market_assets/exchange/binance/schemas/cm_futures_ws/lob.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/cm_futures_ws/lob.rs
@@ -1,0 +1,198 @@
+use serde::Deserialize;
+
+use crate::arch::{
+    market_assets::{
+        api_general::ts_to_micros, exchange::binance::api_utils::binance_fut_inst_to_cli,
+        market_core::Market,
+    },
+    strategy_base::handler::lob_events::{LobEventKind, LobLevel, LobLevelAction, LobSeq, WsLob},
+    traits::conversion::IntoWsData,
+};
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(transparent)]
+pub(crate) struct WsBookTickerBinanceCM(BinanceBookTicker);
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(transparent)]
+pub(crate) struct WsPartialDepthBinanceCM(BinanceDepthBook);
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(transparent)]
+pub(crate) struct WsDiffDepthBinanceCM(BinanceDepthBook);
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Deserialize)]
+struct BinanceBookTicker {
+    u: u64,
+    s: String,
+    b: String,
+    B: String,
+    a: String,
+    A: String,
+    T: u64,
+}
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Deserialize)]
+struct BinanceDepthBook {
+    T: u64,
+    s: String,
+    U: u64,
+    u: u64,
+    pu: Option<u64>,
+    b: Vec<BinanceLobLevel>,
+    a: Vec<BinanceLobLevel>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct BinanceLobLevel(String, String);
+
+impl BinanceBookTicker {
+    fn into_ws_lob(self) -> WsLob {
+        let update_id = self.u;
+
+        WsLob {
+            timestamp: ts_to_micros(self.T),
+            market: Market::BinanceCmFutures,
+            inst: binance_fut_inst_to_cli(&self.s),
+            event: LobEventKind::Bbo,
+            bids: vec![binance_bbo_level(&self.b, &self.B, update_id)],
+            asks: vec![binance_bbo_level(&self.a, &self.A, update_id)],
+            seq: Some(LobSeq {
+                prev: None,
+                first: Some(update_id),
+                last: Some(update_id),
+            }),
+            checksum: None,
+        }
+    }
+}
+
+impl BinanceDepthBook {
+    fn into_ws_lob(self, event: LobEventKind) -> WsLob {
+        let is_empty_update = self.b.is_empty() && self.a.is_empty();
+        let delete_on_zero = matches!(event, LobEventKind::Incremental);
+
+        WsLob {
+            timestamp: ts_to_micros(self.T),
+            market: Market::BinanceCmFutures,
+            inst: binance_fut_inst_to_cli(&self.s),
+            event: if matches!(event, LobEventKind::Incremental) && is_empty_update {
+                LobEventKind::Heartbeat
+            } else {
+                event
+            },
+            bids: self
+                .b
+                .into_iter()
+                .map(|level| binance_lob_level(level, delete_on_zero))
+                .collect(),
+            asks: self
+                .a
+                .into_iter()
+                .map(|level| binance_lob_level(level, delete_on_zero))
+                .collect(),
+            seq: Some(LobSeq {
+                prev: self.pu,
+                first: Some(self.U),
+                last: Some(self.u),
+            }),
+            checksum: None,
+        }
+    }
+}
+
+fn binance_bbo_level(price: &str, size: &str, update_id: u64) -> LobLevel {
+    let size = size.parse().unwrap_or_default();
+
+    LobLevel {
+        price: price.parse().unwrap_or_default(),
+        size,
+        action: if size == 0.0 {
+            LobLevelAction::Delete
+        } else {
+            LobLevelAction::Upsert
+        },
+        order_count: None,
+        level_update_id: Some(update_id),
+    }
+}
+
+fn binance_lob_level(level: BinanceLobLevel, delete_on_zero: bool) -> LobLevel {
+    let size = level.1.parse().unwrap_or_default();
+
+    LobLevel {
+        price: level.0.parse().unwrap_or_default(),
+        size,
+        action: if delete_on_zero && size == 0.0 {
+            LobLevelAction::Delete
+        } else {
+            LobLevelAction::Upsert
+        },
+        order_count: None,
+        level_update_id: None,
+    }
+}
+
+impl IntoWsData for WsBookTickerBinanceCM {
+    type Output = WsLob;
+
+    fn into_ws(self) -> Self::Output {
+        self.0.into_ws_lob()
+    }
+}
+
+impl IntoWsData for WsPartialDepthBinanceCM {
+    type Output = WsLob;
+
+    fn into_ws(self) -> Self::Output {
+        self.0.into_ws_lob(LobEventKind::Snapshot)
+    }
+}
+
+impl IntoWsData for WsDiffDepthBinanceCM {
+    type Output = WsLob;
+
+    fn into_ws(self) -> Self::Output {
+        self.0.into_ws_lob(LobEventKind::Incremental)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::arch::{
+        market_assets::{exchange::binance::binance_ws_msg::BinanceWsData, market_core::Market},
+        strategy_base::handler::lob_events::{LobEventKind, LobLevelAction},
+        traits::conversion::IntoWsData,
+    };
+
+    use super::*;
+
+    #[test]
+    fn parses_binance_cm_partial_depth_as_snapshot() {
+        let raw = r#"{
+            "e":"depthUpdate",
+            "E":1780563999230,
+            "T":1780563999229,
+            "s":"BTCUSD_PERP",
+            "ps":"BTCUSD",
+            "U":1691890103301,
+            "u":1691890108316,
+            "pu":1691890103299,
+            "b":[["63298.6","5563"]],
+            "a":[["63298.7","333"]]
+        }"#;
+
+        let parsed: BinanceWsData<WsPartialDepthBinanceCM> = serde_json::from_str(raw).unwrap();
+        let lob = parsed.into_ws();
+
+        assert_eq!(lob.len(), 1);
+        assert!(matches!(lob[0].event, LobEventKind::Snapshot));
+        assert_eq!(lob[0].market, Market::BinanceCmFutures);
+        assert_eq!(lob[0].inst, "BTC_USD_PERP");
+        assert_eq!(lob[0].seq.as_ref().unwrap().prev, Some(1691890103299));
+        assert_eq!(lob[0].seq.as_ref().unwrap().first, Some(1691890103301));
+        assert!(matches!(lob[0].bids[0].action, LobLevelAction::Upsert));
+    }
+}

--- a/src/arch/market_assets/exchange/binance/schemas/um_futures_ws.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/um_futures_ws.rs
@@ -3,3 +3,4 @@ pub(crate) mod account_order;
 pub(crate) mod account_position;
 pub(crate) mod agg_trades;
 pub(crate) mod candles;
+pub(crate) mod lob;

--- a/src/arch/market_assets/exchange/binance/schemas/um_futures_ws/lob.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/um_futures_ws/lob.rs
@@ -1,0 +1,223 @@
+use serde::Deserialize;
+
+use crate::arch::{
+    market_assets::{
+        api_general::ts_to_micros, exchange::binance::api_utils::binance_fut_inst_to_cli,
+        market_core::Market,
+    },
+    strategy_base::handler::lob_events::{LobEventKind, LobLevel, LobLevelAction, LobSeq, WsLob},
+    traits::conversion::IntoWsData,
+};
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(transparent)]
+pub(crate) struct WsBookTickerBinanceUM(BinanceBookTicker);
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(transparent)]
+pub(crate) struct WsPartialDepthBinanceUM(BinanceDepthBook);
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(transparent)]
+pub(crate) struct WsDiffDepthBinanceUM(BinanceDepthBook);
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Deserialize)]
+struct BinanceBookTicker {
+    u: u64,
+    s: String,
+    b: String,
+    B: String,
+    a: String,
+    A: String,
+    T: u64,
+}
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Deserialize)]
+struct BinanceDepthBook {
+    T: u64,
+    s: String,
+    U: u64,
+    u: u64,
+    pu: Option<u64>,
+    b: Vec<BinanceLobLevel>,
+    a: Vec<BinanceLobLevel>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct BinanceLobLevel(String, String);
+
+impl BinanceBookTicker {
+    fn into_ws_lob(self) -> WsLob {
+        let update_id = self.u;
+
+        WsLob {
+            timestamp: ts_to_micros(self.T),
+            market: Market::BinanceUmFutures,
+            inst: binance_fut_inst_to_cli(&self.s),
+            event: LobEventKind::Bbo,
+            bids: vec![binance_bbo_level(&self.b, &self.B, update_id)],
+            asks: vec![binance_bbo_level(&self.a, &self.A, update_id)],
+            seq: Some(LobSeq {
+                prev: None,
+                first: Some(update_id),
+                last: Some(update_id),
+            }),
+            checksum: None,
+        }
+    }
+}
+
+impl BinanceDepthBook {
+    fn into_ws_lob(self, event: LobEventKind) -> WsLob {
+        let is_empty_update = self.b.is_empty() && self.a.is_empty();
+        let delete_on_zero = matches!(event, LobEventKind::Incremental);
+
+        WsLob {
+            timestamp: ts_to_micros(self.T),
+            market: Market::BinanceUmFutures,
+            inst: binance_fut_inst_to_cli(&self.s),
+            event: if matches!(event, LobEventKind::Incremental) && is_empty_update {
+                LobEventKind::Heartbeat
+            } else {
+                event
+            },
+            bids: self
+                .b
+                .into_iter()
+                .map(|level| binance_lob_level(level, delete_on_zero))
+                .collect(),
+            asks: self
+                .a
+                .into_iter()
+                .map(|level| binance_lob_level(level, delete_on_zero))
+                .collect(),
+            seq: Some(LobSeq {
+                prev: self.pu,
+                first: Some(self.U),
+                last: Some(self.u),
+            }),
+            checksum: None,
+        }
+    }
+}
+
+fn binance_bbo_level(price: &str, size: &str, update_id: u64) -> LobLevel {
+    let size = size.parse().unwrap_or_default();
+
+    LobLevel {
+        price: price.parse().unwrap_or_default(),
+        size,
+        action: if size == 0.0 {
+            LobLevelAction::Delete
+        } else {
+            LobLevelAction::Upsert
+        },
+        order_count: None,
+        level_update_id: Some(update_id),
+    }
+}
+
+fn binance_lob_level(level: BinanceLobLevel, delete_on_zero: bool) -> LobLevel {
+    let size = level.1.parse().unwrap_or_default();
+
+    LobLevel {
+        price: level.0.parse().unwrap_or_default(),
+        size,
+        action: if delete_on_zero && size == 0.0 {
+            LobLevelAction::Delete
+        } else {
+            LobLevelAction::Upsert
+        },
+        order_count: None,
+        level_update_id: None,
+    }
+}
+
+impl IntoWsData for WsBookTickerBinanceUM {
+    type Output = WsLob;
+
+    fn into_ws(self) -> Self::Output {
+        self.0.into_ws_lob()
+    }
+}
+
+impl IntoWsData for WsPartialDepthBinanceUM {
+    type Output = WsLob;
+
+    fn into_ws(self) -> Self::Output {
+        self.0.into_ws_lob(LobEventKind::Snapshot)
+    }
+}
+
+impl IntoWsData for WsDiffDepthBinanceUM {
+    type Output = WsLob;
+
+    fn into_ws(self) -> Self::Output {
+        self.0.into_ws_lob(LobEventKind::Incremental)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::arch::{
+        market_assets::{exchange::binance::binance_ws_msg::BinanceWsData, market_core::Market},
+        strategy_base::handler::lob_events::{LobEventKind, LobLevelAction},
+        traits::conversion::IntoWsData,
+    };
+
+    use super::*;
+
+    #[test]
+    fn parses_binance_um_book_ticker_as_bbo() {
+        let raw = r#"{
+            "e":"bookTicker",
+            "u":10708444522016,
+            "s":"BTCUSDT",
+            "b":"63405.40",
+            "B":"4.629",
+            "a":"63405.50",
+            "A":"2.357",
+            "T":1780563843114,
+            "E":1780563843114
+        }"#;
+
+        let parsed: BinanceWsData<WsBookTickerBinanceUM> = serde_json::from_str(raw).unwrap();
+        let lob = parsed.into_ws();
+
+        assert_eq!(lob.len(), 1);
+        assert!(matches!(lob[0].event, LobEventKind::Bbo));
+        assert_eq!(lob[0].market, Market::BinanceUmFutures);
+        assert_eq!(lob[0].inst, "BTC_USDT_PERP");
+        assert_eq!(lob[0].bids[0].price, 63405.40);
+        assert_eq!(lob[0].bids[0].level_update_id, Some(10708444522016));
+        assert_eq!(lob[0].seq.as_ref().unwrap().last, Some(10708444522016));
+    }
+
+    #[test]
+    fn parses_binance_um_diff_depth_zero_size_as_delete() {
+        let raw = r#"{
+            "e":"depthUpdate",
+            "E":1780563845145,
+            "T":1780563845143,
+            "s":"BTCUSDT",
+            "U":10708445053618,
+            "u":10708445072904,
+            "pu":10708445053562,
+            "b":[["50746.30","0.000"],["50748.80","0.002"]],
+            "a":[["63436.10","1.801"]]
+        }"#;
+
+        let parsed: BinanceWsData<WsDiffDepthBinanceUM> = serde_json::from_str(raw).unwrap();
+        let lob = parsed.into_ws();
+
+        assert_eq!(lob.len(), 1);
+        assert!(matches!(lob[0].event, LobEventKind::Incremental));
+        assert_eq!(lob[0].market, Market::BinanceUmFutures);
+        assert!(matches!(lob[0].bids[0].action, LobLevelAction::Delete));
+        assert!(matches!(lob[0].bids[1].action, LobLevelAction::Upsert));
+        assert_eq!(lob[0].seq.as_ref().unwrap().prev, Some(10708445053562));
+        assert_eq!(lob[0].seq.as_ref().unwrap().last, Some(10708445072904));
+    }
+}

--- a/src/arch/task_execution/register_ws.rs
+++ b/src/arch/task_execution/register_ws.rs
@@ -224,6 +224,10 @@ impl WsTaskBuilder {
                 self.ws_channel_hyperliquid(_ws_stream).await;
             },
             #[cfg(feature = "binance")]
+            Market::BinanceCmFutures => {
+                self.ws_channel_binance_cm(_ws_stream).await;
+            },
+            #[cfg(feature = "binance")]
             Market::BinanceUmFutures => {
                 self.ws_channel_binance_um(_ws_stream).await;
             },

--- a/src/arch/task_execution/register_ws/binance.rs
+++ b/src/arch/task_execution/register_ws/binance.rs
@@ -1,17 +1,28 @@
 use crate::arch::{
     market_assets::exchange::binance::{
         binance_ws_msg::BinanceWsData,
-        schemas::spot_ws::account_order::WsAccountOrderEnvelopeBinanceSpot,
-        schemas::um_futures_ws::{
-            account_bal_and_pos::WsBalAndPosBinanceUM, account_order::WsAccountOrderBinanceUM,
-            account_position::WsAccountPositionBinanceUM, agg_trades::WsAggTradeBinanceUM,
-            candles::WsCandleBinanceUM,
+        schemas::{
+            cm_futures_ws::lob::{
+                WsBookTickerBinanceCM, WsDiffDepthBinanceCM, WsPartialDepthBinanceCM,
+            },
+            spot_ws::account_order::WsAccountOrderEnvelopeBinanceSpot,
+            um_futures_ws::{
+                account_bal_and_pos::WsBalAndPosBinanceUM,
+                account_order::WsAccountOrderBinanceUM,
+                account_position::WsAccountPositionBinanceUM,
+                agg_trades::WsAggTradeBinanceUM,
+                candles::WsCandleBinanceUM,
+                lob::{WsBookTickerBinanceUM, WsDiffDepthBinanceUM, WsPartialDepthBinanceUM},
+            },
         },
     },
     strategy_base::handler::handler_core::{
-        find_acc_bal_pos, find_acc_order, find_acc_pos, find_candle, find_trade,
+        find_acc_bal_pos, find_acc_order, find_acc_pos, find_candle, find_lob, find_trade,
     },
-    task_execution::{task_general::LogLevel, task_ws::WsChannel},
+    task_execution::{
+        task_general::LogLevel,
+        task_ws::{LobParam, WsChannel},
+    },
 };
 
 use super::{WsStream, WsTaskBuilder};
@@ -74,6 +85,29 @@ impl WsTaskBuilder {
                     );
                 }
             },
+            WsChannel::Lob(lob_param) => {
+                if let Some(tx) = find_lob(&self.board_cast_channel) {
+                    match lob_param {
+                        Some(LobParam::Bbo { .. }) => {
+                            self.ws_loop::<BinanceWsData<WsBookTickerBinanceUM>>(tx, ws_stream)
+                                .await;
+                        },
+                        Some(LobParam::Snapshot { .. }) => {
+                            self.ws_loop::<BinanceWsData<WsPartialDepthBinanceUM>>(tx, ws_stream)
+                                .await;
+                        },
+                        None | Some(LobParam::Incremental { .. }) => {
+                            self.ws_loop::<BinanceWsData<WsDiffDepthBinanceUM>>(tx, ws_stream)
+                                .await;
+                        },
+                    }
+                } else {
+                    self.log(
+                        LogLevel::Warn,
+                        "No broadcast channel found for Binance UmFutures LOB",
+                    );
+                }
+            },
             c => {
                 self.log(
                     LogLevel::Warn,
@@ -100,6 +134,40 @@ impl WsTaskBuilder {
                 self.log(
                     LogLevel::Warn,
                     &format!("Unknown Binance Spot channel: {:?}", c),
+                );
+            },
+        };
+    }
+
+    pub(super) async fn ws_channel_binance_cm(&mut self, ws_stream: &mut WsStream) {
+        match &self.ws_info.ws_channel {
+            WsChannel::Lob(lob_param) => {
+                if let Some(tx) = find_lob(&self.board_cast_channel) {
+                    match lob_param {
+                        Some(LobParam::Bbo { .. }) => {
+                            self.ws_loop::<BinanceWsData<WsBookTickerBinanceCM>>(tx, ws_stream)
+                                .await;
+                        },
+                        Some(LobParam::Snapshot { .. }) => {
+                            self.ws_loop::<BinanceWsData<WsPartialDepthBinanceCM>>(tx, ws_stream)
+                                .await;
+                        },
+                        None | Some(LobParam::Incremental { .. }) => {
+                            self.ws_loop::<BinanceWsData<WsDiffDepthBinanceCM>>(tx, ws_stream)
+                                .await;
+                        },
+                    }
+                } else {
+                    self.log(
+                        LogLevel::Warn,
+                        "No broadcast channel found for Binance CmFutures LOB",
+                    );
+                }
+            },
+            c => {
+                self.log(
+                    LogLevel::Warn,
+                    &format!("Unknown Binance CM channel: {:?}", c),
                 );
             },
         };


### PR DESCRIPTION
## Summary
- add Binance UM/CM websocket LOB parsers for BBO, partial-depth snapshot, and diff-depth incremental streams
- map Binance LOB params to bookTicker/depth streams and wire UM/CM websocket task routing into the LOB broadcast channel
- make Binance UM/CM live instrument discovery respect InstrumentType and normalized Live state, so delivery futures are included when requested

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-features --all-targets
- cargo test --all-features
- live api_checker checks:
  - binance_ws_lob all 1
  - binance_ws_lob cm 1 BTC_USDT_PERP BTC_USD_FUT_260626
  - binance_ws_lob cm 1 BTC_USDT_PERP BTC_USD_FUT_260925
  - binance_live_instruments um perpetual/futures
  - binance_live_instruments cm perpetual/futures