### PR TITLE
chore: update polars dependency to 0.54.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ rustls = { version = "0.23.40", features = ["aws-lc-rs"] }
 # IPC / Model inference / Data processing
 zeromq = { version = "0.6.0", optional = true }
 tract-onnx = { version = "0.23.0", optional = true }
-polars = { version = "0.53.0", default-features = false, optional = true }
+polars = { version = "0.54.4", default-features = false, optional = true }
 
 # Logging & Tracing
 tracing = "0.1.44"


### PR DESCRIPTION
## Summary
- update the optional polars dependency constraint from 0.53.0 to 0.54.4
- keep default features disabled and the dependency optional

## Verification
- cargo test --all-features --locked
- cargo clippy --all-targets --all-features --locked -- -D warnings