### PR TITLE
feat: add websocket connect targets for decimal sizes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.1.19"
+version = "0.2.0"
 edition = "2024"
 
 readme = "README.md"

--- a/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
@@ -15,6 +15,7 @@ use crate::arch::{
         },
         base_data::{InstrumentType, MarginMode, OrderSide, OrderType, SUBSCRIBE_LOWER},
     },
+    strategy_base::command::command_core::WsConnectTarget,
     task_execution::task_ws::{CandleParam, LobParam, WsChannel},
     traits::{
         conversion::IntoInfraVec,
@@ -146,6 +147,25 @@ impl LobWebsocket for GateFuturesCli {
     async fn get_private_connect_msg(&self, _channel: &WsChannel) -> InfraResult<String> {
         Ok(GATE_FUTURES_WS_USDT.into())
     }
+
+    async fn get_public_connect_target(
+        &self,
+        _channel: &WsChannel,
+    ) -> InfraResult<WsConnectTarget> {
+        Ok(gate_futures_connect_target())
+    }
+
+    async fn get_private_connect_target(
+        &self,
+        _channel: &WsChannel,
+    ) -> InfraResult<WsConnectTarget> {
+        Ok(gate_futures_connect_target())
+    }
+}
+
+fn gate_futures_connect_target() -> WsConnectTarget {
+    WsConnectTarget::new(GATE_FUTURES_WS_USDT)
+        .with_header(GATE_SIZE_DECIMAL_HEADER, GATE_SIZE_DECIMAL_HEADER_VALUE)
 }
 
 impl GateFuturesCli {
@@ -831,10 +851,33 @@ impl GateFuturesCli {
 #[cfg(test)]
 mod tests {
     use crate::arch::{
-        market_assets::exchange::gate::gate_futures_cli::GateFuturesCli,
+        market_assets::exchange::gate::{
+            api_utils::{GATE_SIZE_DECIMAL_HEADER, GATE_SIZE_DECIMAL_HEADER_VALUE},
+            gate_futures_cli::GateFuturesCli,
+        },
         task_execution::task_ws::{LobFrequency, LobParam, WsChannel},
         traits::market_lob::LobWebsocket,
     };
+
+    #[tokio::test]
+    async fn gate_futures_connect_target_requests_decimal_sizes() {
+        let cli = GateFuturesCli::default();
+
+        let public = cli
+            .get_public_connect_target(&WsChannel::Lob(Some(LobParam::Bbo { frequency: None })))
+            .await
+            .unwrap();
+        let private = cli
+            .get_private_connect_target(&WsChannel::AccountPositions)
+            .await
+            .unwrap();
+
+        for target in [public, private] {
+            assert!(target.headers.iter().any(|(name, value)| {
+                name == GATE_SIZE_DECIMAL_HEADER && value == GATE_SIZE_DECIMAL_HEADER_VALUE
+            }));
+        }
+    }
 
     #[tokio::test]
     async fn builds_gate_lob_subscription_messages() {

--- a/src/arch/market_assets/exchange/lob_clients.rs
+++ b/src/arch/market_assets/exchange/lob_clients.rs
@@ -7,6 +7,7 @@ use crate::arch::{
         api_general::OrderParams,
         base_data::InstrumentType,
     },
+    strategy_base::command::command_core::WsConnectTarget,
     task_execution::task_ws::{CandleParam, WsChannel},
     traits::market_lob::*,
 };
@@ -297,6 +298,20 @@ impl LobWebsocket for LobClients {
         }
     }
 
+    async fn get_public_connect_target(&self, channel: &WsChannel) -> InfraResult<WsConnectTarget> {
+        match self {
+            LobClients::Hyperliquid(c) => c.get_public_connect_target(channel).await,
+            LobClients::BinanceCm(c) => c.get_public_connect_target(channel).await,
+            LobClients::BinanceSpot(c) => c.get_public_connect_target(channel).await,
+            LobClients::BinanceUm(c) => c.get_public_connect_target(channel).await,
+            LobClients::GateDelivery(c) => c.get_public_connect_target(channel).await,
+            LobClients::GateFutures(c) => c.get_public_connect_target(channel).await,
+            LobClients::GateSpot(c) => c.get_public_connect_target(channel).await,
+            LobClients::GateUni(c) => c.get_public_connect_target(channel).await,
+            LobClients::Okx(c) => c.get_public_connect_target(channel).await,
+        }
+    }
+
     async fn get_private_connect_msg(&self, channel: &WsChannel) -> InfraResult<String> {
         match self {
             LobClients::Hyperliquid(c) => c.get_private_connect_msg(channel).await,
@@ -308,6 +323,23 @@ impl LobWebsocket for LobClients {
             LobClients::GateSpot(c) => c.get_private_connect_msg(channel).await,
             LobClients::GateUni(c) => c.get_private_connect_msg(channel).await,
             LobClients::Okx(c) => c.get_private_connect_msg(channel).await,
+        }
+    }
+
+    async fn get_private_connect_target(
+        &self,
+        channel: &WsChannel,
+    ) -> InfraResult<WsConnectTarget> {
+        match self {
+            LobClients::Hyperliquid(c) => c.get_private_connect_target(channel).await,
+            LobClients::BinanceCm(c) => c.get_private_connect_target(channel).await,
+            LobClients::BinanceSpot(c) => c.get_private_connect_target(channel).await,
+            LobClients::BinanceUm(c) => c.get_private_connect_target(channel).await,
+            LobClients::GateDelivery(c) => c.get_private_connect_target(channel).await,
+            LobClients::GateFutures(c) => c.get_private_connect_target(channel).await,
+            LobClients::GateSpot(c) => c.get_private_connect_target(channel).await,
+            LobClients::GateUni(c) => c.get_private_connect_target(channel).await,
+            LobClients::Okx(c) => c.get_private_connect_target(channel).await,
         }
     }
 }

--- a/src/arch/strategy_base/command/command_core.rs
+++ b/src/arch/strategy_base/command/command_core.rs
@@ -225,6 +225,14 @@ pub enum TaskCommand {
         ack: AckHandle,
     },
 
+    /// Opens a websocket connection with explicit connect metadata.
+    WsConnectWithTarget {
+        /// Websocket URL plus optional HTTP upgrade headers.
+        target: WsConnectTarget,
+        /// Acknowledgement handle, usually expected as `AckStatus::WsConnect`.
+        ack: AckHandle,
+    },
+
     /// Sends an arbitrary websocket text message through an open relay.
     ///
     /// Use this for login, authentication, subscription, unsubscription, ping,
@@ -282,5 +290,28 @@ impl TaskCommand {
             TaskCommand::WsMessage { ack, .. } | TaskCommand::WsShutdown { ack, .. } => Some(ack),
             _ => None,
         }
+    }
+}
+
+/// Websocket connection target used by websocket relay commands.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WsConnectTarget {
+    /// Websocket URL.
+    pub url: String,
+    /// Additional HTTP headers to include in the websocket upgrade request.
+    pub headers: Vec<(String, String)>,
+}
+
+impl WsConnectTarget {
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            headers: Vec::new(),
+        }
+    }
+
+    pub fn with_header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers.push((key.into(), value.into()));
+        self
     }
 }

--- a/src/arch/task_execution/register_ws.rs
+++ b/src/arch/task_execution/register_ws.rs
@@ -20,7 +20,12 @@ use tokio::{
     time::{Duration, error::Elapsed, sleep, timeout},
 };
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
-use tungstenite::{Bytes, Error, protocol::Message};
+use tungstenite::{
+    Bytes, Error,
+    client::IntoClientRequest,
+    http::{HeaderName, HeaderValue},
+    protocol::Message,
+};
 
 use tracing::{error, info, warn};
 
@@ -29,7 +34,7 @@ use crate::arch::{
     strategy_base::{
         command::{
             ack_handle::{AckHandle, AckStatus},
-            command_core::TaskCommand,
+            command_core::{TaskCommand, WsConnectTarget},
         },
         handler::handler_core::*,
     },
@@ -54,8 +59,23 @@ pub(crate) struct WsTaskBuilder {
 
 #[allow(dead_code)]
 impl WsTaskBuilder {
-    async fn connect_websocket(&self, url: &str) -> InfraResult<WsStream> {
-        let (ws_stream, _) = connect_async(url).await.map_err(|e| {
+    async fn connect_websocket(&self, target: WsConnectTarget) -> InfraResult<WsStream> {
+        let mut request = target.url.into_client_request().map_err(|e| {
+            error!("WebSocket request build failed: {:?}", e);
+            InfraError::WebSocket(Box::new(e))
+        })?;
+
+        for (key, value) in target.headers {
+            let header_name = HeaderName::from_bytes(key.as_bytes()).map_err(|e| {
+                InfraError::Msg(format!("Invalid websocket header name {}: {}", key, e))
+            })?;
+            let header_value = HeaderValue::from_str(&value).map_err(|e| {
+                InfraError::Msg(format!("Invalid websocket header value for {}: {}", key, e))
+            })?;
+            request.headers_mut().insert(header_name, header_value);
+        }
+
+        let (ws_stream, _) = connect_async(request).await.map_err(|e| {
             error!("WebSocket connection failed: {:?}", e);
             InfraError::WebSocket(Box::new(e))
         })?;
@@ -276,8 +296,9 @@ impl WsTaskBuilder {
             self.log(LogLevel::Info, "Initiated");
 
             let initial_command = self.cmd_rx.recv().await;
-            let (url, ack) = match initial_command {
-                Some(TaskCommand::WsConnect { msg, ack }) => (msg, ack),
+            let (target, ack) = match initial_command {
+                Some(TaskCommand::WsConnect { msg, ack }) => (WsConnectTarget::new(msg), ack),
+                Some(TaskCommand::WsConnectWithTarget { target, ack }) => (target, ack),
                 Some(cmd) => {
                     self.log(
                         LogLevel::Warn,
@@ -291,7 +312,7 @@ impl WsTaskBuilder {
                 },
             };
 
-            let mut ws_stream = match self.connect_websocket(&url).await {
+            let mut ws_stream = match self.connect_websocket(target).await {
                 Ok(ws) => ws,
                 Err(e) => {
                     self.log(LogLevel::Error, &format!("Failed to connect ws: {:?}", e));

--- a/src/arch/traits/market_lob.rs
+++ b/src/arch/traits/market_lob.rs
@@ -6,6 +6,7 @@ use crate::arch::{
         api_general::OrderParams,
         base_data::InstrumentType,
     },
+    strategy_base::command::command_core::WsConnectTarget,
     task_execution::task_ws::{CandleParam, WsChannel},
 };
 use crate::errors::{InfraError, InfraResult};
@@ -160,11 +161,27 @@ pub trait LobWebsocket: Send + Sync {
         ready(Err(InfraError::Unimplemented))
     }
 
+    /// Builds or returns a public websocket connection target.
+    fn get_public_connect_target(
+        &self,
+        _channel: &WsChannel,
+    ) -> impl Future<Output = InfraResult<WsConnectTarget>> + Send {
+        ready(Err(InfraError::Unimplemented))
+    }
+
     /// Builds or returns a private websocket connection target.
     fn get_private_connect_msg(
         &self,
         _channel: &WsChannel,
     ) -> impl Future<Output = InfraResult<String>> + Send {
+        ready(Err(InfraError::Unimplemented))
+    }
+
+    /// Builds or returns a private websocket connection target.
+    fn get_private_connect_target(
+        &self,
+        _channel: &WsChannel,
+    ) -> impl Future<Output = InfraResult<WsConnectTarget>> + Send {
         ready(Err(InfraError::Unimplemented))
     }
 }


### PR DESCRIPTION
Summary: add WsConnectTarget and WsConnectWithTarget for websocket upgrade metadata; wire Gate futures public/private connect targets to request X-Gate-Size-Decimal: 1; dispatch connect targets through LobClients; bump extrema_infra to 0.2.0. Validation: cargo fmt; cargo check; cargo check --features gate; cargo test --features gate gate_futures_connect_target_requests_decimal_sizes. Manual api_checker evidence: Gate public BBO old path returned LAB size 0.0/delete while new header path returned decimal size; Gate private positions old path returned LAB size 0.0/Both while new header path returned size 0.1/Long.