### PR TITLE
chore: harden exchange API response handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2024"
 
 readme = "README.md"

--- a/src/arch/market_assets/api_general.rs
+++ b/src/arch/market_assets/api_general.rs
@@ -10,6 +10,7 @@ use std::{
 use crate::arch::market_assets::base_data::{
     MarginMode, OrderSide, OrderType, PositionSide, TimeInForce,
 };
+use crate::arch::task_execution::task_ws::CandleParam;
 use crate::errors::{InfraError, InfraResult};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -106,6 +107,23 @@ pub fn ts_to_micros(ts: u64) -> u64 {
         0..=9_999_999_999 => ts * 1_000_000,
         10_000_000_000..=9_999_999_999_999 => ts * 1_000,
         _ => ts,
+    }
+}
+
+pub fn candle_interval_millis(interval: &CandleParam) -> InfraResult<u64> {
+    match interval {
+        CandleParam::OneSecond => Ok(1_000),
+        CandleParam::OneMinute => Ok(60_000),
+        CandleParam::FiveMinutes => Ok(5 * 60_000),
+        CandleParam::FifteenMinutes => Ok(15 * 60_000),
+        CandleParam::OneHour => Ok(60 * 60_000),
+        CandleParam::FourHours => Ok(4 * 60 * 60_000),
+        CandleParam::OneDay => Ok(24 * 60 * 60_000),
+        CandleParam::OneWeek => Ok(7 * 24 * 60 * 60_000),
+        CandleParam::Custom(value) => Err(InfraError::ApiCliError(format!(
+            "Candle interval duration is unknown for custom interval: {}",
+            value
+        ))),
     }
 }
 
@@ -253,4 +271,30 @@ pub struct OrderParams {
     pub time_in_force: Option<TimeInForce>, // GTC, IOC, FOK, GTD
     pub client_order_id: Option<String>,
     pub extra: HashMap<String, String>, // general
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_supported_candle_intervals_to_millis() {
+        assert_eq!(
+            candle_interval_millis(&CandleParam::OneSecond).unwrap(),
+            1_000
+        );
+        assert_eq!(
+            candle_interval_millis(&CandleParam::OneMinute).unwrap(),
+            60_000
+        );
+        assert_eq!(
+            candle_interval_millis(&CandleParam::OneWeek).unwrap(),
+            7 * 24 * 60 * 60_000
+        );
+    }
+
+    #[test]
+    fn rejects_custom_candle_interval_without_known_duration() {
+        assert!(candle_interval_millis(&CandleParam::Custom("2m".into())).is_err());
+    }
 }

--- a/src/arch/market_assets/exchange/binance/schemas/um_futures_rest/order_history.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/um_futures_rest/order_history.rs
@@ -18,7 +18,8 @@ pub struct RestOrderHistoryBinanceUM {
     pub avgPrice: Option<String>,
     pub origQty: String,
     pub executedQty: String,
-    pub cumQuote: String,
+    #[serde(default)]
+    pub cumQuote: Option<String>,
     pub status: String,
     pub timeInForce: String,
     pub r#type: String,
@@ -104,5 +105,37 @@ impl From<RestOrderHistoryBinanceUM> for HistoOrderData {
             update_time: ts_to_micros(d.updateTime),
             fee_currency: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn parses_order_history_without_cum_quote() {
+        let order: RestOrderHistoryBinanceUM = serde_json::from_value(json!({
+            "symbol": "LABUSDT",
+            "orderId": 4639403608_u64,
+            "clientOrderId": "dpYARrVywce855tPrX9P8s",
+            "price": "0",
+            "avgPrice": "14.7157407",
+            "origQty": "27",
+            "executedQty": "27",
+            "status": "FILLED",
+            "timeInForce": "GTC",
+            "type": "MARKET",
+            "side": "SELL",
+            "positionSide": "BOTH",
+            "reduceOnly": false,
+            "time": 1782726621000_u64,
+            "updateTime": 1782726621000_u64
+        }))
+        .unwrap();
+
+        assert_eq!(order.cumQuote, None);
+        assert_eq!(order.executedQty, "27");
     }
 }

--- a/src/arch/market_assets/exchange/gate/api_key.rs
+++ b/src/arch/market_assets/exchange/gate/api_key.rs
@@ -12,7 +12,9 @@ use crate::arch::market_assets::{
 };
 use crate::errors::{InfraError, InfraResult};
 
-use super::api_utils::GATE_CHANNEL_ID_HEADER;
+use super::api_utils::{
+    GATE_CHANNEL_ID_HEADER, GATE_SIZE_DECIMAL_HEADER, GATE_SIZE_DECIMAL_HEADER_VALUE,
+};
 
 #[allow(dead_code)]
 pub fn read_gate_env_key() -> InfraResult<GateKey> {
@@ -115,6 +117,7 @@ impl GateKey {
             .header("KEY", &self.api_key)
             .header("SIGN", &signature.signature)
             .header("Timestamp", signature.timestamp.to_string())
+            .header(GATE_SIZE_DECIMAL_HEADER, GATE_SIZE_DECIMAL_HEADER_VALUE)
             .send()
             .await?;
 
@@ -145,6 +148,7 @@ impl GateKey {
             .header("KEY", &self.api_key)
             .header("SIGN", &signature.signature)
             .header("Timestamp", signature.timestamp.to_string())
+            .header(GATE_SIZE_DECIMAL_HEADER, GATE_SIZE_DECIMAL_HEADER_VALUE)
             .header("Content-Type", "application/json");
 
         if let Some(channel_id) = channel_id {
@@ -168,6 +172,7 @@ impl GateKey {
             .header("KEY", &self.api_key)
             .header("SIGN", &signature.signature)
             .header("Timestamp", signature.timestamp.to_string())
+            .header(GATE_SIZE_DECIMAL_HEADER, GATE_SIZE_DECIMAL_HEADER_VALUE)
             .header("Content-Type", "application/json")
             .body(body.to_string())
             .send()
@@ -188,6 +193,7 @@ impl GateKey {
             .header("KEY", &self.api_key)
             .header("SIGN", &signature.signature)
             .header("Timestamp", signature.timestamp.to_string())
+            .header(GATE_SIZE_DECIMAL_HEADER, GATE_SIZE_DECIMAL_HEADER_VALUE)
             .header("Content-Type", "application/json")
             .body(body.to_string())
             .send()

--- a/src/arch/market_assets/exchange/gate/api_utils.rs
+++ b/src/arch/market_assets/exchange/gate/api_utils.rs
@@ -10,6 +10,8 @@ use crate::errors::{InfraError, InfraResult};
 
 pub const GATE_CHANNEL_ID_EXTRA_KEY: &str = "gate_channel_id";
 pub const GATE_CHANNEL_ID_HEADER: &str = "X-Gate-Channel-Id";
+pub const GATE_SIZE_DECIMAL_HEADER: &str = "X-Gate-Size-Decimal";
+pub const GATE_SIZE_DECIMAL_HEADER_VALUE: &str = "1";
 
 pub(crate) fn value_to_order_id(value: Option<&Value>) -> Option<String> {
     match value {

--- a/src/arch/market_assets/exchange/gate/schemas/futures_rest/account_position.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/futures_rest/account_position.rs
@@ -49,3 +49,34 @@ impl From<RestAccountPosGateFutures> for PositionData {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::arch::market_assets::base_data::PositionSide;
+
+    use super::*;
+
+    #[test]
+    fn converts_decimal_contract_position_size() {
+        let raw: RestAccountPosGateFutures = serde_json::from_value(json!({
+            "contract": "LAB_USDT",
+            "size": "0.1",
+            "entry_price": "14.64758",
+            "mark_price": "13.8101",
+            "initial_margin": "27.72377575",
+            "lever": "5",
+            "update_time": 1782726621
+        }))
+        .unwrap();
+
+        let position = PositionData::from(raw);
+
+        assert_eq!(position.inst, "LAB_USDT_PERP");
+        assert_eq!(position.position_side, PositionSide::Long);
+        assert_eq!(position.size, 0.1);
+        assert_eq!(position.avg_price, 14.64758);
+        assert_eq!(position.mark_price, 13.8101);
+    }
+}

--- a/src/arch/market_assets/exchange/gate/schemas/futures_rest/order_history.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/futures_rest/order_history.rs
@@ -118,3 +118,39 @@ fn parse_time_in_force(tif: Option<&str>) -> Option<TimeInForce> {
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn converts_decimal_contract_order_history_size() {
+        let raw: RestFuturesOrderHistoryGateFutures = serde_json::from_value(json!({
+            "id": 281193504063418585_i64,
+            "contract": "LAB_USDT",
+            "size": "-0.1",
+            "left": "0",
+            "price": "0",
+            "fill_price": "14.64758",
+            "status": "finished",
+            "finish_as": "filled",
+            "create_time": 1782726621.0,
+            "update_time": 1782726621.0,
+            "finish_time": 1782726621.0,
+            "text": "api",
+            "tif": "ioc"
+        }))
+        .unwrap();
+
+        let order = HistoOrderData::from(raw);
+
+        assert_eq!(order.inst, "LAB_USDT_PERP");
+        assert_eq!(order.side, OrderSide::SELL);
+        assert_eq!(order.order_status, OrderStatus::Filled);
+        assert_eq!(order.size, 0.1);
+        assert_eq!(order.executed_size, 0.1);
+        assert_eq!(order.avg_price, 14.64758);
+    }
+}

--- a/src/arch/market_assets/exchange/gate/schemas/futures_ws/account_order.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/futures_ws/account_order.rs
@@ -174,4 +174,30 @@ mod tests {
         assert_eq!(ws.order_id.as_deref(), Some("123456789"));
         assert_eq!(ws.cli_order_id.as_deref(), Some("gate-futures-client-id"));
     }
+
+    #[test]
+    fn into_ws_converts_decimal_contract_size() {
+        let raw: WsAccountOrderGateFutures = serde_json::from_value(json!({
+            "id": "281193504063418585",
+            "contract": "LAB_USDT",
+            "size": "0.1",
+            "left": "0",
+            "price": "0",
+            "fill_price": "14.64758",
+            "status": "finished",
+            "finish_as": "filled",
+            "update_time": 1782726621_u64,
+            "create_time_ms": 1782726621776_u64,
+            "tif": "ioc",
+            "text": "api"
+        }))
+        .unwrap();
+
+        let ws = raw.into_ws();
+
+        assert_eq!(ws.inst, "LAB_USDT_PERP");
+        assert_eq!(ws.size, 0.1);
+        assert_eq!(ws.filled_size, 0.1);
+        assert_eq!(ws.status, OrderStatus::Filled);
+    }
 }

--- a/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
@@ -11,7 +11,8 @@ use crate::arch::{
             utils_data::{FundingRateData, FundingRateInfo, InstrumentInfo},
         },
         api_general::{
-            OrderParams, get_micros_timestamp, get_mills_timestamp, parse_json_response,
+            OrderParams, candle_interval_millis, get_micros_timestamp, get_mills_timestamp,
+            parse_json_response,
         },
         base_data::{InstrumentType, MarginMode},
     },
@@ -29,13 +30,21 @@ use super::{
     config_assets::*,
     hyperliquid_rest_msg::RestResHyperliquid,
     schemas::rest::{
-        all_mids::RestAllMidsHyperliquid, asset_ctxs::RestMetaAndAssetCtxsHyperliquid,
-        candle::RestCandleHyperliquid, clearinghouse_state::RestClearinghouseStateHyperliquid,
-        funding_history::RestFundingHistoryHyperliquid, meta::RestMetaHyperliquid,
-        order_status::RestOrderStatusHyperliquid, orderbook::RestOrderBookHyperliquid,
+        all_mids::RestAllMidsHyperliquid,
+        asset_ctxs::RestMetaAndAssetCtxsHyperliquid,
+        candle::RestCandleHyperliquid,
+        clearinghouse_state::RestClearinghouseStateHyperliquid,
+        funding_history::RestFundingHistoryHyperliquid,
+        meta::RestMetaHyperliquid,
+        order_status::{
+            RestOrderStatusHyperliquid, finalize_hyperliquid_order_history,
+            validate_hyperliquid_order_history_range,
+        },
+        orderbook::RestOrderBookHyperliquid,
         perp_dexs::RestPerpDexHyperliquid,
         spot_clearinghouse_state::RestSpotClearinghouseStateHyperliquid,
-        spot_meta::RestSpotMetaHyperliquid, trade_order::RestOrderAckHyperliquid,
+        spot_meta::RestSpotMetaHyperliquid,
+        trade_order::RestOrderAckHyperliquid,
     },
 };
 
@@ -657,11 +666,13 @@ impl HyperliquidCli {
     async fn _get_order_history(
         &self,
         inst: &str,
-        _start_time: Option<u64>,
-        _end_time: Option<u64>,
+        start_time: Option<u64>,
+        end_time: Option<u64>,
         limit: Option<u32>,
         order_id: Option<&str>,
     ) -> InfraResult<Vec<HistoOrderData>> {
+        validate_hyperliquid_order_history_range(start_time, end_time)?;
+
         let user = self._owner_address()?;
         let body = match order_id {
             Some(order_id) => json!({
@@ -690,19 +701,20 @@ impl HyperliquidCli {
         let res: RestResHyperliquid<RestOrderStatusHyperliquid> =
             self._post_info_raw(&body).await?;
 
-        let mut data: Vec<HistoOrderData> = res
+        let data: Vec<HistoOrderData> = res
             .into_vec()?
             .into_iter()
             .map(|order| order.into_histo_order_data(perp_quote.as_deref()))
-            .filter(|order| order.inst == normalized_inst)
             .collect();
 
-        data.sort_by_key(|b| std::cmp::Reverse(b.update_time));
-        if let Some(limit) = limit {
-            data.truncate(limit as usize);
-        }
-
-        Ok(data)
+        finalize_hyperliquid_order_history(
+            data,
+            &normalized_inst,
+            start_time,
+            end_time,
+            limit,
+            order_id.is_none(),
+        )
     }
 
     fn _get_public_connect_msg(&self, channel: &WsChannel) -> InfraResult<String> {
@@ -1066,22 +1078,5 @@ impl HyperliquidCli {
         } else {
             hyperliquid_index_to_asset_id(InstrumentType::Spot, index)
         }
-    }
-}
-
-fn candle_interval_millis(interval: &CandleParam) -> InfraResult<u64> {
-    match interval {
-        CandleParam::OneSecond => Ok(1_000),
-        CandleParam::OneMinute => Ok(60_000),
-        CandleParam::FiveMinutes => Ok(5 * 60_000),
-        CandleParam::FifteenMinutes => Ok(15 * 60_000),
-        CandleParam::OneHour => Ok(60 * 60_000),
-        CandleParam::FourHours => Ok(4 * 60 * 60_000),
-        CandleParam::OneDay => Ok(24 * 60 * 60_000),
-        CandleParam::OneWeek => Ok(7 * 24 * 60 * 60_000),
-        CandleParam::Custom(value) => Err(InfraError::ApiCliError(format!(
-            "Hyperliquid candle interval duration is unknown for custom interval: {}",
-            value
-        ))),
     }
 }

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest/order_status.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest/order_status.rs
@@ -7,6 +7,9 @@ use crate::arch::market_assets::{
     base_data::{OrderSide, OrderStatus, OrderType},
     exchange::hyperliquid::api_utils::{hyperliquid_inst_to_cli, hyperliquid_perp_to_cli},
 };
+use crate::errors::{InfraError, InfraResult};
+
+const HYPERLIQUID_HISTORICAL_ORDERS_RECENT_LIMIT: usize = 2_000;
 
 #[allow(non_snake_case)]
 #[derive(Clone, Debug, Deserialize)]
@@ -92,5 +95,182 @@ fn parse_order_status(status: &str, filled_size: f64) -> OrderStatus {
         OrderStatus::Rejected
     } else {
         OrderStatus::Unknown
+    }
+}
+
+pub fn validate_hyperliquid_order_history_range(
+    start_time_ms: Option<u64>,
+    end_time_ms: Option<u64>,
+) -> InfraResult<()> {
+    if let Some(end_time_ms) = end_time_ms
+        && let Some(start_time_ms) = start_time_ms
+        && end_time_ms < start_time_ms
+    {
+        return Err(InfraError::ApiCliError(format!(
+            "Hyperliquid order history end_time_ms {} is earlier than start_time_ms {}",
+            end_time_ms, start_time_ms
+        )));
+    }
+
+    Ok(())
+}
+
+pub fn finalize_hyperliquid_order_history(
+    data: Vec<HistoOrderData>,
+    normalized_inst: &str,
+    start_time_ms: Option<u64>,
+    end_time_ms: Option<u64>,
+    limit: Option<u32>,
+    require_recent_window_coverage: bool,
+) -> InfraResult<Vec<HistoOrderData>> {
+    if require_recent_window_coverage {
+        ensure_recent_orders_cover_start(&data, start_time_ms)?;
+    }
+
+    Ok(filter_order_history(
+        data,
+        normalized_inst,
+        start_time_ms,
+        end_time_ms,
+        limit,
+    ))
+}
+
+fn order_history_time(order: &HistoOrderData) -> u64 {
+    order.update_time.max(order.timestamp)
+}
+
+fn millis_to_micros(timestamp_ms: u64) -> u64 {
+    timestamp_ms.saturating_mul(1_000)
+}
+
+fn filter_order_history(
+    mut data: Vec<HistoOrderData>,
+    normalized_inst: &str,
+    start_time_ms: Option<u64>,
+    end_time_ms: Option<u64>,
+    limit: Option<u32>,
+) -> Vec<HistoOrderData> {
+    let start_time_us = start_time_ms.map(millis_to_micros);
+    let end_time_us = end_time_ms.map(millis_to_micros);
+
+    data.retain(|order| {
+        if order.inst != normalized_inst {
+            return false;
+        }
+
+        let order_time = order_history_time(order);
+        start_time_us.is_none_or(|start| order_time >= start)
+            && end_time_us.is_none_or(|end| order_time <= end)
+    });
+
+    data.sort_by_key(|order| std::cmp::Reverse(order_history_time(order)));
+    if let Some(limit) = limit {
+        data.truncate(limit as usize);
+    }
+
+    data
+}
+
+fn ensure_recent_orders_cover_start(
+    data: &[HistoOrderData],
+    start_time_ms: Option<u64>,
+) -> InfraResult<()> {
+    let Some(start_time_ms) = start_time_ms else {
+        return Ok(());
+    };
+
+    if data.len() < HYPERLIQUID_HISTORICAL_ORDERS_RECENT_LIMIT {
+        return Ok(());
+    }
+
+    let Some(earliest_returned_us) = data.iter().map(order_history_time).min() else {
+        return Ok(());
+    };
+
+    let start_time_us = millis_to_micros(start_time_ms);
+    if earliest_returned_us > start_time_us {
+        return Err(InfraError::ApiCliError(format!(
+            "Hyperliquid historicalOrders only returns the most recent {} orders; requested startTime={}ms is older than earliest returned order update_time={}ms",
+            HYPERLIQUID_HISTORICAL_ORDERS_RECENT_LIMIT,
+            start_time_ms,
+            earliest_returned_us / 1_000
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn histo_order(inst: &str, order_id: &str, update_time: u64) -> HistoOrderData {
+        HistoOrderData {
+            timestamp: update_time.saturating_sub(1_000),
+            inst: inst.to_string(),
+            order_id: order_id.to_string(),
+            cli_order_id: None,
+            side: OrderSide::BUY,
+            position_side: None,
+            order_type: OrderType::Limit,
+            order_status: OrderStatus::Filled,
+            price: 1.0,
+            avg_price: 1.0,
+            size: 1.0,
+            executed_size: 1.0,
+            fee: None,
+            fee_currency: None,
+            reduce_only: None,
+            time_in_force: None,
+            update_time,
+        }
+    }
+
+    #[test]
+    fn filters_hyperliquid_order_history_by_inst_time_and_limit() {
+        let data = vec![
+            histo_order("BTC_USDC_PERP", "old", 1_000_000),
+            histo_order("BTC_USDC_PERP", "middle", 2_000_000),
+            histo_order("BTC_USDC_PERP", "new", 3_000_000),
+            histo_order("ETH_USDC_PERP", "other", 3_500_000),
+        ];
+
+        let filtered = finalize_hyperliquid_order_history(
+            data,
+            "BTC_USDC_PERP",
+            Some(1_500),
+            Some(3_500),
+            Some(2),
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(
+            filtered
+                .iter()
+                .map(|order| order.order_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["new", "middle"]
+        );
+    }
+
+    #[test]
+    fn rejects_time_range_older_than_full_recent_historical_orders_window() {
+        let data = (0..HYPERLIQUID_HISTORICAL_ORDERS_RECENT_LIMIT)
+            .map(|idx| histo_order("BTC_USDC_PERP", &idx.to_string(), 2_000_000 + idx as u64))
+            .collect::<Vec<_>>();
+
+        let err = finalize_hyperliquid_order_history(
+            data,
+            "BTC_USDC_PERP",
+            Some(1_000),
+            None,
+            None,
+            true,
+        )
+        .unwrap_err();
+
+        assert!(format!("{err:?}").contains("historicalOrders only returns the most recent"));
     }
 }


### PR DESCRIPTION
## Summary
- add Gate X-Gate-Size-Decimal support and decimal-size parsing coverage for futures position/order payloads
- make Binance UM order-history cumQuote optional so missing cumulative quote fields do not break deserialization
- add common candle interval duration helper and fail-loud Hyperliquid order-history filtering for recent historicalOrders windows

## Tests
- cargo fmt
- cargo test --features gate converts_decimal_contract --lib
- cargo test --features binance parses_order_history_without_cum_quote --lib
- cargo test --features hyperliquid maps_supported_candle_intervals_to_millis --lib
- cargo test --features hyperliquid rejects_custom_candle_interval_without_known_duration --lib
- cargo test --features hyperliquid hyperliquid_order_history --lib
- cargo test --features hyperliquid rejects_time_range_older_than_full_recent_historical_orders_window --lib
- cargo check --features hyperliquid
- cargo check --features "gate binance hyperliquid"