### PR TITLE
feat: preserve account order ids from websockets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 
 readme = "README.md"
@@ -51,7 +51,7 @@ rustls = { version = "0.23.40", features = ["aws-lc-rs"] }
 
 # IPC / Model inference / Data processing
 zeromq = { version = "0.6.0", optional = true }
-tract-onnx = { version = "0.23.2", optional = true }
+tract-onnx = { version = "0.23.3", optional = true }
 polars = { version = "0.54.4", default-features = false, optional = true }
 
 # Logging & Tracing

--- a/src/arch/market_assets/exchange/binance/schemas/spot_ws/account_order.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/spot_ws/account_order.rs
@@ -23,6 +23,8 @@ pub(crate) struct WsAccountOrderBinanceSpot {
     E: u64,    // Event time
     s: String, // Symbol
     c: String, // Client order id
+    #[serde(default)]
+    i: Option<u64>, // Order id
     S: String, // Side
     o: String, // Order type
     q: String, // Original quantity
@@ -66,7 +68,43 @@ impl IntoWsData for WsAccountOrderEnvelopeBinanceSpot {
                 "LIMIT" | "LIMIT_MAKER" => OrderType::Limit,
                 _ => OrderType::Unknown,
             },
+            order_id: event.i.map(|id| id.to_string()),
             cli_order_id: Some(event.c),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::arch::traits::conversion::IntoWsData;
+
+    use super::*;
+
+    #[test]
+    fn into_ws_preserves_exchange_and_client_order_ids() {
+        let raw: WsAccountOrderEnvelopeBinanceSpot = serde_json::from_value(json!({
+            "subscriptionId": 1_u64,
+            "event": {
+                "E": 1781905826733_u64,
+                "s": "REUSDT",
+                "c": "spot-client-id",
+                "i": 370702544401581041_u64,
+                "S": "BUY",
+                "o": "MARKET",
+                "q": "16",
+                "p": "0",
+                "L": "0.87295",
+                "z": "16",
+                "X": "FILLED"
+            }
+        }))
+        .unwrap();
+
+        let ws = raw.into_ws();
+
+        assert_eq!(ws.order_id.as_deref(), Some("370702544401581041"));
+        assert_eq!(ws.cli_order_id.as_deref(), Some("spot-client-id"));
     }
 }

--- a/src/arch/market_assets/exchange/binance/schemas/um_futures_ws/account_order.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/um_futures_ws/account_order.rs
@@ -96,7 +96,69 @@ impl IntoWsData for WsAccountOrderBinanceUM {
                 "LIMIT" => OrderType::Limit,
                 _ => OrderType::Unknown,
             },
+            order_id: Some(self.o.i.to_string()),
             cli_order_id: Some(self.o.c),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::arch::traits::conversion::IntoWsData;
+
+    use super::*;
+
+    #[test]
+    fn into_ws_preserves_exchange_and_client_order_ids() {
+        let raw: WsAccountOrderBinanceUM = serde_json::from_value(json!({
+            "e": "ORDER_TRADE_UPDATE",
+            "E": 1781905826733_u64,
+            "T": 1781905826733_u64,
+            "o": {
+                "s": "GUNUSDT",
+                "c": "CYA3pfUhF2yFO3kbBgIDMP",
+                "S": "BUY",
+                "o": "MARKET",
+                "f": "GTC",
+                "q": "4350",
+                "p": "0",
+                "ap": "0.005857",
+                "sp": "0",
+                "x": "TRADE",
+                "X": "FILLED",
+                "i": 1272696572_u64,
+                "l": "4350",
+                "z": "4350",
+                "L": "0.005857",
+                "N": "USDT",
+                "n": "0",
+                "T": 1781905826733_u64,
+                "t": 1_u64,
+                "b": "0",
+                "a": "0",
+                "m": false,
+                "R": false,
+                "wt": "CONTRACT_PRICE",
+                "ot": "MARKET",
+                "ps": "BOTH",
+                "cp": false,
+                "AP": null,
+                "cr": null,
+                "pP": false,
+                "rp": "0",
+                "V": "NONE",
+                "pm": "NONE",
+                "gtd": 0_u64,
+                "er": "0"
+            }
+        }))
+        .unwrap();
+
+        let ws = raw.into_ws();
+
+        assert_eq!(ws.order_id.as_deref(), Some("1272696572"));
+        assert_eq!(ws.cli_order_id.as_deref(), Some("CYA3pfUhF2yFO3kbBgIDMP"));
     }
 }

--- a/src/arch/market_assets/exchange/gate/api_utils.rs
+++ b/src/arch/market_assets/exchange/gate/api_utils.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use serde_json::{Value, json};
 use tracing::{error, warn};
 
 use crate::arch::market_assets::{api_general::get_seconds_timestamp, base_data::SUBSCRIBE_LOWER};
@@ -10,6 +10,14 @@ use crate::errors::{InfraError, InfraResult};
 
 pub const GATE_CHANNEL_ID_EXTRA_KEY: &str = "gate_channel_id";
 pub const GATE_CHANNEL_ID_HEADER: &str = "X-Gate-Channel-Id";
+
+pub(crate) fn value_to_order_id(value: Option<&Value>) -> Option<String> {
+    match value {
+        Some(Value::String(id)) if !id.is_empty() && id != "-" => Some(id.clone()),
+        Some(Value::Number(id)) => Some(id.to_string()),
+        _ => None,
+    }
+}
 
 pub fn ws_subscribe_msg_gate_futures(channel: &str, payload: Vec<String>) -> String {
     let msg = json!({

--- a/src/arch/market_assets/exchange/gate/schemas/futures_ws/account_order.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/futures_ws/account_order.rs
@@ -5,7 +5,7 @@ use crate::arch::{
     market_assets::{
         api_general::{ts_to_micros, value_to_f64},
         base_data::{InstrumentType, OrderSide, OrderStatus, OrderType},
-        exchange::gate::api_utils::gate_fut_inst_to_cli,
+        exchange::gate::api_utils::{gate_fut_inst_to_cli, value_to_order_id},
         market_core::Market,
     },
     strategy_base::handler::lob_events::WsAccOrder,
@@ -15,6 +15,8 @@ use crate::arch::{
 #[allow(non_snake_case)]
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct WsAccountOrderGateFutures {
+    #[serde(default)]
+    id: Option<Value>,
     contract: String,
     size: Value,
     left: Value,
@@ -58,6 +60,7 @@ impl IntoWsData for WsAccountOrderGateFutures {
             order_price
         };
         let order_type = parse_order_type(order_price, self.tif.as_deref());
+        let order_id = value_to_order_id(self.id.as_ref());
 
         let timestamp = self
             .update_time
@@ -76,6 +79,7 @@ impl IntoWsData for WsAccountOrderGateFutures {
             side,
             status,
             order_type,
+            order_id,
             cli_order_id: self.text.as_ref().and_then(|t| {
                 if t.is_empty() || t == "-" {
                     None
@@ -136,5 +140,38 @@ fn parse_order_type(price: f64, tif: Option<&str>) -> OrderType {
         "ioc" => OrderType::Ioc,
         "fok" => OrderType::Fok,
         _ => OrderType::Limit,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::arch::traits::conversion::IntoWsData;
+
+    use super::*;
+
+    #[test]
+    fn into_ws_preserves_exchange_and_client_order_ids() {
+        let raw: WsAccountOrderGateFutures = serde_json::from_value(json!({
+            "id": 123456789_u64,
+            "contract": "GUN_USDT",
+            "size": -435,
+            "left": 0,
+            "price": "0",
+            "fill_price": "0.005857",
+            "status": "finished",
+            "finish_as": "filled",
+            "update_time": 1781905826_u64,
+            "create_time_ms": 1781905826733_u64,
+            "tif": "ioc",
+            "text": "gate-futures-client-id"
+        }))
+        .unwrap();
+
+        let ws = raw.into_ws();
+
+        assert_eq!(ws.order_id.as_deref(), Some("123456789"));
+        assert_eq!(ws.cli_order_id.as_deref(), Some("gate-futures-client-id"));
     }
 }

--- a/src/arch/market_assets/exchange/gate/schemas/spot_ws/account_order.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/spot_ws/account_order.rs
@@ -5,6 +5,7 @@ use crate::arch::{
     market_assets::{
         api_general::ts_to_micros,
         base_data::{InstrumentType, OrderSide, OrderStatus, OrderType},
+        exchange::gate::api_utils::value_to_order_id,
         market_core::Market,
     },
     strategy_base::handler::lob_events::WsAccOrder,
@@ -14,6 +15,8 @@ use crate::arch::{
 #[allow(non_snake_case)]
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct WsAccountOrderGateSpot {
+    #[serde(default)]
+    id: Option<Value>,
     currency_pair: String,
     side: String,
     r#type: String,
@@ -68,6 +71,7 @@ impl IntoWsData for WsAccountOrderGateSpot {
             .and_then(value_to_u64_ms)
             .or_else(|| self.create_time_ms.as_ref().and_then(value_to_u64_ms))
             .unwrap_or_default();
+        let order_id = value_to_order_id(self.id.as_ref());
 
         WsAccOrder {
             timestamp: ts_to_micros(timestamp_ms),
@@ -88,6 +92,7 @@ impl IntoWsData for WsAccountOrderGateSpot {
             } else {
                 OrderType::Limit
             },
+            order_id,
             cli_order_id: self.text.and_then(|t| {
                 if t.is_empty() || t == "-" {
                     None
@@ -168,4 +173,40 @@ fn value_to_u64_ms(v: &Value) -> Option<u64> {
             .and_then(|s| s.split('.').next())
             .and_then(|s| s.parse::<u64>().ok())
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::arch::traits::conversion::IntoWsData;
+
+    use super::*;
+
+    #[test]
+    fn into_ws_preserves_exchange_and_client_order_ids() {
+        let raw: WsAccountOrderGateSpot = serde_json::from_value(json!({
+            "id": "370702544401581041",
+            "currency_pair": "RE_USDT",
+            "side": "buy",
+            "type": "market",
+            "amount": "16",
+            "price": "0",
+            "left": "0",
+            "filled_amount": "16",
+            "avg_deal_price": "0.87295",
+            "status": "closed",
+            "finish_as": "filled",
+            "event": "finish",
+            "update_time_ms": 1781905826733_u64,
+            "create_time_ms": 1781905826733_u64,
+            "text": "gate-spot-client-id"
+        }))
+        .unwrap();
+
+        let ws = raw.into_ws();
+
+        assert_eq!(ws.order_id.as_deref(), Some("370702544401581041"));
+        assert_eq!(ws.cli_order_id.as_deref(), Some("gate-spot-client-id"));
+    }
 }

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/ws/account_order.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/ws/account_order.rs
@@ -56,6 +56,7 @@ impl IntoWsData for WsAccountOrderHyperliquid {
             },
             status: parse_order_status(&self.status, filled_size),
             order_type: OrderType::Limit,
+            order_id: Some(self.order.oid.to_string()),
             cli_order_id: self.order.cloid.filter(|cloid| !cloid.is_empty()),
         }
     }
@@ -86,5 +87,38 @@ fn parse_order_status(status: &str, filled_size: f64) -> OrderStatus {
         OrderStatus::Canceled
     } else {
         OrderStatus::Unknown
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::arch::traits::conversion::IntoWsData;
+
+    use super::*;
+
+    #[test]
+    fn into_ws_preserves_exchange_and_client_order_ids() {
+        let raw: WsAccountOrderHyperliquid = serde_json::from_value(json!({
+            "order": {
+                "coin": "GUN",
+                "side": "B",
+                "limitPx": "0.005857",
+                "sz": "0",
+                "oid": 987654321_u64,
+                "timestamp": 1781905826733_u64,
+                "origSz": "4350",
+                "cloid": "hl-client-id"
+            },
+            "status": "filled",
+            "statusTimestamp": 1781905826733_u64
+        }))
+        .unwrap();
+
+        let ws = raw.into_ws();
+
+        assert_eq!(ws.order_id.as_deref(), Some("987654321"));
+        assert_eq!(ws.cli_order_id.as_deref(), Some("hl-client-id"));
     }
 }

--- a/src/arch/market_assets/exchange/okx/schemas/ws/account_order.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/ws/account_order.rs
@@ -78,11 +78,48 @@ impl IntoWsData for WsAccountOrderOkx {
                 "limit" => OrderType::Limit,
                 _ => OrderType::Unknown,
             },
-            cli_order_id: if self.clOrdId.is_empty() {
-                None
-            } else {
-                Some(self.clOrdId)
-            },
+            order_id: (!self.ordId.is_empty()).then_some(self.ordId),
+            cli_order_id: (!self.clOrdId.is_empty()).then_some(self.clOrdId),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::arch::traits::conversion::IntoWsData;
+
+    use super::*;
+
+    #[test]
+    fn into_ws_preserves_exchange_and_client_order_ids() {
+        let raw: WsAccountOrderOkx = serde_json::from_value(json!({
+            "ordId": "2234567890",
+            "clOrdId": "okx-client-id",
+            "instId": "GUN-USDT-SWAP",
+            "instType": "SWAP",
+            "side": "buy",
+            "posSide": "net",
+            "tdMode": "cross",
+            "ordType": "market",
+            "state": "filled",
+            "px": null,
+            "sz": "4350",
+            "fillPx": "0.005857",
+            "fillSz": "4350",
+            "fillPnl": null,
+            "fillTime": "1781905826733",
+            "tradeId": "1",
+            "fee": "0",
+            "feeCcy": "USDT",
+            "uTime": "1781905826733"
+        }))
+        .unwrap();
+
+        let ws = raw.into_ws();
+
+        assert_eq!(ws.order_id.as_deref(), Some("2234567890"));
+        assert_eq!(ws.cli_order_id.as_deref(), Some("okx-client-id"));
     }
 }

--- a/src/arch/strategy_base/handler/lob_events.rs
+++ b/src/arch/strategy_base/handler/lob_events.rs
@@ -112,6 +112,7 @@ pub struct WsAccOrder {
     pub side: OrderSide,
     pub status: OrderStatus,
     pub order_type: OrderType,
+    pub order_id: Option<String>,
     pub cli_order_id: Option<String>,
 }
 


### PR DESCRIPTION
## Summary
- Add `order_id: Option<String>` to unified account-order websocket events.
- Populate exchange order IDs for Binance Spot/UM, Gate Spot/Futures, OKX, and HyperLiquid account-order WS parsers.
- Prepare `extrema_infra` 0.1.15 and bump `tract-onnx` to 0.23.3.

## Breaking Changes
- `WsAccOrder` now has a new `order_id` field. Downstream code constructing this struct directly must populate it.

## Database Migrations
None

## Merge Order
None

## Related
None

## Test Plan
- [x] `cargo fmt --check`
- [x] `cargo test --features 'binance gate okx hyperliquid' into_ws_preserves_exchange_and_client_order_ids`
- [x] `cargo check --all-features`
- [x] `cargo test --all-features`
- [x] `cargo clippy --all-features -- -D warnings`
