### PR TITLE
fix: handle single-instrument ws subscription payloads

### DIFF
--- a/src/arch/market_assets/exchange/gate/api_utils.rs
+++ b/src/arch/market_assets/exchange/gate/api_utils.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use tracing::error;
+use tracing::{error, warn};
 
 use crate::arch::market_assets::{api_general::get_seconds_timestamp, base_data::SUBSCRIBE_LOWER};
 use crate::arch::task_execution::task_ws::LobFrequency;
@@ -52,8 +52,18 @@ pub fn cli_perp_to_gate_inst(symbol: &str) -> String {
 }
 
 pub fn gate_first_contract(insts: Option<&[String]>) -> InfraResult<String> {
-    let inst = insts
-        .and_then(|list| list.first())
+    let list = insts
+        .ok_or_else(|| InfraError::ApiCliError("Gate futures ws requires one instrument".into()))?;
+    if list.len() > 1 {
+        warn!(
+            "Gate futures ws supports one instrument for this channel; got {} instruments: {:?}; using the first one",
+            list.len(),
+            list
+        );
+    }
+
+    let inst = list
+        .first()
         .ok_or_else(|| InfraError::ApiCliError("Gate futures ws requires one instrument".into()))?;
     Ok(cli_perp_to_gate_inst(inst))
 }

--- a/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
@@ -1,7 +1,7 @@
 use reqwest::Client;
 use serde_json::{Value, json};
 use std::{collections::HashMap, sync::Arc};
-use tracing::error;
+use tracing::{error, warn};
 
 use crate::arch::{
     market_assets::{
@@ -678,22 +678,24 @@ impl HyperliquidCli {
             ));
         }
 
-        let msgs: InfraResult<Vec<String>> = insts
-            .iter()
-            .map(|inst| {
-                let coin = self._inst_to_trade_coin(inst)?;
-                Ok(json!({
-                    "method": "subscribe",
-                    "subscription": {
-                        "type": "trades",
-                        "coin": coin.to_string(),
-                    }
-                })
-                .to_string())
-            })
-            .collect();
+        if insts.len() > 1 {
+            warn!(
+                "Hyperliquid trades ws supports one instrument per subscription message; got {} instruments: {:?}",
+                insts.len(),
+                insts
+            );
+        }
 
-        Ok(msgs?.join("\n"))
+        let inst = insts.first().expect("checked non-empty insts");
+        let coin = self._inst_to_trade_coin(inst)?;
+        Ok(json!({
+            "method": "subscribe",
+            "subscription": {
+                "type": "trades",
+                "coin": coin.to_string(),
+            }
+        })
+        .to_string())
     }
 
     fn _ws_subscribe_lob(
@@ -711,23 +713,25 @@ impl HyperliquidCli {
             ));
         }
 
-        let subscription_type = hyperliquid_lob_subscription_type(lob_param)?;
-        let msgs: InfraResult<Vec<String>> = insts
-            .iter()
-            .map(|inst| {
-                let coin = self._inst_to_trade_coin(inst)?;
-                Ok(json!({
-                    "method": "subscribe",
-                    "subscription": {
-                        "type": subscription_type,
-                        "coin": coin.to_string(),
-                    }
-                })
-                .to_string())
-            })
-            .collect();
+        if insts.len() > 1 {
+            warn!(
+                "Hyperliquid lob ws supports one instrument per subscription message; got {} instruments: {:?}",
+                insts.len(),
+                insts
+            );
+        }
 
-        Ok(msgs?.join("\n"))
+        let subscription_type = hyperliquid_lob_subscription_type(lob_param)?;
+        let inst = insts.first().expect("checked non-empty insts");
+        let coin = self._inst_to_trade_coin(inst)?;
+        Ok(json!({
+            "method": "subscribe",
+            "subscription": {
+                "type": subscription_type,
+                "coin": coin.to_string(),
+            }
+        })
+        .to_string())
     }
 
     fn _inst_to_trade_coin(&self, inst: &str) -> InfraResult<String> {


### PR DESCRIPTION
Summary:\n- Generate Hyperliquid trades/LOB websocket subscriptions from the first instrument only instead of newline-joining multiple JSON payloads.\n- Warn when Hyperliquid or Gate single-instrument websocket channels receive multiple instruments.\n\nVerification:\n- cargo check --features hyperliquid\n- cargo check --features gate\n- cargo run -- hyperliquid_ws_lob bbo BTC_USDC_PERP ETH_USDC_PERP