### PR TITLE
feat: support Gate futures websocket LOB

### DIFF
--- a/src/arch/market_assets/exchange/gate/api_utils.rs
+++ b/src/arch/market_assets/exchange/gate/api_utils.rs
@@ -5,6 +5,7 @@ use serde_json::json;
 use tracing::error;
 
 use crate::arch::market_assets::{api_general::get_seconds_timestamp, base_data::SUBSCRIBE_LOWER};
+use crate::arch::task_execution::task_ws::LobFrequency;
 use crate::errors::{InfraError, InfraResult};
 
 pub const GATE_CHANNEL_ID_EXTRA_KEY: &str = "gate_channel_id";
@@ -67,6 +68,55 @@ pub fn gate_contracts_from_insts(insts: Option<&[String]>) -> InfraResult<Vec<St
         ));
     }
     Ok(list.iter().map(|s| cli_perp_to_gate_inst(s)).collect())
+}
+
+pub(crate) fn gate_lob_depth(depth: &Option<u16>) -> InfraResult<u16> {
+    match depth.as_ref().copied() {
+        None => Ok(20),
+        Some(depth @ (20 | 50 | 100)) => Ok(depth),
+        Some(depth) => Err(InfraError::ApiCliError(format!(
+            "Gate futures LOB supports only 20, 50, or 100 levels: {}",
+            depth
+        ))),
+    }
+}
+
+pub(crate) fn gate_lob_bbo_frequency(frequency: &Option<LobFrequency>) -> InfraResult<()> {
+    match frequency {
+        None | Some(LobFrequency::Realtime) => Ok(()),
+        Some(freq) => Err(InfraError::ApiCliError(format!(
+            "Gate futures book ticker does not support requested frequency: {:?}",
+            freq
+        ))),
+    }
+}
+
+pub(crate) fn gate_lob_snapshot_frequency(frequency: &Option<LobFrequency>) -> InfraResult<()> {
+    match frequency {
+        None => Ok(()),
+        Some(freq) => Err(InfraError::ApiCliError(format!(
+            "Gate futures order book snapshot does not support frequency: {:?}",
+            freq
+        ))),
+    }
+}
+
+pub(crate) fn gate_lob_update_frequency(
+    frequency: &Option<LobFrequency>,
+    depth: u16,
+) -> InfraResult<&'static str> {
+    match frequency {
+        None | Some(LobFrequency::Ms100) => Ok("100ms"),
+        Some(LobFrequency::Ms20) if depth == 20 => Ok("20ms"),
+        Some(LobFrequency::Ms20) => Err(InfraError::ApiCliError(format!(
+            "Gate futures 20ms LOB updates support only 20 levels, got {}",
+            depth
+        ))),
+        Some(freq) => Err(InfraError::ApiCliError(format!(
+            "Gate futures LOB updates support only 20ms or 100ms frequency: {:?}",
+            freq
+        ))),
+    }
 }
 
 pub fn infer_settle_from_inst(inst: &str) -> String {

--- a/src/arch/market_assets/exchange/gate/config_assets.rs
+++ b/src/arch/market_assets/exchange/gate/config_assets.rs
@@ -45,6 +45,9 @@ pub const GATE_WS_FUTURES_BALANCES: &str = "futures.balances";
 pub const GATE_WS_FUTURES_POSITIONS: &str = "futures.positions";
 pub const GATE_WS_FUTURES_TRADES: &str = "futures.trades";
 pub const GATE_WS_FUTURES_CANDLES: &str = "futures.candlesticks";
+pub const GATE_WS_FUTURES_BOOK_TICKER: &str = "futures.book_ticker";
+pub const GATE_WS_FUTURES_ORDER_BOOK: &str = "futures.order_book";
+pub const GATE_WS_FUTURES_ORDER_BOOK_UPDATE: &str = "futures.order_book_update";
 
 /// Delivery REST endpoints
 pub const GATE_DELIVERY_CONTRACTS: &str = "/api/v4/delivery/{settle}/contracts";

--- a/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
@@ -15,7 +15,7 @@ use crate::arch::{
         },
         base_data::{InstrumentType, MarginMode, OrderSide, OrderType, SUBSCRIBE_LOWER},
     },
-    task_execution::task_ws::{CandleParam, WsChannel},
+    task_execution::task_ws::{CandleParam, LobParam, WsChannel},
     traits::{
         conversion::IntoInfraVec,
         market_lob::{LobPrivateRest, LobPublicRest, LobWebsocket, MarketLobApi},
@@ -634,7 +634,7 @@ impl GateFuturesCli {
         match ws_channel {
             WsChannel::Candles(channel) => self._ws_subscribe_candle(channel, insts),
             WsChannel::Trades(_) => self._ws_subscribe_trades(insts),
-            WsChannel::Lob(_) => Err(InfraError::Unimplemented),
+            WsChannel::Lob(lob_param) => self._ws_subscribe_lob(lob_param, insts),
             _ => Err(InfraError::Unimplemented),
         }
     }
@@ -661,6 +661,48 @@ impl GateFuturesCli {
         ))
     }
 
+    fn _ws_subscribe_lob(
+        &self,
+        lob_param: &Option<LobParam>,
+        insts: Option<&[String]>,
+    ) -> InfraResult<String> {
+        match lob_param {
+            Some(LobParam::Bbo { frequency }) => {
+                gate_lob_bbo_frequency(frequency)?;
+                let contracts = gate_contracts_from_insts(insts)?;
+                Ok(ws_subscribe_msg_gate_futures(
+                    GATE_WS_FUTURES_BOOK_TICKER,
+                    contracts,
+                ))
+            },
+            Some(LobParam::Snapshot { depth, frequency }) => {
+                gate_lob_snapshot_frequency(frequency)?;
+                let contract = gate_first_contract(insts)?;
+                let depth = gate_lob_depth(depth)?;
+                Ok(ws_subscribe_msg_gate_futures(
+                    GATE_WS_FUTURES_ORDER_BOOK,
+                    vec![contract, depth.to_string(), "0".into()],
+                ))
+            },
+            None => {
+                let contract = gate_first_contract(insts)?;
+                Ok(ws_subscribe_msg_gate_futures(
+                    GATE_WS_FUTURES_ORDER_BOOK_UPDATE,
+                    vec![contract, "100ms".into(), "20".into()],
+                ))
+            },
+            Some(LobParam::Incremental { depth, frequency }) => {
+                let contract = gate_first_contract(insts)?;
+                let depth = gate_lob_depth(depth)?;
+                let frequency = gate_lob_update_frequency(frequency, depth)?;
+                Ok(ws_subscribe_msg_gate_futures(
+                    GATE_WS_FUTURES_ORDER_BOOK_UPDATE,
+                    vec![contract, frequency.into(), depth.to_string()],
+                ))
+            },
+        }
+    }
+
     fn _get_private_sub_msg(&self, channel: &WsChannel) -> InfraResult<String> {
         let topic = match channel {
             WsChannel::AccountOrders => GATE_WS_FUTURES_ORDERS,
@@ -668,5 +710,87 @@ impl GateFuturesCli {
             _ => return Err(InfraError::Unimplemented),
         };
         self.ws_subscribe_private(topic)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::arch::{
+        market_assets::exchange::gate::gate_futures_cli::GateFuturesCli,
+        task_execution::task_ws::{LobFrequency, LobParam, WsChannel},
+        traits::market_lob::LobWebsocket,
+    };
+
+    #[tokio::test]
+    async fn builds_gate_lob_subscription_messages() {
+        let cli = GateFuturesCli::default();
+        let insts = vec!["BTC_USDT_PERP".to_string(), "ETH_USDT_PERP".to_string()];
+
+        let bbo = cli
+            .get_public_sub_msg(
+                &WsChannel::Lob(Some(LobParam::Bbo {
+                    frequency: Some(LobFrequency::Realtime),
+                })),
+                Some(&insts),
+            )
+            .await
+            .unwrap();
+        assert!(bbo.contains("\"channel\":\"futures.book_ticker\""));
+        assert!(bbo.contains("\"BTC_USDT\""));
+        assert!(bbo.contains("\"ETH_USDT\""));
+
+        let snapshot = cli
+            .get_public_sub_msg(
+                &WsChannel::Lob(Some(LobParam::Snapshot {
+                    depth: Some(50),
+                    frequency: None,
+                })),
+                Some(&insts),
+            )
+            .await
+            .unwrap();
+        assert!(snapshot.contains("\"channel\":\"futures.order_book\""));
+        assert!(snapshot.contains("\"payload\":[\"BTC_USDT\",\"50\",\"0\"]"));
+
+        let incremental = cli
+            .get_public_sub_msg(
+                &WsChannel::Lob(Some(LobParam::Incremental {
+                    depth: Some(20),
+                    frequency: Some(LobFrequency::Ms20),
+                })),
+                Some(&insts),
+            )
+            .await
+            .unwrap();
+        assert!(incremental.contains("\"channel\":\"futures.order_book_update\""));
+        assert!(incremental.contains("\"payload\":[\"BTC_USDT\",\"20ms\",\"20\"]"));
+    }
+
+    #[tokio::test]
+    async fn rejects_unsupported_gate_lob_subscription_params() {
+        let cli = GateFuturesCli::default();
+        let insts = vec!["BTC_USDT_PERP".to_string()];
+
+        let err = cli
+            .get_public_sub_msg(
+                &WsChannel::Lob(Some(LobParam::Snapshot {
+                    depth: Some(20),
+                    frequency: Some(LobFrequency::Ms100),
+                })),
+                Some(&insts),
+            )
+            .await;
+        assert!(err.is_err());
+
+        let err = cli
+            .get_public_sub_msg(
+                &WsChannel::Lob(Some(LobParam::Incremental {
+                    depth: Some(50),
+                    frequency: Some(LobFrequency::Ms20),
+                })),
+                Some(&insts),
+            )
+            .await;
+        assert!(err.is_err());
     }
 }

--- a/src/arch/market_assets/exchange/gate/gate_ws_msg.rs
+++ b/src/arch/market_assets/exchange/gate/gate_ws_msg.rs
@@ -8,6 +8,7 @@ use crate::arch::traits::conversion::IntoWsData;
 #[serde(untagged)]
 pub enum GateWsData<T> {
     Channel(GateWsChannel<T>),
+    Single(GateWsSingleChannel<T>),
     Event(GateWsEvent),
 }
 
@@ -16,6 +17,13 @@ pub struct GateWsChannel<T> {
     pub channel: String,
     pub event: String,
     pub result: Vec<T>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct GateWsSingleChannel<T> {
+    pub channel: String,
+    pub event: String,
+    pub result: T,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -41,6 +49,7 @@ where
     fn into_ws(self) -> Self::Output {
         match self {
             GateWsData::Channel(c) => c.result.into_iter().map(|d| d.into_ws()).collect(),
+            GateWsData::Single(c) => vec![c.result.into_ws()],
             GateWsData::Event(res) => {
                 if let Some(err) = res.error {
                     warn!(

--- a/src/arch/market_assets/exchange/gate/schemas/futures_ws.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/futures_ws.rs
@@ -1,4 +1,5 @@
 pub(crate) mod account_order;
 pub(crate) mod account_position;
 pub(crate) mod candles;
+pub(crate) mod lob;
 pub(crate) mod trades;

--- a/src/arch/market_assets/exchange/gate/schemas/futures_ws/lob.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/futures_ws/lob.rs
@@ -1,0 +1,280 @@
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::arch::{
+    market_assets::{
+        api_general::{ts_to_micros, value_to_f64},
+        exchange::gate::api_utils::gate_fut_inst_to_cli,
+        market_core::Market,
+    },
+    strategy_base::handler::lob_events::{LobEventKind, LobLevel, LobLevelAction, LobSeq, WsLob},
+    traits::conversion::IntoWsData,
+};
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct WsBookTickerGateFutures {
+    t: u64,
+    u: u64,
+    s: String,
+    b: Value,
+    B: Value,
+    a: Value,
+    A: Value,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct WsOrderBookGateFutures {
+    t: u64,
+    id: u64,
+    contract: String,
+    asks: Vec<GateLobLevel>,
+    bids: Vec<GateLobLevel>,
+}
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct WsOrderBookUpdateGateFutures {
+    t: u64,
+    U: u64,
+    u: u64,
+    s: String,
+    a: Vec<GateLobLevel>,
+    b: Vec<GateLobLevel>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct GateLobLevel {
+    p: Value,
+    s: Value,
+}
+
+impl WsBookTickerGateFutures {
+    fn into_ws_lob(self) -> WsLob {
+        WsLob {
+            timestamp: ts_to_micros(self.t),
+            market: Market::GateFutures,
+            inst: gate_fut_inst_to_cli(&self.s),
+            event: LobEventKind::Bbo,
+            bids: vec![gate_bbo_level(self.b, self.B, self.u)],
+            asks: vec![gate_bbo_level(self.a, self.A, self.u)],
+            seq: Some(LobSeq {
+                prev: None,
+                first: Some(self.u),
+                last: Some(self.u),
+            }),
+            checksum: None,
+        }
+    }
+}
+
+impl WsOrderBookGateFutures {
+    fn into_ws_lob(self) -> WsLob {
+        WsLob {
+            timestamp: ts_to_micros(self.t),
+            market: Market::GateFutures,
+            inst: gate_fut_inst_to_cli(&self.contract),
+            event: LobEventKind::Snapshot,
+            bids: self
+                .bids
+                .into_iter()
+                .map(|level| gate_lob_level(level, false))
+                .collect(),
+            asks: self
+                .asks
+                .into_iter()
+                .map(|level| gate_lob_level(level, false))
+                .collect(),
+            seq: Some(LobSeq {
+                prev: None,
+                first: Some(self.id),
+                last: Some(self.id),
+            }),
+            checksum: None,
+        }
+    }
+}
+
+impl WsOrderBookUpdateGateFutures {
+    fn into_ws_lob(self) -> WsLob {
+        let is_empty_update = self.a.is_empty() && self.b.is_empty();
+
+        WsLob {
+            timestamp: ts_to_micros(self.t),
+            market: Market::GateFutures,
+            inst: gate_fut_inst_to_cli(&self.s),
+            event: if is_empty_update {
+                LobEventKind::Heartbeat
+            } else {
+                LobEventKind::Incremental
+            },
+            bids: self
+                .b
+                .into_iter()
+                .map(|level| gate_lob_level(level, true))
+                .collect(),
+            asks: self
+                .a
+                .into_iter()
+                .map(|level| gate_lob_level(level, true))
+                .collect(),
+            seq: Some(LobSeq {
+                prev: None,
+                first: Some(self.U),
+                last: Some(self.u),
+            }),
+            checksum: None,
+        }
+    }
+}
+
+fn gate_bbo_level(price: Value, size: Value, update_id: u64) -> LobLevel {
+    let size = value_to_f64(&size);
+
+    LobLevel {
+        price: value_to_f64(&price),
+        size,
+        action: if size == 0.0 {
+            LobLevelAction::Delete
+        } else {
+            LobLevelAction::Upsert
+        },
+        order_count: None,
+        level_update_id: Some(update_id),
+    }
+}
+
+fn gate_lob_level(level: GateLobLevel, delete_on_zero: bool) -> LobLevel {
+    let size = value_to_f64(&level.s);
+
+    LobLevel {
+        price: value_to_f64(&level.p),
+        size,
+        action: if delete_on_zero && size == 0.0 {
+            LobLevelAction::Delete
+        } else {
+            LobLevelAction::Upsert
+        },
+        order_count: None,
+        level_update_id: None,
+    }
+}
+
+impl IntoWsData for WsBookTickerGateFutures {
+    type Output = WsLob;
+
+    fn into_ws(self) -> WsLob {
+        self.into_ws_lob()
+    }
+}
+
+impl IntoWsData for WsOrderBookGateFutures {
+    type Output = WsLob;
+
+    fn into_ws(self) -> WsLob {
+        self.into_ws_lob()
+    }
+}
+
+impl IntoWsData for WsOrderBookUpdateGateFutures {
+    type Output = WsLob;
+
+    fn into_ws(self) -> WsLob {
+        self.into_ws_lob()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::arch::{
+        market_assets::exchange::gate::{
+            gate_ws_msg::GateWsData,
+            schemas::futures_ws::lob::{
+                WsBookTickerGateFutures, WsOrderBookGateFutures, WsOrderBookUpdateGateFutures,
+            },
+        },
+        strategy_base::handler::lob_events::{LobEventKind, LobLevelAction, WsLob},
+        traits::conversion::IntoWsData,
+    };
+
+    #[test]
+    fn parses_gate_book_ticker_as_bbo() {
+        let raw = json!({
+            "channel": "futures.book_ticker",
+            "event": "update",
+            "result": {
+                "t": 1780569310140_u64,
+                "u": 114427040898_u64,
+                "s": "BTC_USDT",
+                "b": "62706.4",
+                "B": 3335,
+                "a": "62706.5",
+                "A": 8275
+            }
+        });
+
+        let data: GateWsData<WsBookTickerGateFutures> = serde_json::from_value(raw).unwrap();
+        let lob: Vec<WsLob> = data.into_ws();
+
+        assert_eq!(lob.len(), 1);
+        assert!(matches!(lob[0].event, LobEventKind::Bbo));
+        assert_eq!(lob[0].inst, "BTC_USDT_PERP");
+        assert_eq!(lob[0].timestamp, 1_780_569_310_140_000);
+        assert_eq!(lob[0].bids[0].price, 62_706.4);
+        assert_eq!(lob[0].bids[0].size, 3335.0);
+        assert_eq!(lob[0].bids[0].level_update_id, Some(114427040898));
+        assert_eq!(lob[0].seq.as_ref().unwrap().first, Some(114427040898));
+    }
+
+    #[test]
+    fn parses_gate_order_book_snapshot() {
+        let raw = json!({
+            "channel": "futures.order_book",
+            "event": "all",
+            "result": {
+                "t": 1780569310995_u64,
+                "id": 114427042721_u64,
+                "contract": "BTC_USDT",
+                "asks": [{"p": "62698.1", "s": 10046}],
+                "bids": [{"p": "62698", "s": 144730}],
+                "l": "20"
+            }
+        });
+
+        let data: GateWsData<WsOrderBookGateFutures> = serde_json::from_value(raw).unwrap();
+        let lob: Vec<WsLob> = data.into_ws();
+
+        assert_eq!(lob.len(), 1);
+        assert!(matches!(lob[0].event, LobEventKind::Snapshot));
+        assert_eq!(lob[0].seq.as_ref().unwrap().last, Some(114427042721));
+        assert!(matches!(lob[0].asks[0].action, LobLevelAction::Upsert));
+    }
+
+    #[test]
+    fn parses_gate_order_book_incremental_delete() {
+        let raw = json!({
+            "channel": "futures.order_book_update",
+            "event": "update",
+            "result": {
+                "t": 1780569312795_u64,
+                "U": 114427044935_u64,
+                "u": 114427045214_u64,
+                "s": "BTC_USDT",
+                "a": [{"p": "62706.5", "s": 0}],
+                "b": [],
+                "l": "20"
+            }
+        });
+
+        let data: GateWsData<WsOrderBookUpdateGateFutures> = serde_json::from_value(raw).unwrap();
+        let lob: Vec<WsLob> = data.into_ws();
+
+        assert_eq!(lob.len(), 1);
+        assert!(matches!(lob[0].event, LobEventKind::Incremental));
+        assert_eq!(lob[0].seq.as_ref().unwrap().first, Some(114427044935));
+        assert_eq!(lob[0].seq.as_ref().unwrap().last, Some(114427045214));
+        assert!(matches!(lob[0].asks[0].action, LobLevelAction::Delete));
+    }
+}

--- a/src/arch/task_execution/register_ws/gate.rs
+++ b/src/arch/task_execution/register_ws/gate.rs
@@ -3,13 +3,20 @@ use crate::arch::{
         gate_ws_msg::GateWsData,
         schemas::futures_ws::{
             account_order::WsAccountOrderGateFutures,
-            account_position::WsAccountPositionGateFutures, candles::WsCandleGateFutures,
+            account_position::WsAccountPositionGateFutures,
+            candles::WsCandleGateFutures,
+            lob::{WsBookTickerGateFutures, WsOrderBookGateFutures, WsOrderBookUpdateGateFutures},
             trades::WsTradeGateFutures,
         },
         schemas::spot_ws::account_order::WsAccountOrderGateSpot,
     },
-    strategy_base::handler::handler_core::{find_acc_order, find_acc_pos, find_candle, find_trade},
-    task_execution::{task_general::LogLevel, task_ws::WsChannel},
+    strategy_base::handler::handler_core::{
+        find_acc_order, find_acc_pos, find_candle, find_lob, find_trade,
+    },
+    task_execution::{
+        task_general::LogLevel,
+        task_ws::{LobParam, WsChannel},
+    },
 };
 
 use super::{WsStream, WsTaskBuilder};
@@ -58,6 +65,29 @@ impl WsTaskBuilder {
                     self.log(
                         LogLevel::Warn,
                         "No broadcast channel found for Gate Futures Trades",
+                    );
+                }
+            },
+            WsChannel::Lob(lob_param) => {
+                if let Some(tx) = find_lob(&self.board_cast_channel) {
+                    match lob_param {
+                        Some(LobParam::Bbo { .. }) => {
+                            self.ws_loop::<GateWsData<WsBookTickerGateFutures>>(tx, ws_stream)
+                                .await;
+                        },
+                        Some(LobParam::Snapshot { .. }) => {
+                            self.ws_loop::<GateWsData<WsOrderBookGateFutures>>(tx, ws_stream)
+                                .await;
+                        },
+                        None | Some(LobParam::Incremental { .. }) => {
+                            self.ws_loop::<GateWsData<WsOrderBookUpdateGateFutures>>(tx, ws_stream)
+                                .await;
+                        },
+                    }
+                } else {
+                    self.log(
+                        LogLevel::Warn,
+                        "No broadcast channel found for Gate Futures LOB",
                     );
                 }
             },

--- a/src/arch/task_execution/task_ws.rs
+++ b/src/arch/task_execution/task_ws.rs
@@ -131,6 +131,8 @@ pub enum LobFrequency {
     Realtime,
     /// Ten millisecond updates.
     Ms10,
+    /// Twenty millisecond updates.
+    Ms20,
     /// One hundred millisecond updates.
     Ms100,
     /// Two hundred fifty millisecond updates.


### PR DESCRIPTION
Summary:
- add Gate futures websocket LOB subscription mapping for BBO, snapshot, and incremental feeds
- parse Gate futures book_ticker, order_book, and order_book_update payloads into normalized WsLob events
- support Gate single-object websocket result envelopes while preserving existing vector-result parsing
- add LobFrequency::Ms20 for Gate 20ms incremental book updates

Live Gate checks:
- futures.book_ticker accepts single and multi-contract payloads
- futures.order_book accepts depths 20, 50, and 100 with accuracy "0"
- futures.order_book rejects "100ms" as snapshot accuracy
- futures.order_book_update accepts 100ms at depths 20, 50, and 100
- futures.order_book_update accepts 20ms only at depth 20 and rejects 20ms + 50

Tests:
- cargo fmt --all -- --check
- cargo clippy --all-features --all-targets
- cargo test --all-features