### PR TITLE
feat: add candle REST support

### DIFF
--- a/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
+++ b/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
@@ -26,6 +26,7 @@ use super::{
         account_balance::RestAccountBalBinanceUM,
         account_config::RestAccountConfigBinanceUM,
         account_position_risk::RestAccountPosRiskBinanceUM,
+        candle::RestCandleBinanceUM,
         exchange_info::RestExchangeInfoBinanceUM,
         funding_rate::RestFundingRateBinanceUM,
         funding_rate_info::RestFundingInfoBinanceUM,
@@ -61,6 +62,18 @@ impl LobPublicRest for BinanceUmCli {
         inst_type: Option<InstrumentType>,
     ) -> InfraResult<Vec<TickerData>> {
         self._get_tickers(insts, inst_type).await
+    }
+
+    async fn get_candles(
+        &self,
+        inst: &str,
+        interval: CandleParam,
+        limit: Option<u32>,
+        start_time_us: Option<u64>,
+        end_time_us: Option<u64>,
+    ) -> InfraResult<Vec<CandleData>> {
+        self._get_candles(inst, interval, limit, start_time_us, end_time_us)
+            .await
     }
 
     async fn get_instrument_info(
@@ -376,6 +389,49 @@ impl BinanceUmCli {
             .collect();
 
         Ok(candles)
+    }
+
+    async fn _get_candles(
+        &self,
+        inst: &str,
+        interval: CandleParam,
+        limit: Option<u32>,
+        start_time_us: Option<u64>,
+        end_time_us: Option<u64>,
+    ) -> InfraResult<Vec<CandleData>> {
+        let mut params = vec![
+            format!("symbol={}", cli_perp_to_pure_uppercase(inst)),
+            format!("interval={}", interval.as_str()),
+        ];
+        if let Some(limit) = limit {
+            params.push(format!("limit={limit}"));
+        }
+        if let Some(start_time_us) = start_time_us {
+            params.push(format!("startTime={}", start_time_us / 1_000));
+        }
+        if let Some(end_time_us) = end_time_us {
+            params.push(format!("endTime={}", end_time_us / 1_000));
+        }
+
+        let url = format!(
+            "{}{}?{}",
+            BINANCE_UM_FUTURES_BASE_URL,
+            BINANCE_UM_FUTURES_KLINES,
+            params.join("&")
+        );
+
+        let response = self.client.get(url).send().await?;
+        let res: RestResBinance<RestCandleBinanceUM> =
+            parse_json_response("BinanceUmFutures candles", response).await?;
+
+        let mut data: Vec<CandleData> = res
+            .into_vec()?
+            .into_iter()
+            .map(|entry| entry.into_candle_data(inst))
+            .collect();
+        data.sort_by_key(|candle| candle.timestamp);
+
+        Ok(data)
     }
 
     pub async fn get_premium_index(

--- a/src/arch/market_assets/exchange/binance/config_assets.rs
+++ b/src/arch/market_assets/exchange/binance/config_assets.rs
@@ -33,6 +33,7 @@ pub const BINANCE_UM_FUTURES_ACCOUNT_CONFIG: &str = "/fapi/v1/accountConfig";
 pub const BINANCE_UM_FUTURES_SYMBOL_CONFIG: &str = "/fapi/v1/symbolConfig";
 pub const BINANCE_UM_FUTURES_POSITION_RISK_INFO: &str = "/fapi/v3/positionRisk";
 pub const BINANCE_UM_FUTURES_TICKERS: &str = "/fapi/v2/ticker/price";
+pub const BINANCE_UM_FUTURES_KLINES: &str = "/fapi/v1/klines";
 pub const BINANCE_UM_FUTURES_PREMIUM_INDEX_KLINES: &str = "/fapi/v1/premiumIndexKlines";
 pub const BINANCE_UM_FUTURES_PREMIUM_INDEX: &str = "/fapi/v1/premiumIndex";
 pub const BINANCE_UM_FUTURES_FUNDING_INFO: &str = "/fapi/v1/fundingInfo";

--- a/src/arch/market_assets/exchange/binance/schemas/um_futures_rest.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/um_futures_rest.rs
@@ -1,6 +1,7 @@
 pub mod account_balance;
 pub mod account_config;
 pub mod account_position_risk;
+pub mod candle;
 pub mod exchange_info;
 pub mod funding_rate;
 pub mod funding_rate_info;

--- a/src/arch/market_assets/exchange/binance/schemas/um_futures_rest/candle.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/um_futures_rest/candle.rs
@@ -1,0 +1,25 @@
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::arch::market_assets::{
+    api_data::price_data::CandleData,
+    api_general::{ts_to_micros, value_to_f64},
+};
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestCandleBinanceUM(pub Vec<Value>);
+
+impl RestCandleBinanceUM {
+    pub fn into_candle_data(self, inst: &str) -> CandleData {
+        let values = self.0;
+        CandleData {
+            timestamp: ts_to_micros(values.first().and_then(Value::as_u64).unwrap_or_default()),
+            inst: inst.to_string(),
+            open: values.get(1).map(value_to_f64).unwrap_or_default(),
+            high: values.get(2).map(value_to_f64).unwrap_or_default(),
+            low: values.get(3).map(value_to_f64).unwrap_or_default(),
+            close: values.get(4).map(value_to_f64).unwrap_or_default(),
+            volume: values.get(5).map(value_to_f64).unwrap_or_default(),
+        }
+    }
+}

--- a/src/arch/market_assets/exchange/gate/config_assets.rs
+++ b/src/arch/market_assets/exchange/gate/config_assets.rs
@@ -32,6 +32,7 @@ pub const GATE_UNI_SUB_ACCOUNTS: &str = "/api/v4/sub_accounts";
 pub const GATE_FUTURES_CONTRACTS: &str = "/api/v4/futures/{settle}/contracts";
 pub const GATE_FUTURES_CONTRACT: &str = "/api/v4/futures/{settle}/contracts/{contract}";
 pub const GATE_FUTURES_TICKERS: &str = "/api/v4/futures/{settle}/tickers";
+pub const GATE_FUTURES_CANDLESTICKS: &str = "/api/v4/futures/{settle}/candlesticks";
 pub const GATE_FUTURES_PREMIUM_INDEX: &str = "/api/v4/futures/{settle}/premium_index";
 pub const GATE_FUTURES_FUNDING_RATE: &str = "/api/v4/futures/{settle}/funding_rate";
 pub const GATE_FUTURES_SET_POSITION_MODE: &str = "/api/v4/futures/{settle}/set_position_mode";

--- a/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
@@ -7,7 +7,7 @@ use crate::arch::{
     market_assets::{
         api_data::{
             account_data::{HistoOrderData, OrderAckData, PositionData},
-            price_data::TickerData,
+            price_data::{CandleData, TickerData},
             utils_data::{FundingRateData, FundingRateInfo, InstrumentInfo},
         },
         api_general::{
@@ -29,9 +29,10 @@ use super::{
     config_assets::*,
     gate_rest_msg::RestResGate,
     schemas::futures_rest::{
-        account_position::RestAccountPosGateFutures, contract_futures::RestContractGateFutures,
-        funding_rate::RestFundingRateGateFutures, order::RestFuturesOrderGateFutures,
-        order_history::RestFuturesOrderHistoryGateFutures, ticker::RestTickerGateFutures,
+        account_position::RestAccountPosGateFutures, candle::RestCandleGateFutures,
+        contract_futures::RestContractGateFutures, funding_rate::RestFundingRateGateFutures,
+        order::RestFuturesOrderGateFutures, order_history::RestFuturesOrderHistoryGateFutures,
+        ticker::RestTickerGateFutures,
     },
 };
 
@@ -56,6 +57,18 @@ impl LobPublicRest for GateFuturesCli {
         inst_type: Option<InstrumentType>,
     ) -> InfraResult<Vec<TickerData>> {
         self._get_tickers(insts, inst_type).await
+    }
+
+    async fn get_candles(
+        &self,
+        inst: &str,
+        interval: CandleParam,
+        limit: Option<u32>,
+        start_time_us: Option<u64>,
+        end_time_us: Option<u64>,
+    ) -> InfraResult<Vec<CandleData>> {
+        self._get_candles(inst, interval, limit, start_time_us, end_time_us)
+            .await
     }
 
     async fn get_instrument_info(
@@ -393,6 +406,56 @@ impl GateFuturesCli {
                     })
                     .map(TickerData::from),
             );
+        }
+
+        Ok(data)
+    }
+
+    async fn _get_candles(
+        &self,
+        inst: &str,
+        interval: CandleParam,
+        limit: Option<u32>,
+        start_time_us: Option<u64>,
+        end_time_us: Option<u64>,
+    ) -> InfraResult<Vec<CandleData>> {
+        let settle = infer_settle_from_inst(inst);
+        let endpoint = GATE_FUTURES_CANDLESTICKS.replace("{settle}", &settle);
+        let mut params = vec![
+            format!("contract={}", cli_perp_to_gate_inst(inst)),
+            format!("interval={}", interval.as_str()),
+        ];
+        let has_time_window = start_time_us.is_some() || end_time_us.is_some();
+        if !has_time_window && let Some(limit) = limit {
+            params.push(format!("limit={limit}"));
+        }
+        if let Some(start_time_us) = start_time_us {
+            params.push(format!("from={}", start_time_us / 1_000_000));
+        }
+        if let Some(end_time_us) = end_time_us {
+            params.push(format!("to={}", end_time_us / 1_000_000));
+        }
+
+        let url = format!("{}{}?{}", GATE_BASE_URL, endpoint, params.join("&"));
+
+        let response = self.client.get(url).send().await?;
+        let res: RestResGate<RestCandleGateFutures> =
+            parse_json_response("GateFutures candles", response).await?;
+
+        let mut data: Vec<CandleData> = res
+            .into_vec()?
+            .into_iter()
+            .map(|entry| entry.into_candle_data(inst))
+            .filter(|entry| start_time_us.is_none_or(|start| entry.timestamp >= start))
+            .filter(|entry| end_time_us.is_none_or(|end| entry.timestamp <= end))
+            .collect();
+        data.sort_by_key(|candle| candle.timestamp);
+
+        if has_time_window
+            && let Some(limit) = limit
+            && data.len() > limit as usize
+        {
+            data.drain(..data.len() - limit as usize);
         }
 
         Ok(data)

--- a/src/arch/market_assets/exchange/gate/schemas/futures_rest.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/futures_rest.rs
@@ -1,4 +1,5 @@
 pub mod account_position;
+pub mod candle;
 pub mod contract_futures;
 pub mod funding_rate;
 pub mod leverage;

--- a/src/arch/market_assets/exchange/gate/schemas/futures_rest/candle.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/futures_rest/candle.rs
@@ -1,0 +1,32 @@
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::arch::market_assets::{
+    api_data::price_data::CandleData,
+    api_general::{ts_to_micros, value_to_f64},
+};
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestCandleGateFutures {
+    pub t: u64,
+    pub o: Value,
+    pub h: Value,
+    pub l: Value,
+    pub c: Value,
+    #[serde(default)]
+    pub v: Value,
+}
+
+impl RestCandleGateFutures {
+    pub fn into_candle_data(self, inst: &str) -> CandleData {
+        CandleData {
+            timestamp: ts_to_micros(self.t),
+            inst: inst.to_string(),
+            open: value_to_f64(&self.o),
+            high: value_to_f64(&self.h),
+            low: value_to_f64(&self.l),
+            close: value_to_f64(&self.c),
+            volume: value_to_f64(&self.v),
+        }
+    }
+}

--- a/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
@@ -7,13 +7,15 @@ use crate::arch::{
     market_assets::{
         api_data::{
             account_data::{BalanceData, HistoOrderData, OrderAckData, PositionData},
-            price_data::TickerData,
+            price_data::{CandleData, TickerData},
             utils_data::{FundingRateData, FundingRateInfo, InstrumentInfo},
         },
-        api_general::{OrderParams, get_micros_timestamp, parse_json_response},
+        api_general::{
+            OrderParams, get_micros_timestamp, get_mills_timestamp, parse_json_response,
+        },
         base_data::{InstrumentType, MarginMode},
     },
-    task_execution::task_ws::{LobParam, TradesParam, WsChannel},
+    task_execution::task_ws::{CandleParam, LobParam, TradesParam, WsChannel},
     traits::{
         conversion::IntoInfraVec,
         market_lob::{LobPrivateRest, LobPublicRest, LobWebsocket, MarketLobApi},
@@ -28,7 +30,7 @@ use super::{
     hyperliquid_rest_msg::RestResHyperliquid,
     schemas::rest::{
         all_mids::RestAllMidsHyperliquid, asset_ctxs::RestMetaAndAssetCtxsHyperliquid,
-        clearinghouse_state::RestClearinghouseStateHyperliquid,
+        candle::RestCandleHyperliquid, clearinghouse_state::RestClearinghouseStateHyperliquid,
         funding_history::RestFundingHistoryHyperliquid, meta::RestMetaHyperliquid,
         order_status::RestOrderStatusHyperliquid, perp_dexs::RestPerpDexHyperliquid,
         spot_clearinghouse_state::RestSpotClearinghouseStateHyperliquid,
@@ -58,6 +60,18 @@ impl LobPublicRest for HyperliquidCli {
         inst_type: Option<InstrumentType>,
     ) -> InfraResult<Vec<TickerData>> {
         self._get_tickers(insts, inst_type).await
+    }
+
+    async fn get_candles(
+        &self,
+        inst: &str,
+        interval: CandleParam,
+        limit: Option<u32>,
+        start_time_us: Option<u64>,
+        end_time_us: Option<u64>,
+    ) -> InfraResult<Vec<CandleData>> {
+        self._get_candles(inst, interval, limit, start_time_us, end_time_us)
+            .await
     }
 
     async fn get_instrument_info(
@@ -128,6 +142,8 @@ impl LobWebsocket for HyperliquidCli {
 }
 
 impl HyperliquidCli {
+    const DEFAULT_CANDLE_LIMIT: u32 = 7;
+
     pub fn new(shared_client: Arc<Client>) -> Self {
         Self {
             client: shared_client,
@@ -282,6 +298,52 @@ impl HyperliquidCli {
             .into_iter()
             .map(|entry| entry.into_funding_rate_data(&quote))
             .collect();
+
+        Ok(data)
+    }
+
+    async fn _get_candles(
+        &self,
+        inst: &str,
+        interval: CandleParam,
+        limit: Option<u32>,
+        start_time_us: Option<u64>,
+        end_time_us: Option<u64>,
+    ) -> InfraResult<Vec<CandleData>> {
+        let normalized_inst = normalize_hyperliquid_cli_inst(inst);
+        self._ensure_perp_quote_matches(&normalized_inst)?;
+        let quote = hyperliquid_cli_perp_quote(&normalized_inst)?;
+        let coin = self._inst_to_raw_perp_coin(&normalized_inst)?;
+        let limit = limit.unwrap_or(Self::DEFAULT_CANDLE_LIMIT);
+        let interval_ms = candle_interval_millis(&interval)?;
+        let end_time = end_time_us
+            .map(|end| end / 1_000)
+            .unwrap_or_else(get_mills_timestamp);
+        let start_time = start_time_us
+            .map(|start| start / 1_000)
+            .unwrap_or_else(|| end_time.saturating_sub(limit as u64 * interval_ms));
+
+        let body = json!({
+            "type": "candleSnapshot",
+            "req": {
+                "coin": coin,
+                "interval": interval.as_str(),
+                "startTime": start_time,
+                "endTime": end_time,
+            },
+        });
+        let res: RestResHyperliquid<RestCandleHyperliquid> = self._post_info_raw(&body).await?;
+
+        let mut data: Vec<CandleData> = res
+            .into_vec()?
+            .into_iter()
+            .map(|entry| entry.into_candle_data(&quote))
+            .collect();
+        data.sort_by_key(|candle| candle.timestamp);
+
+        if data.len() > limit as usize {
+            data.drain(..data.len() - limit as usize);
+        }
 
         Ok(data)
     }
@@ -908,5 +970,22 @@ impl HyperliquidCli {
         } else {
             hyperliquid_index_to_asset_id(InstrumentType::Spot, index)
         }
+    }
+}
+
+fn candle_interval_millis(interval: &CandleParam) -> InfraResult<u64> {
+    match interval {
+        CandleParam::OneSecond => Ok(1_000),
+        CandleParam::OneMinute => Ok(60_000),
+        CandleParam::FiveMinutes => Ok(5 * 60_000),
+        CandleParam::FifteenMinutes => Ok(15 * 60_000),
+        CandleParam::OneHour => Ok(60 * 60_000),
+        CandleParam::FourHours => Ok(4 * 60 * 60_000),
+        CandleParam::OneDay => Ok(24 * 60 * 60_000),
+        CandleParam::OneWeek => Ok(7 * 24 * 60 * 60_000),
+        CandleParam::Custom(value) => Err(InfraError::ApiCliError(format!(
+            "Hyperliquid candle interval duration is unknown for custom interval: {}",
+            value
+        ))),
     }
 }

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest.rs
@@ -1,5 +1,6 @@
 pub mod all_mids;
 pub mod asset_ctxs;
+pub mod candle;
 pub mod clearinghouse_state;
 pub mod funding_history;
 pub mod meta;

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest/candle.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest/candle.rs
@@ -1,0 +1,35 @@
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::arch::market_assets::{
+    api_data::price_data::CandleData,
+    api_general::{ts_to_micros, value_to_f64},
+    exchange::hyperliquid::api_utils::hyperliquid_perp_to_cli,
+};
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestCandleHyperliquid {
+    pub t: u64,
+    pub s: String,
+    pub o: Value,
+    pub c: Value,
+    pub h: Value,
+    pub l: Value,
+    #[serde(default)]
+    pub v: Value,
+}
+
+impl RestCandleHyperliquid {
+    pub fn into_candle_data(self, quote: &str) -> CandleData {
+        CandleData {
+            timestamp: ts_to_micros(self.t),
+            inst: hyperliquid_perp_to_cli(&self.s, quote),
+            open: value_to_f64(&self.o),
+            high: value_to_f64(&self.h),
+            low: value_to_f64(&self.l),
+            close: value_to_f64(&self.c),
+            volume: value_to_f64(&self.v),
+        }
+    }
+}

--- a/src/arch/market_assets/exchange/lob_clients.rs
+++ b/src/arch/market_assets/exchange/lob_clients.rs
@@ -70,17 +70,51 @@ impl LobPublicRest for LobClients {
         }
     }
 
-    async fn get_candles(&self, inst: &str, interval: CandleParam) -> InfraResult<Vec<CandleData>> {
+    async fn get_candles(
+        &self,
+        inst: &str,
+        interval: CandleParam,
+        limit: Option<u32>,
+        start_time_us: Option<u64>,
+        end_time_us: Option<u64>,
+    ) -> InfraResult<Vec<CandleData>> {
         match self {
-            LobClients::Hyperliquid(c) => c.get_candles(inst, interval).await,
-            LobClients::BinanceCm(c) => c.get_candles(inst, interval).await,
-            LobClients::BinanceSpot(c) => c.get_candles(inst, interval).await,
-            LobClients::BinanceUm(c) => c.get_candles(inst, interval).await,
-            LobClients::GateDelivery(c) => c.get_candles(inst, interval).await,
-            LobClients::GateFutures(c) => c.get_candles(inst, interval).await,
-            LobClients::GateSpot(c) => c.get_candles(inst, interval).await,
-            LobClients::GateUni(c) => c.get_candles(inst, interval).await,
-            LobClients::Okx(c) => c.get_candles(inst, interval).await,
+            LobClients::Hyperliquid(c) => {
+                c.get_candles(inst, interval, limit, start_time_us, end_time_us)
+                    .await
+            },
+            LobClients::BinanceCm(c) => {
+                c.get_candles(inst, interval, limit, start_time_us, end_time_us)
+                    .await
+            },
+            LobClients::BinanceSpot(c) => {
+                c.get_candles(inst, interval, limit, start_time_us, end_time_us)
+                    .await
+            },
+            LobClients::BinanceUm(c) => {
+                c.get_candles(inst, interval, limit, start_time_us, end_time_us)
+                    .await
+            },
+            LobClients::GateDelivery(c) => {
+                c.get_candles(inst, interval, limit, start_time_us, end_time_us)
+                    .await
+            },
+            LobClients::GateFutures(c) => {
+                c.get_candles(inst, interval, limit, start_time_us, end_time_us)
+                    .await
+            },
+            LobClients::GateSpot(c) => {
+                c.get_candles(inst, interval, limit, start_time_us, end_time_us)
+                    .await
+            },
+            LobClients::GateUni(c) => {
+                c.get_candles(inst, interval, limit, start_time_us, end_time_us)
+                    .await
+            },
+            LobClients::Okx(c) => {
+                c.get_candles(inst, interval, limit, start_time_us, end_time_us)
+                    .await
+            },
         }
     }
 

--- a/src/arch/market_assets/exchange/okx/api_utils.rs
+++ b/src/arch/market_assets/exchange/okx/api_utils.rs
@@ -5,6 +5,7 @@ use tracing::error;
 use crate::arch::market_assets::base_data::{
     InstrumentType, MarginMode, PositionSide, SUBSCRIBE_LOWER,
 };
+use crate::arch::task_execution::task_ws::CandleParam;
 
 pub fn ws_subscribe_msg_okx(channel: &str, insts: Option<&[String]>) -> String {
     let args: Vec<_> = match insts {
@@ -66,6 +67,20 @@ pub fn okx_inst_to_cli(symbol: &str) -> String {
             error!("Invalid okx symbol: {}", symbol);
             symbol.into()
         },
+    }
+}
+
+pub fn okx_candle_interval(interval: &CandleParam) -> &str {
+    match interval {
+        CandleParam::OneSecond => "1s",
+        CandleParam::OneMinute => "1m",
+        CandleParam::FiveMinutes => "5m",
+        CandleParam::FifteenMinutes => "15m",
+        CandleParam::OneHour => "1H",
+        CandleParam::FourHours => "4H",
+        CandleParam::OneDay => "1Dutc",
+        CandleParam::OneWeek => "1W",
+        CandleParam::Custom(value) => value.as_str(),
     }
 }
 

--- a/src/arch/market_assets/exchange/okx/okx_cli.rs
+++ b/src/arch/market_assets/exchange/okx/okx_cli.rs
@@ -30,7 +30,7 @@ use super::{
         asset_deposit_address::RestAssetDepositAddressOkx,
         asset_deposit_history::RestAssetDepositHistoryOkx, asset_transfer::RestAssetTransferOkx,
         asset_transfer_state::RestAssetTransferStateOkx, asset_withdrawal::RestAssetWithdrawalOkx,
-        asset_withdrawal_history::RestAssetWithdrawalHistoryOkx,
+        asset_withdrawal_history::RestAssetWithdrawalHistoryOkx, candle::RestCandleOkx,
         ct_current_lead_traders::RestLeadtraderOkx,
         ct_public_current_subpositions::RestSubPositionOkx,
         ct_public_lead_trader_stats::RestPubLeadTraderStatsOkx,
@@ -79,6 +79,18 @@ impl LobPublicRest for OkxCli {
         inst_type: Option<InstrumentType>,
     ) -> InfraResult<Vec<TickerData>> {
         self._get_tickers(insts, inst_type).await
+    }
+
+    async fn get_candles(
+        &self,
+        inst: &str,
+        interval: CandleParam,
+        limit: Option<u32>,
+        start_time_us: Option<u64>,
+        end_time_us: Option<u64>,
+    ) -> InfraResult<Vec<CandleData>> {
+        self._get_candles(inst, interval, limit, start_time_us, end_time_us)
+            .await
     }
 
     async fn get_instrument_info(
@@ -866,6 +878,50 @@ impl OkxCli {
             })
             .map(TickerData::from)
             .collect();
+
+        Ok(data)
+    }
+
+    async fn _get_candles(
+        &self,
+        inst: &str,
+        interval: CandleParam,
+        limit: Option<u32>,
+        start_time_us: Option<u64>,
+        end_time_us: Option<u64>,
+    ) -> InfraResult<Vec<CandleData>> {
+        let mut params = vec![
+            format!("instId={}", cli_perp_to_okx_inst(inst)),
+            format!("bar={}", okx_candle_interval(&interval)),
+        ];
+        if let Some(limit) = limit {
+            params.push(format!("limit={limit}"));
+        }
+        if let Some(start_time_us) = start_time_us {
+            params.push(format!("before={}", start_time_us / 1_000));
+        }
+        if let Some(end_time_us) = end_time_us {
+            params.push(format!("after={}", end_time_us / 1_000));
+        }
+
+        let url = format!(
+            "{}{}?{}",
+            OKX_BASE_URL,
+            OKX_MARKET_CANDLES,
+            params.join("&")
+        );
+
+        let response = self.client.get(url).send().await?;
+        let res: RestResOkx<RestCandleOkx> = parse_json_response("Okx candles", response).await?;
+
+        let mut data: Vec<CandleData> = res
+            .into_vec()?
+            .into_iter()
+            .map(|entry| entry.into_candle_data(inst))
+            .filter(|entry| start_time_us.is_none_or(|start| entry.timestamp >= start))
+            .filter(|entry| end_time_us.is_none_or(|end| entry.timestamp <= end))
+            .collect();
+        data.sort_by_key(|candle| candle.timestamp);
 
         Ok(data)
     }

--- a/src/arch/market_assets/exchange/okx/schemas/rest.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/rest.rs
@@ -11,6 +11,7 @@ pub mod asset_transfer;
 pub mod asset_transfer_state;
 pub mod asset_withdrawal;
 pub mod asset_withdrawal_history;
+pub mod candle;
 pub mod ct_current_lead_traders;
 pub mod ct_public_current_subpositions;
 pub mod ct_public_lead_trader_stats;

--- a/src/arch/market_assets/exchange/okx/schemas/rest/candle.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/rest/candle.rs
@@ -1,0 +1,31 @@
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::arch::market_assets::{
+    api_data::price_data::CandleData,
+    api_general::{ts_to_micros, value_to_f64},
+};
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestCandleOkx(pub Vec<Value>);
+
+impl RestCandleOkx {
+    pub fn into_candle_data(self, inst: &str) -> CandleData {
+        let values = self.0;
+        CandleData {
+            timestamp: ts_to_micros(
+                values
+                    .first()
+                    .and_then(Value::as_str)
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or_default(),
+            ),
+            inst: inst.to_string(),
+            open: values.get(1).map(value_to_f64).unwrap_or_default(),
+            high: values.get(2).map(value_to_f64).unwrap_or_default(),
+            low: values.get(3).map(value_to_f64).unwrap_or_default(),
+            close: values.get(4).map(value_to_f64).unwrap_or_default(),
+            volume: values.get(5).map(value_to_f64).unwrap_or_default(),
+        }
+    }
+}

--- a/src/arch/traits/market_lob.rs
+++ b/src/arch/traits/market_lob.rs
@@ -45,6 +45,9 @@ pub trait LobPublicRest: Send + Sync {
         &self,
         _inst: &str,
         _interval: CandleParam,
+        _limit: Option<u32>,
+        _start_time_us: Option<u64>,
+        _end_time_us: Option<u64>,
     ) -> impl Future<Output = InfraResult<Vec<CandleData>>> + Send {
         ready(Err(InfraError::Unimplemented))
     }


### PR DESCRIPTION
## Summary
- add unified candle REST parameters to LobPublicRest
- implement ordinary candle fetching for Binance UM, Gate futures, OKX, and Hyperliquid
- normalize candle output ordering and microsecond timestamps

## Tests
- cargo test