### PR TITLE
feat: add REST orderbook market data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2024"
 
 readme = "README.md"

--- a/src/arch/market_assets/exchange/binance/api_utils.rs
+++ b/src/arch/market_assets/exchange/binance/api_utils.rs
@@ -526,6 +526,17 @@ pub fn binance_lob_stream(lob_param: &Option<LobParam>) -> InfraResult<String> {
     }
 }
 
+pub(crate) fn binance_um_orderbook_limit(depth: usize) -> InfraResult<usize> {
+    match depth {
+        0 => Ok(500),
+        depth @ (5 | 10 | 20 | 50 | 100 | 500 | 1000) => Ok(depth),
+        depth => Err(InfraError::ApiCliError(format!(
+            "Binance UM orderbook supports only 5, 10, 20, 50, 100, 500, or 1000 levels: {}",
+            depth
+        ))),
+    }
+}
+
 fn binance_lob_frequency_suffix(frequency: &Option<LobFrequency>) -> InfraResult<&'static str> {
     match frequency {
         None | Some(LobFrequency::Ms250) => Ok(""),
@@ -730,6 +741,13 @@ mod tests {
             }))
             .is_err()
         );
+    }
+
+    #[test]
+    fn validates_binance_um_orderbook_limit() {
+        assert_eq!(binance_um_orderbook_limit(0).unwrap(), 500);
+        assert_eq!(binance_um_orderbook_limit(20).unwrap(), 20);
+        assert!(binance_um_orderbook_limit(7).is_err());
     }
 
     #[test]

--- a/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
+++ b/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
@@ -33,6 +33,7 @@ use super::{
         leverage::RestLeverageBinanceUM,
         open_interest_statistics::RestOpenInterestBinanceUM,
         order_history::RestOrderHistoryBinanceUM,
+        orderbook::RestOrderBookBinanceUM,
         position_mode::{RestPositionModeBinanceUM, RestPositionModeChangeBinanceUM},
         premium_index::RestPremiumIndexBinanceUM,
         symbol_config::RestSymbolConfigBinanceUM,
@@ -67,6 +68,7 @@ impl LobPublicRest for BinanceUmCli {
     async fn get_candles(
         &self,
         inst: &str,
+        _inst_type: InstrumentType,
         interval: CandleParam,
         limit: Option<u32>,
         start_time_us: Option<u64>,
@@ -74,6 +76,15 @@ impl LobPublicRest for BinanceUmCli {
     ) -> InfraResult<Vec<CandleData>> {
         self._get_candles(inst, interval, limit, start_time_us, end_time_us)
             .await
+    }
+
+    async fn get_orderbook(
+        &self,
+        inst: &str,
+        inst_type: InstrumentType,
+        depth: usize,
+    ) -> InfraResult<OrderBookData> {
+        self._get_orderbook(inst, inst_type, depth).await
     }
 
     async fn get_instrument_info(
@@ -432,6 +443,41 @@ impl BinanceUmCli {
         data.sort_by_key(|candle| candle.timestamp);
 
         Ok(data)
+    }
+
+    async fn _get_orderbook(
+        &self,
+        inst: &str,
+        inst_type: InstrumentType,
+        depth: usize,
+    ) -> InfraResult<OrderBookData> {
+        if inst_type != InstrumentType::Perpetual {
+            return Err(InfraError::ApiCliError(format!(
+                "Binance UM orderbook supports perpetual instruments only, got {:?}",
+                inst_type
+            )));
+        }
+
+        let mut params = vec![format!("symbol={}", cli_perp_to_pure_uppercase(inst))];
+        if depth > 0 {
+            params.push(format!("limit={}", binance_um_orderbook_limit(depth)?));
+        }
+
+        let url = format!(
+            "{}{}?{}",
+            BINANCE_UM_FUTURES_BASE_URL,
+            BINANCE_UM_FUTURES_DEPTH,
+            params.join("&")
+        );
+        let response = self.client.get(url).send().await?;
+        let res: RestResBinance<RestOrderBookBinanceUM> =
+            parse_json_response("BinanceUmFutures orderbook", response).await?;
+
+        res.into_vec()?
+            .into_iter()
+            .next()
+            .map(|entry| entry.into_orderbook_data(inst))
+            .ok_or_else(|| InfraError::ApiCliError("No Binance UM orderbook data returned".into()))
     }
 
     pub async fn get_premium_index(

--- a/src/arch/market_assets/exchange/binance/config_assets.rs
+++ b/src/arch/market_assets/exchange/binance/config_assets.rs
@@ -34,6 +34,7 @@ pub const BINANCE_UM_FUTURES_SYMBOL_CONFIG: &str = "/fapi/v1/symbolConfig";
 pub const BINANCE_UM_FUTURES_POSITION_RISK_INFO: &str = "/fapi/v3/positionRisk";
 pub const BINANCE_UM_FUTURES_TICKERS: &str = "/fapi/v2/ticker/price";
 pub const BINANCE_UM_FUTURES_KLINES: &str = "/fapi/v1/klines";
+pub const BINANCE_UM_FUTURES_DEPTH: &str = "/fapi/v1/depth";
 pub const BINANCE_UM_FUTURES_PREMIUM_INDEX_KLINES: &str = "/fapi/v1/premiumIndexKlines";
 pub const BINANCE_UM_FUTURES_PREMIUM_INDEX: &str = "/fapi/v1/premiumIndex";
 pub const BINANCE_UM_FUTURES_FUNDING_INFO: &str = "/fapi/v1/fundingInfo";

--- a/src/arch/market_assets/exchange/binance/schemas/um_futures_rest.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/um_futures_rest.rs
@@ -8,6 +8,7 @@ pub mod funding_rate_info;
 pub mod leverage;
 pub mod open_interest_statistics;
 pub mod order_history;
+pub mod orderbook;
 pub mod position_mode;
 pub mod premium_index;
 pub mod symbol_config;

--- a/src/arch/market_assets/exchange/binance/schemas/um_futures_rest/orderbook.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/um_futures_rest/orderbook.rs
@@ -1,0 +1,55 @@
+use serde::Deserialize;
+
+use crate::arch::market_assets::{
+    api_data::price_data::OrderBookData,
+    api_general::{get_micros_timestamp, value_to_f64},
+};
+
+#[derive(Clone, Debug, Deserialize)]
+#[allow(non_snake_case)]
+pub struct RestOrderBookBinanceUM {
+    pub lastUpdateId: u64,
+    pub bids: Vec<[serde_json::Value; 2]>,
+    pub asks: Vec<[serde_json::Value; 2]>,
+}
+
+impl RestOrderBookBinanceUM {
+    pub fn into_orderbook_data(self, inst: &str) -> OrderBookData {
+        OrderBookData {
+            timestamp: get_micros_timestamp(),
+            inst: inst.to_string(),
+            bids: levels_to_pairs(self.bids),
+            asks: levels_to_pairs(self.asks),
+        }
+    }
+}
+
+fn levels_to_pairs(levels: Vec<[serde_json::Value; 2]>) -> Vec<(f64, f64)> {
+    levels
+        .into_iter()
+        .map(|[price, size]| (value_to_f64(&price), value_to_f64(&size)))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_binance_um_orderbook_snapshot() {
+        let raw = r#"{
+            "lastUpdateId": 1027024,
+            "E": 1589436922972,
+            "T": 1589436922959,
+            "bids": [["4.00000000", "431.00000000"]],
+            "asks": [["4.00000200", "12.00000000"]]
+        }"#;
+
+        let parsed: RestOrderBookBinanceUM = serde_json::from_str(raw).unwrap();
+        let book = parsed.into_orderbook_data("BTC_USDT_PERP");
+
+        assert_eq!(book.inst, "BTC_USDT_PERP");
+        assert_eq!(book.bids, vec![(4.0, 431.0)]);
+        assert_eq!(book.asks, vec![(4.000002, 12.0)]);
+    }
+}

--- a/src/arch/market_assets/exchange/gate/api_utils.rs
+++ b/src/arch/market_assets/exchange/gate/api_utils.rs
@@ -99,6 +99,16 @@ pub(crate) fn gate_lob_depth(depth: &Option<u16>) -> InfraResult<u16> {
     }
 }
 
+pub(crate) fn nonzero_depth_u16(depth: usize) -> InfraResult<Option<u16>> {
+    if depth == 0 {
+        return Ok(None);
+    }
+
+    u16::try_from(depth)
+        .map(Some)
+        .map_err(|_| InfraError::ApiCliError(format!("Depth exceeds u16 range: {}", depth)))
+}
+
 pub(crate) fn gate_lob_bbo_frequency(frequency: &Option<LobFrequency>) -> InfraResult<()> {
     match frequency {
         None | Some(LobFrequency::Realtime) => Ok(()),

--- a/src/arch/market_assets/exchange/gate/config_assets.rs
+++ b/src/arch/market_assets/exchange/gate/config_assets.rs
@@ -34,6 +34,7 @@ pub const GATE_FUTURES_CONTRACTS: &str = "/api/v4/futures/{settle}/contracts";
 pub const GATE_FUTURES_CONTRACT: &str = "/api/v4/futures/{settle}/contracts/{contract}";
 pub const GATE_FUTURES_TICKERS: &str = "/api/v4/futures/{settle}/tickers";
 pub const GATE_FUTURES_CANDLESTICKS: &str = "/api/v4/futures/{settle}/candlesticks";
+pub const GATE_FUTURES_ORDER_BOOK: &str = "/api/v4/futures/{settle}/order_book";
 pub const GATE_FUTURES_PREMIUM_INDEX: &str = "/api/v4/futures/{settle}/premium_index";
 pub const GATE_FUTURES_FUNDING_RATE: &str = "/api/v4/futures/{settle}/funding_rate";
 pub const GATE_FUTURES_SET_POSITION_MODE: &str = "/api/v4/futures/{settle}/set_position_mode";

--- a/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
@@ -7,7 +7,7 @@ use crate::arch::{
     market_assets::{
         api_data::{
             account_data::{HistoOrderData, OrderAckData, PositionData},
-            price_data::{CandleData, TickerData},
+            price_data::{CandleData, OrderBookData, TickerData},
             utils_data::{FundingRateData, FundingRateInfo, InstrumentInfo},
         },
         api_general::{
@@ -32,7 +32,7 @@ use super::{
         account_position::RestAccountPosGateFutures, candle::RestCandleGateFutures,
         contract_futures::RestContractGateFutures, funding_rate::RestFundingRateGateFutures,
         order::RestFuturesOrderGateFutures, order_history::RestFuturesOrderHistoryGateFutures,
-        ticker::RestTickerGateFutures,
+        orderbook::RestOrderBookGateFutures, ticker::RestTickerGateFutures,
     },
 };
 
@@ -62,6 +62,7 @@ impl LobPublicRest for GateFuturesCli {
     async fn get_candles(
         &self,
         inst: &str,
+        _inst_type: InstrumentType,
         interval: CandleParam,
         limit: Option<u32>,
         start_time_us: Option<u64>,
@@ -69,6 +70,15 @@ impl LobPublicRest for GateFuturesCli {
     ) -> InfraResult<Vec<CandleData>> {
         self._get_candles(inst, interval, limit, start_time_us, end_time_us)
             .await
+    }
+
+    async fn get_orderbook(
+        &self,
+        inst: &str,
+        inst_type: InstrumentType,
+        depth: usize,
+    ) -> InfraResult<OrderBookData> {
+        self._get_orderbook(inst, inst_type, depth).await
     }
 
     async fn get_instrument_info(
@@ -459,6 +469,44 @@ impl GateFuturesCli {
         }
 
         Ok(data)
+    }
+
+    async fn _get_orderbook(
+        &self,
+        inst: &str,
+        inst_type: InstrumentType,
+        depth: usize,
+    ) -> InfraResult<OrderBookData> {
+        if !matches!(
+            inst_type,
+            InstrumentType::Perpetual | InstrumentType::Futures
+        ) {
+            return Err(InfraError::ApiCliError(format!(
+                "Gate futures orderbook supports futures/perpetual instruments only, got {:?}",
+                inst_type
+            )));
+        }
+
+        let settle = infer_settle_from_inst(inst);
+        let endpoint = GATE_FUTURES_ORDER_BOOK.replace("{settle}", &settle);
+        let depth = gate_lob_depth(&nonzero_depth_u16(depth)?)?;
+        let params = [
+            format!("contract={}", cli_perp_to_gate_inst(inst)),
+            format!("limit={depth}"),
+        ];
+        let url = format!("{}{}?{}", GATE_BASE_URL, endpoint, params.join("&"));
+
+        let response = self.client.get(url).send().await?;
+        let res: RestResGate<RestOrderBookGateFutures> =
+            parse_json_response("GateFutures orderbook", response).await?;
+
+        res.into_vec()?
+            .into_iter()
+            .next()
+            .map(|entry| entry.into_orderbook_data(inst))
+            .ok_or_else(|| {
+                InfraError::ApiCliError("No Gate futures orderbook data returned".into())
+            })
     }
 
     async fn _get_instrument_info(

--- a/src/arch/market_assets/exchange/gate/schemas/futures_rest.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/futures_rest.rs
@@ -5,4 +5,5 @@ pub mod funding_rate;
 pub mod leverage;
 pub mod order;
 pub mod order_history;
+pub mod orderbook;
 pub mod ticker;

--- a/src/arch/market_assets/exchange/gate/schemas/futures_rest/orderbook.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/futures_rest/orderbook.rs
@@ -1,0 +1,106 @@
+use serde::Deserialize;
+
+use crate::arch::market_assets::{
+    api_data::price_data::OrderBookData,
+    api_general::{get_micros_timestamp, value_to_f64},
+};
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestOrderBookGateFutures {
+    #[serde(default)]
+    pub current: Option<serde_json::Value>,
+    #[serde(default)]
+    pub asks: Vec<RestOrderBookLevelGateFutures>,
+    #[serde(default)]
+    pub bids: Vec<RestOrderBookLevelGateFutures>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+pub enum RestOrderBookLevelGateFutures {
+    Object {
+        p: serde_json::Value,
+        s: serde_json::Value,
+    },
+    Array(Vec<serde_json::Value>),
+}
+
+impl RestOrderBookGateFutures {
+    pub fn into_orderbook_data(self, inst: &str) -> OrderBookData {
+        OrderBookData {
+            timestamp: self
+                .current
+                .as_ref()
+                .map(gate_current_to_micros)
+                .unwrap_or_else(get_micros_timestamp),
+            inst: inst.to_string(),
+            bids: levels_to_pairs(self.bids),
+            asks: levels_to_pairs(self.asks),
+        }
+    }
+}
+
+fn gate_current_to_micros(value: &serde_json::Value) -> u64 {
+    if let Some(raw) = value.as_u64() {
+        return raw.saturating_mul(1_000_000);
+    }
+    if let Some(raw) = value.as_f64() {
+        return (raw * 1_000_000.0) as u64;
+    }
+    value
+        .as_str()
+        .and_then(|raw| raw.parse::<f64>().ok())
+        .map(|raw| (raw * 1_000_000.0) as u64)
+        .unwrap_or_else(get_micros_timestamp)
+}
+
+fn levels_to_pairs(levels: Vec<RestOrderBookLevelGateFutures>) -> Vec<(f64, f64)> {
+    levels
+        .into_iter()
+        .filter_map(|level| match level {
+            RestOrderBookLevelGateFutures::Object { p, s } => {
+                Some((value_to_f64(&p), value_to_f64(&s)))
+            },
+            RestOrderBookLevelGateFutures::Array(values) => {
+                let price = values.first().map(value_to_f64)?;
+                let size = values.get(1).map(value_to_f64)?;
+                Some((price, size))
+            },
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_gate_futures_object_orderbook_snapshot() {
+        let raw = r#"{
+            "current": 1716803367.123,
+            "asks": [{"p": "64321.5", "s": 10}],
+            "bids": [{"p": "64320.9", "s": 8}]
+        }"#;
+
+        let parsed: RestOrderBookGateFutures = serde_json::from_str(raw).unwrap();
+        let book = parsed.into_orderbook_data("BTC_USDT_PERP");
+
+        assert_eq!(book.inst, "BTC_USDT_PERP");
+        assert_eq!(book.bids, vec![(64320.9, 8.0)]);
+        assert_eq!(book.asks, vec![(64321.5, 10.0)]);
+    }
+
+    #[test]
+    fn parses_gate_futures_array_orderbook_snapshot() {
+        let raw = r#"{
+            "asks": [["64321.5", "10"]],
+            "bids": [["64320.9", "8"]]
+        }"#;
+
+        let parsed: RestOrderBookGateFutures = serde_json::from_str(raw).unwrap();
+        let book = parsed.into_orderbook_data("BTC_USDT_PERP");
+
+        assert_eq!(book.bids, vec![(64320.9, 8.0)]);
+        assert_eq!(book.asks, vec![(64321.5, 10.0)]);
+    }
+}

--- a/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
@@ -7,7 +7,7 @@ use crate::arch::{
     market_assets::{
         api_data::{
             account_data::{BalanceData, HistoOrderData, OrderAckData, PositionData},
-            price_data::{CandleData, TickerData},
+            price_data::{CandleData, OrderBookData, TickerData},
             utils_data::{FundingRateData, FundingRateInfo, InstrumentInfo},
         },
         api_general::{
@@ -32,7 +32,8 @@ use super::{
         all_mids::RestAllMidsHyperliquid, asset_ctxs::RestMetaAndAssetCtxsHyperliquid,
         candle::RestCandleHyperliquid, clearinghouse_state::RestClearinghouseStateHyperliquid,
         funding_history::RestFundingHistoryHyperliquid, meta::RestMetaHyperliquid,
-        order_status::RestOrderStatusHyperliquid, perp_dexs::RestPerpDexHyperliquid,
+        order_status::RestOrderStatusHyperliquid, orderbook::RestOrderBookHyperliquid,
+        perp_dexs::RestPerpDexHyperliquid,
         spot_clearinghouse_state::RestSpotClearinghouseStateHyperliquid,
         spot_meta::RestSpotMetaHyperliquid, trade_order::RestOrderAckHyperliquid,
     },
@@ -65,13 +66,23 @@ impl LobPublicRest for HyperliquidCli {
     async fn get_candles(
         &self,
         inst: &str,
+        inst_type: InstrumentType,
         interval: CandleParam,
         limit: Option<u32>,
         start_time_us: Option<u64>,
         end_time_us: Option<u64>,
     ) -> InfraResult<Vec<CandleData>> {
-        self._get_candles(inst, interval, limit, start_time_us, end_time_us)
+        self._get_candles(inst, inst_type, interval, limit, start_time_us, end_time_us)
             .await
+    }
+
+    async fn get_orderbook(
+        &self,
+        inst: &str,
+        inst_type: InstrumentType,
+        depth: usize,
+    ) -> InfraResult<OrderBookData> {
+        self._get_orderbook(inst, inst_type, depth).await
     }
 
     async fn get_instrument_info(
@@ -305,15 +316,13 @@ impl HyperliquidCli {
     async fn _get_candles(
         &self,
         inst: &str,
+        inst_type: InstrumentType,
         interval: CandleParam,
         limit: Option<u32>,
         start_time_us: Option<u64>,
         end_time_us: Option<u64>,
     ) -> InfraResult<Vec<CandleData>> {
-        let normalized_inst = normalize_hyperliquid_cli_inst(inst);
-        self._ensure_perp_quote_matches(&normalized_inst)?;
-        let quote = hyperliquid_cli_perp_quote(&normalized_inst)?;
-        let coin = self._inst_to_raw_perp_coin(&normalized_inst)?;
+        let coin = self._inst_to_trade_coin_for_type(inst, inst_type)?;
         let limit = limit.unwrap_or(Self::DEFAULT_CANDLE_LIMIT);
         let interval_ms = candle_interval_millis(&interval)?;
         let end_time = end_time_us
@@ -337,7 +346,7 @@ impl HyperliquidCli {
         let mut data: Vec<CandleData> = res
             .into_vec()?
             .into_iter()
-            .map(|entry| entry.into_candle_data(&quote))
+            .map(|entry| entry.into_candle_data(inst))
             .collect();
         data.sort_by_key(|candle| candle.timestamp);
 
@@ -346,6 +355,29 @@ impl HyperliquidCli {
         }
 
         Ok(data)
+    }
+
+    async fn _get_orderbook(
+        &self,
+        inst: &str,
+        inst_type: InstrumentType,
+        depth: usize,
+    ) -> InfraResult<OrderBookData> {
+        let coin = self._inst_to_trade_coin_for_type(inst, inst_type)?;
+        let body = json!({
+            "type": "l2Book",
+            "coin": coin,
+        });
+        let res: RestResHyperliquid<RestOrderBookHyperliquid> = self._post_info_raw(&body).await?;
+        let book = res
+            .into_vec()?
+            .into_iter()
+            .next()
+            .ok_or(InfraError::ApiCliError(
+                "No Hyperliquid l2Book data returned".into(),
+            ))?;
+
+        Ok(book.into_orderbook_data(inst, depth))
     }
 
     pub async fn get_perps_at_open_interest_cap(&self) -> InfraResult<Vec<String>> {
@@ -822,6 +854,70 @@ impl HyperliquidCli {
                     InfraError::ApiCliError(format!(
                         "Hyperliquid inst not found in inst_index_map: {}",
                         inst
+                    ))
+                }
+            })?;
+
+        Ok(format!("@{}", index))
+    }
+
+    fn _inst_to_trade_coin_for_type(
+        &self,
+        inst: &str,
+        inst_type: InstrumentType,
+    ) -> InfraResult<String> {
+        let normalized_inst = normalize_hyperliquid_cli_inst(inst);
+        match inst_type {
+            InstrumentType::Perpetual => {
+                if !is_hyperliquid_cli_perp_inst(&normalized_inst) {
+                    return Err(InfraError::ApiCliError(format!(
+                        "Hyperliquid perpetual instrument expected, got {}",
+                        inst
+                    )));
+                }
+                self._ensure_perp_quote_matches(&normalized_inst)?;
+                self._inst_to_raw_perp_coin(&normalized_inst)
+            },
+            InstrumentType::Spot => {
+                if is_hyperliquid_cli_perp_inst(&normalized_inst) {
+                    return Err(InfraError::ApiCliError(format!(
+                        "Hyperliquid spot instrument expected, got {}",
+                        inst
+                    )));
+                }
+                self._inst_to_spot_coin(&normalized_inst, inst)
+            },
+            _ => Err(InfraError::ApiCliError(format!(
+                "Hyperliquid market data supports Spot and Perpetual only, got {:?}",
+                inst_type
+            ))),
+        }
+    }
+
+    fn _inst_to_spot_coin(
+        &self,
+        normalized_inst: &str,
+        original_inst: &str,
+    ) -> InfraResult<String> {
+        if let Some(coin) = hyperliquid_cli_inst_to_raw_trade_coin(original_inst) {
+            return Ok(coin);
+        }
+
+        let index = self
+            .market_cache
+            .inst_index_map
+            .get(normalized_inst)
+            .copied()
+            .ok_or_else(|| {
+                if self.market_cache.inst_index_map.is_empty() {
+                    InfraError::ApiCliError(
+                        "Hyperliquid inst_index_map is empty, call init_inst_index_map() first"
+                            .into(),
+                    )
+                } else {
+                    InfraError::ApiCliError(format!(
+                        "Hyperliquid spot inst not found in inst_index_map: {}",
+                        original_inst
                     ))
                 }
             })?;

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest.rs
@@ -5,6 +5,7 @@ pub mod clearinghouse_state;
 pub mod funding_history;
 pub mod meta;
 pub mod order_status;
+pub mod orderbook;
 pub mod perp_dexs;
 pub mod spot_clearinghouse_state;
 pub mod spot_meta;

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest/candle.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest/candle.rs
@@ -4,7 +4,6 @@ use serde_json::Value;
 use crate::arch::market_assets::{
     api_data::price_data::CandleData,
     api_general::{ts_to_micros, value_to_f64},
-    exchange::hyperliquid::api_utils::hyperliquid_perp_to_cli,
 };
 
 #[allow(non_snake_case)]
@@ -21,10 +20,10 @@ pub struct RestCandleHyperliquid {
 }
 
 impl RestCandleHyperliquid {
-    pub fn into_candle_data(self, quote: &str) -> CandleData {
+    pub fn into_candle_data(self, inst: &str) -> CandleData {
         CandleData {
             timestamp: ts_to_micros(self.t),
-            inst: hyperliquid_perp_to_cli(&self.s, quote),
+            inst: inst.to_string(),
             open: value_to_f64(&self.o),
             high: value_to_f64(&self.h),
             low: value_to_f64(&self.l),

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest/orderbook.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest/orderbook.rs
@@ -1,0 +1,68 @@
+use serde::Deserialize;
+
+use crate::arch::market_assets::{
+    api_data::price_data::OrderBookData,
+    api_general::{ts_to_micros, value_to_f64},
+};
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestOrderBookHyperliquid {
+    pub levels: Vec<Vec<RestOrderBookLevelHyperliquid>>,
+    pub time: u64,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestOrderBookLevelHyperliquid {
+    pub px: serde_json::Value,
+    pub sz: serde_json::Value,
+}
+
+impl RestOrderBookHyperliquid {
+    pub fn into_orderbook_data(self, inst: &str, depth: usize) -> OrderBookData {
+        let mut levels = self.levels.into_iter();
+        let bids = levels.next().unwrap_or_default();
+        let asks = levels.next().unwrap_or_default();
+
+        OrderBookData {
+            timestamp: ts_to_micros(self.time),
+            inst: inst.to_string(),
+            bids: levels_to_pairs(bids, depth),
+            asks: levels_to_pairs(asks, depth),
+        }
+    }
+}
+
+fn levels_to_pairs(levels: Vec<RestOrderBookLevelHyperliquid>, depth: usize) -> Vec<(f64, f64)> {
+    let iter = levels
+        .into_iter()
+        .map(|level| (value_to_f64(&level.px), value_to_f64(&level.sz)));
+    if depth == 0 {
+        iter.collect()
+    } else {
+        iter.take(depth).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_hyperliquid_orderbook_snapshot() {
+        let raw = r#"{
+            "time": 1780540000123,
+            "levels": [
+                [{"px": "63900.0", "sz": "1.25", "n": 3}],
+                [{"px": "63901.0", "sz": "0.75", "n": 2}]
+            ]
+        }"#;
+
+        let parsed: RestOrderBookHyperliquid = serde_json::from_str(raw).unwrap();
+        let book = parsed.into_orderbook_data("BTC_USDC_PERP", 1);
+
+        assert_eq!(book.timestamp, 1_780_540_000_123_000);
+        assert_eq!(book.inst, "BTC_USDC_PERP");
+        assert_eq!(book.bids, vec![(63900.0, 1.25)]);
+        assert_eq!(book.asks, vec![(63901.0, 0.75)]);
+    }
+}

--- a/src/arch/market_assets/exchange/lob_clients.rs
+++ b/src/arch/market_assets/exchange/lob_clients.rs
@@ -56,23 +56,29 @@ impl LobPublicRest for LobClients {
         }
     }
 
-    async fn get_orderbook(&self, inst: &str, depth: usize) -> InfraResult<OrderBookData> {
+    async fn get_orderbook(
+        &self,
+        inst: &str,
+        inst_type: InstrumentType,
+        depth: usize,
+    ) -> InfraResult<OrderBookData> {
         match self {
-            LobClients::Hyperliquid(c) => c.get_orderbook(inst, depth).await,
-            LobClients::BinanceCm(c) => c.get_orderbook(inst, depth).await,
-            LobClients::BinanceSpot(c) => c.get_orderbook(inst, depth).await,
-            LobClients::BinanceUm(c) => c.get_orderbook(inst, depth).await,
-            LobClients::GateDelivery(c) => c.get_orderbook(inst, depth).await,
-            LobClients::GateFutures(c) => c.get_orderbook(inst, depth).await,
-            LobClients::GateSpot(c) => c.get_orderbook(inst, depth).await,
-            LobClients::GateUni(c) => c.get_orderbook(inst, depth).await,
-            LobClients::Okx(c) => c.get_orderbook(inst, depth).await,
+            LobClients::Hyperliquid(c) => c.get_orderbook(inst, inst_type, depth).await,
+            LobClients::BinanceCm(c) => c.get_orderbook(inst, inst_type, depth).await,
+            LobClients::BinanceSpot(c) => c.get_orderbook(inst, inst_type, depth).await,
+            LobClients::BinanceUm(c) => c.get_orderbook(inst, inst_type, depth).await,
+            LobClients::GateDelivery(c) => c.get_orderbook(inst, inst_type, depth).await,
+            LobClients::GateFutures(c) => c.get_orderbook(inst, inst_type, depth).await,
+            LobClients::GateSpot(c) => c.get_orderbook(inst, inst_type, depth).await,
+            LobClients::GateUni(c) => c.get_orderbook(inst, inst_type, depth).await,
+            LobClients::Okx(c) => c.get_orderbook(inst, inst_type, depth).await,
         }
     }
 
     async fn get_candles(
         &self,
         inst: &str,
+        inst_type: InstrumentType,
         interval: CandleParam,
         limit: Option<u32>,
         start_time_us: Option<u64>,
@@ -80,39 +86,39 @@ impl LobPublicRest for LobClients {
     ) -> InfraResult<Vec<CandleData>> {
         match self {
             LobClients::Hyperliquid(c) => {
-                c.get_candles(inst, interval, limit, start_time_us, end_time_us)
+                c.get_candles(inst, inst_type, interval, limit, start_time_us, end_time_us)
                     .await
             },
             LobClients::BinanceCm(c) => {
-                c.get_candles(inst, interval, limit, start_time_us, end_time_us)
+                c.get_candles(inst, inst_type, interval, limit, start_time_us, end_time_us)
                     .await
             },
             LobClients::BinanceSpot(c) => {
-                c.get_candles(inst, interval, limit, start_time_us, end_time_us)
+                c.get_candles(inst, inst_type, interval, limit, start_time_us, end_time_us)
                     .await
             },
             LobClients::BinanceUm(c) => {
-                c.get_candles(inst, interval, limit, start_time_us, end_time_us)
+                c.get_candles(inst, inst_type, interval, limit, start_time_us, end_time_us)
                     .await
             },
             LobClients::GateDelivery(c) => {
-                c.get_candles(inst, interval, limit, start_time_us, end_time_us)
+                c.get_candles(inst, inst_type, interval, limit, start_time_us, end_time_us)
                     .await
             },
             LobClients::GateFutures(c) => {
-                c.get_candles(inst, interval, limit, start_time_us, end_time_us)
+                c.get_candles(inst, inst_type, interval, limit, start_time_us, end_time_us)
                     .await
             },
             LobClients::GateSpot(c) => {
-                c.get_candles(inst, interval, limit, start_time_us, end_time_us)
+                c.get_candles(inst, inst_type, interval, limit, start_time_us, end_time_us)
                     .await
             },
             LobClients::GateUni(c) => {
-                c.get_candles(inst, interval, limit, start_time_us, end_time_us)
+                c.get_candles(inst, inst_type, interval, limit, start_time_us, end_time_us)
                     .await
             },
             LobClients::Okx(c) => {
-                c.get_candles(inst, interval, limit, start_time_us, end_time_us)
+                c.get_candles(inst, inst_type, interval, limit, start_time_us, end_time_us)
                     .await
             },
         }

--- a/src/arch/market_assets/exchange/okx/api_utils.rs
+++ b/src/arch/market_assets/exchange/okx/api_utils.rs
@@ -2,10 +2,11 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tracing::error;
 
-use crate::arch::market_assets::base_data::{
-    InstrumentType, MarginMode, PositionSide, SUBSCRIBE_LOWER,
+use crate::arch::{
+    market_assets::base_data::{InstrumentType, MarginMode, PositionSide, SUBSCRIBE_LOWER},
+    task_execution::task_ws::CandleParam,
 };
-use crate::arch::task_execution::task_ws::CandleParam;
+use crate::errors::InfraResult;
 
 pub fn ws_subscribe_msg_okx(channel: &str, insts: Option<&[String]>) -> String {
     let args: Vec<_> = match insts {
@@ -51,6 +52,27 @@ pub fn cli_perp_to_okx_inst(symbol: &str) -> String {
     }
 
     upper.replace('_', "-")
+}
+
+pub fn cli_inst_to_okx_inst(symbol: &str, inst_type: &InstrumentType) -> InfraResult<String> {
+    let upper = symbol.to_uppercase();
+    match inst_type {
+        InstrumentType::Spot => Ok(upper.replace('_', "-")),
+        InstrumentType::Perpetual => {
+            if upper.ends_with("-SWAP") {
+                Ok(upper)
+            } else if let Some(pair) = upper.strip_suffix("_PERP") {
+                Ok(format!("{}-SWAP", pair.replace('_', "-")))
+            } else {
+                Ok(format!("{}-SWAP", upper.replace('_', "-")))
+            }
+        },
+        InstrumentType::Futures => Ok(cli_perp_to_okx_inst(&upper)),
+        InstrumentType::Options => Ok(upper.replace('_', "-")),
+        InstrumentType::Unknown => Err(crate::errors::InfraError::ApiCliError(
+            "Unknown instrument type for OKX instId conversion".into(),
+        )),
+    }
 }
 
 pub fn okx_inst_to_cli(symbol: &str) -> String {
@@ -389,5 +411,17 @@ mod tests {
         assert_eq!(cli_perp_to_okx_inst("BTC_USDT_PERP"), "BTC-USDT-SWAP");
         assert_eq!(okx_inst_to_cli("BTC-USD-240329"), "BTC_USD_FUT_240329");
         assert_eq!(cli_perp_to_okx_inst("BTC_USD_FUT_240329"), "BTC-USD-240329");
+        assert_eq!(
+            cli_inst_to_okx_inst("BTC_USDT", &InstrumentType::Spot).unwrap(),
+            "BTC-USDT"
+        );
+        assert_eq!(
+            cli_inst_to_okx_inst("BTC_USDT", &InstrumentType::Perpetual).unwrap(),
+            "BTC-USDT-SWAP"
+        );
+        assert_eq!(
+            cli_inst_to_okx_inst("BTC_USD_FUT_240329", &InstrumentType::Futures).unwrap(),
+            "BTC-USD-240329"
+        );
     }
 }

--- a/src/arch/market_assets/exchange/okx/okx_cli.rs
+++ b/src/arch/market_assets/exchange/okx/okx_cli.rs
@@ -38,8 +38,8 @@ use super::{
         ct_public_subpositions_history::RestSubPositionHistoryOkx,
         funding_rate::RestFundingRateOkx, funding_rate_history::RestFundingRateHistoryOkx,
         market_ticker::RestMarketTickerOkx, order_history::RestOrderHistoryOkx,
-        price_limit::RestPriceLimitOkx, public_instruments::RestInstrumentsOkx,
-        trade_order::RestOrderAckOkx,
+        orderbook::RestOrderBookOkx, price_limit::RestPriceLimitOkx,
+        public_instruments::RestInstrumentsOkx, trade_order::RestOrderAckOkx,
     },
 };
 
@@ -84,13 +84,23 @@ impl LobPublicRest for OkxCli {
     async fn get_candles(
         &self,
         inst: &str,
+        inst_type: InstrumentType,
         interval: CandleParam,
         limit: Option<u32>,
         start_time_us: Option<u64>,
         end_time_us: Option<u64>,
     ) -> InfraResult<Vec<CandleData>> {
-        self._get_candles(inst, interval, limit, start_time_us, end_time_us)
+        self._get_candles(inst, inst_type, interval, limit, start_time_us, end_time_us)
             .await
+    }
+
+    async fn get_orderbook(
+        &self,
+        inst: &str,
+        inst_type: InstrumentType,
+        depth: usize,
+    ) -> InfraResult<OrderBookData> {
+        self._get_orderbook(inst, inst_type, depth).await
     }
 
     async fn get_instrument_info(
@@ -885,13 +895,14 @@ impl OkxCli {
     async fn _get_candles(
         &self,
         inst: &str,
+        inst_type: InstrumentType,
         interval: CandleParam,
         limit: Option<u32>,
         start_time_us: Option<u64>,
         end_time_us: Option<u64>,
     ) -> InfraResult<Vec<CandleData>> {
         let mut params = vec![
-            format!("instId={}", cli_perp_to_okx_inst(inst)),
+            format!("instId={}", cli_inst_to_okx_inst(inst, &inst_type)?),
             format!("bar={}", okx_candle_interval(&interval)),
         ];
         if let Some(limit) = limit {
@@ -924,6 +935,38 @@ impl OkxCli {
         data.sort_by_key(|candle| candle.timestamp);
 
         Ok(data)
+    }
+
+    async fn _get_orderbook(
+        &self,
+        inst: &str,
+        inst_type: InstrumentType,
+        depth: usize,
+    ) -> InfraResult<OrderBookData> {
+        let mut params = vec![format!(
+            "instId={}",
+            cli_inst_to_okx_inst(inst, &inst_type)?
+        )];
+        if depth > 0 {
+            if depth > 400 {
+                return Err(InfraError::ApiCliError(format!(
+                    "OKX orderbook supports at most 400 levels: {}",
+                    depth
+                )));
+            }
+            params.push(format!("sz={depth}"));
+        }
+
+        let url = format!("{}{}?{}", OKX_BASE_URL, OKX_MARKET_BOOKS, params.join("&"));
+        let response = self.client.get(url).send().await?;
+        let res: RestResOkx<RestOrderBookOkx> =
+            parse_json_response("Okx orderbook", response).await?;
+
+        res.into_vec()?
+            .into_iter()
+            .next()
+            .map(|entry| entry.into_orderbook_data(inst))
+            .ok_or_else(|| InfraError::ApiCliError("No OKX orderbook data returned".into()))
     }
 
     async fn _get_instrument_info(

--- a/src/arch/market_assets/exchange/okx/schemas/rest.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/rest.rs
@@ -21,6 +21,7 @@ pub mod funding_rate;
 pub mod funding_rate_history;
 pub mod market_ticker;
 pub mod order_history;
+pub mod orderbook;
 pub mod price_limit;
 pub mod public_instruments;
 pub mod trade_order;

--- a/src/arch/market_assets/exchange/okx/schemas/rest/orderbook.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/rest/orderbook.rs
@@ -1,0 +1,59 @@
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::arch::market_assets::{
+    api_data::price_data::OrderBookData,
+    api_general::{ts_to_micros, value_to_f64},
+};
+
+#[derive(Clone, Debug, Deserialize)]
+#[allow(non_snake_case)]
+pub struct RestOrderBookOkx {
+    pub asks: Vec<Vec<Value>>,
+    pub bids: Vec<Vec<Value>>,
+    pub ts: String,
+}
+
+impl RestOrderBookOkx {
+    pub fn into_orderbook_data(self, inst: &str) -> OrderBookData {
+        OrderBookData {
+            timestamp: ts_to_micros(self.ts.parse().unwrap_or_default()),
+            inst: inst.to_string(),
+            bids: levels_to_pairs(self.bids),
+            asks: levels_to_pairs(self.asks),
+        }
+    }
+}
+
+fn levels_to_pairs(levels: Vec<Vec<Value>>) -> Vec<(f64, f64)> {
+    levels
+        .into_iter()
+        .filter_map(|level| {
+            let price = level.first().map(value_to_f64)?;
+            let size = level.get(1).map(value_to_f64)?;
+            Some((price, size))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_okx_orderbook_snapshot() {
+        let raw = r#"{
+            "asks": [["63901.0", "0.75", "0", "2"]],
+            "bids": [["63900.0", "1.25", "0", "3"]],
+            "ts": "1780540000123"
+        }"#;
+
+        let parsed: RestOrderBookOkx = serde_json::from_str(raw).unwrap();
+        let book = parsed.into_orderbook_data("BTC_USDT_PERP");
+
+        assert_eq!(book.timestamp, 1_780_540_000_123_000);
+        assert_eq!(book.inst, "BTC_USDT_PERP");
+        assert_eq!(book.bids, vec![(63900.0, 1.25)]);
+        assert_eq!(book.asks, vec![(63901.0, 0.75)]);
+    }
+}

--- a/src/arch/traits/market_lob.rs
+++ b/src/arch/traits/market_lob.rs
@@ -35,6 +35,7 @@ pub trait LobPublicRest: Send + Sync {
     fn get_orderbook(
         &self,
         _inst: &str,
+        _inst_type: InstrumentType,
         _depth: usize,
     ) -> impl Future<Output = InfraResult<OrderBookData>> + Send {
         ready(Err(InfraError::Unimplemented))
@@ -44,6 +45,7 @@ pub trait LobPublicRest: Send + Sync {
     fn get_candles(
         &self,
         _inst: &str,
+        _inst_type: InstrumentType,
         _interval: CandleParam,
         _limit: Option<u32>,
         _start_time_us: Option<u64>,


### PR DESCRIPTION
## Summary
- Add inst-type-aware REST order book snapshots to LobPublicRest.
- Implement orderbook support for OKX, Hyperliquid, Binance UM futures, and Gate futures.
- Route candle requests with instrument type and bump crate version to 0.1.17.

## Breaking Changes
- LobPublicRest::get_orderbook now requires InstrumentType.
- LobPublicRest::get_candles now requires InstrumentType.

## Database Migrations
None.

## Merge Order
None.

## Related
None.

## Test Plan
- [x] cargo fmt --check
- [x] cargo test --features lob_clients
- [x] cargo run -- lob_market_data_probe from api_checkers against public exchange APIs