### PR TITLE
chore: bump extrema_infra crate version to 0.1.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2024"
 
 readme = "README.md"


### PR DESCRIPTION
Summary:\n- Bump extrema_infra crate version from 0.1.11 to 0.1.12 for the next crates.io release.\n\nVerification:\n- cargo check\n- cargo package --allow-dirty --no-verify