### PR TITLE
feat: add Gate spot balance support

### DIFF
--- a/src/arch/market_assets/exchange/gate/config_assets.rs
+++ b/src/arch/market_assets/exchange/gate/config_assets.rs
@@ -12,6 +12,7 @@ pub const GATE_WS_SPOT_CROSS_BALANCES: &str = "spot.cross_balances";
 pub const GATE_SPOT_CURRENCY_PAIRS: &str = "/api/v4/spot/currency_pairs";
 pub const GATE_SPOT_ORDERS: &str = "/api/v4/spot/orders";
 pub const GATE_SPOT_TICKERS: &str = "/api/v4/spot/tickers";
+pub const GATE_SPOT_ACCOUNTS: &str = "/api/v4/spot/accounts";
 
 /// Uni (margin/unified) REST endpoints
 pub const GATE_UNI_MARGIN_CURRENCY_PAIRS: &str = "/api/v4/margin/uni/currency_pairs";

--- a/src/arch/market_assets/exchange/gate/gate_spot_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_spot_cli.rs
@@ -6,7 +6,9 @@ use tracing::error;
 use crate::arch::{
     market_assets::{
         api_data::{
-            account_data::OrderAckData, price_data::TickerData, utils_data::InstrumentInfo,
+            account_data::{BalanceData, OrderAckData},
+            price_data::TickerData,
+            utils_data::InstrumentInfo,
         },
         api_general::{OrderParams, RequestMethod, get_seconds_timestamp, parse_json_response},
         base_data::{InstrumentType, OrderSide, OrderType, SUBSCRIBE_LOWER, TimeInForce},
@@ -15,6 +17,7 @@ use crate::arch::{
             gate_rest_msg::RestResGate,
             schemas::{
                 spot_rest::{
+                    account_balance::RestAccountBalGateSpot,
                     currency_pair::RestCurrencyPairGateSpot, order::RestOrderGateSpot,
                     ticker::RestTickerGateSpot,
                 },
@@ -96,6 +99,10 @@ impl LobPrivateRest for GateSpotCli {
 
     async fn place_order(&self, order_params: OrderParams) -> InfraResult<OrderAckData> {
         self._place_order(order_params).await
+    }
+
+    async fn get_balance(&self, assets: Option<&[String]>) -> InfraResult<Vec<BalanceData>> {
+        self._get_balance(assets).await
     }
 }
 
@@ -465,6 +472,37 @@ impl GateSpotCli {
             .collect();
 
         Ok(data)
+    }
+
+    async fn _get_balance(&self, assets: Option<&[String]>) -> InfraResult<Vec<BalanceData>> {
+        let res: RestResGate<RestAccountBalGateSpot> = self
+            .api_key
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_signed_request(
+                &self.client,
+                RequestMethod::Get,
+                None,
+                None,
+                GATE_BASE_URL,
+                GATE_SPOT_ACCOUNTS,
+            )
+            .await?;
+
+        let balances: Vec<BalanceData> =
+            res.into_vec()?.into_iter().map(BalanceData::from).collect();
+        let filtered = match assets {
+            Some(list) if !list.is_empty() => balances
+                .into_iter()
+                .filter(|b| {
+                    list.iter()
+                        .any(|asset| asset.eq_ignore_ascii_case(&b.asset))
+                })
+                .collect(),
+            _ => balances,
+        };
+
+        Ok(filtered)
     }
 
     async fn _place_order(&self, order_params: OrderParams) -> InfraResult<OrderAckData> {

--- a/src/arch/market_assets/exchange/gate/schemas/spot_rest.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/spot_rest.rs
@@ -1,3 +1,4 @@
+pub mod account_balance;
 pub mod currency_pair;
 pub mod order;
 pub mod ticker;

--- a/src/arch/market_assets/exchange/gate/schemas/spot_rest/account_balance.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/spot_rest/account_balance.rs
@@ -1,0 +1,27 @@
+use serde::Deserialize;
+
+use crate::arch::market_assets::{
+    api_data::account_data::BalanceData, api_general::get_micros_timestamp,
+};
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestAccountBalGateSpot {
+    pub currency: String,
+    pub available: String,
+    pub locked: String,
+}
+
+impl From<RestAccountBalGateSpot> for BalanceData {
+    fn from(d: RestAccountBalGateSpot) -> Self {
+        let available = d.available.parse().unwrap_or_default();
+        let frozen = d.locked.parse().unwrap_or_default();
+        BalanceData {
+            timestamp: get_micros_timestamp(),
+            asset: d.currency,
+            total: available + frozen,
+            available,
+            frozen,
+            borrowed: None,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Gate spot account balance schema and endpoint constant
- implement GateSpotCli::get_balance via /api/v4/spot/accounts
- support asset filtering consistent with other balance clients

## Tests
- cargo fmt
- cargo test gate
- cargo check --features lob_clients
- cargo test --features lob_clients