### PR TITLE
chore: prepare 0.1.14 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 
 readme = "README.md"
@@ -51,7 +51,7 @@ rustls = { version = "0.23.40", features = ["aws-lc-rs"] }
 
 # IPC / Model inference / Data processing
 zeromq = { version = "0.6.0", optional = true }
-tract-onnx = { version = "0.23.1", optional = true }
+tract-onnx = { version = "0.23.2", optional = true }
 polars = { version = "0.54.4", default-features = false, optional = true }
 
 # Logging & Tracing


### PR DESCRIPTION
## Summary
- bump crate version to 0.1.14
- bump optional tract-onnx dependency to 0.23.2

## Tests
- cargo fmt --check
- cargo check --features lob_clients
- git diff --check