### PR TITLE
feat: add Hyperliquid withdraw3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,11 +332,11 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-extrema_infra = { version = "0.1", features = ["all"] }
+extrema_infra = { version = "0.2", features = ["all"] }
 
 # Enable exchange clients explicitly when needed.
-# extrema_infra = { version = "0.1", features = ["hyperliquid", "okx"] }
-# extrema_infra = { version = "0.1", features = ["lob_clients"] }
+# extrema_infra = { version = "0.2", features = ["hyperliquid", "okx"] }
+# extrema_infra = { version = "0.2", features = ["lob_clients"] }
 
 # For local development.
 # extrema_infra = { path = "../extrema_infra", features = ["all"] }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -89,8 +89,8 @@ see [TLS Setup](#tls-setup).
 # Local workspace development:
 extrema_infra = { path = "../extrema_infra" }
 # Published crate usage:
-# extrema_infra = "0.1"
-tokio = { version = "1.52.3", features = ["full"] }
+# extrema_infra = "0.2"
+tokio = { version = "1.52", features = ["full"] }
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/examples/hyperliquid_api_usage_example.rs
+++ b/examples/hyperliquid_api_usage_example.rs
@@ -76,6 +76,7 @@ async fn main() -> InfraResult<()> {
         cli.auth = Some(HyperliquidAuth {
             owner_address: owner_address.to_ascii_lowercase(),
             agent_private_key: String::new(),
+            owner_private_key: None,
             vault_address: env::var("HYPERLIQUID_VAULT_ADDRESS")
                 .ok()
                 .map(|address| address.to_ascii_lowercase()),

--- a/src/arch/market_assets/exchange/hyperliquid/api_utils.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/api_utils.rs
@@ -403,6 +403,19 @@ pub struct HyperliquidUpdateLeverageAction {
 }
 
 #[derive(Clone, Debug, Serialize)]
+pub struct HyperliquidWithdraw3Action {
+    #[serde(rename = "type")]
+    pub kind: &'static str,
+    pub destination: String,
+    pub amount: String,
+    pub time: u64,
+    #[serde(rename = "signatureChainId")]
+    pub signature_chain_id: String,
+    #[serde(rename = "hyperliquidChain")]
+    pub hyperliquid_chain: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
 pub struct HyperliquidOrderRequest {
     #[serde(rename = "a")]
     asset: u32,

--- a/src/arch/market_assets/exchange/hyperliquid/auth.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/auth.rs
@@ -11,7 +11,7 @@ use crate::arch::market_assets::{
 };
 use crate::errors::{InfraError, InfraResult};
 
-use super::config_assets::*;
+use super::{api_utils::HyperliquidWithdraw3Action, config_assets::*};
 
 pub fn read_hyperliquid_env_auth() -> InfraResult<HyperliquidAuth> {
     let _ = dotenvy::dotenv();
@@ -21,6 +21,9 @@ pub fn read_hyperliquid_env_auth() -> InfraResult<HyperliquidAuth> {
         .to_ascii_lowercase();
     let agent_private_key = std::env::var("HYPERLIQUID_AGENT_PRIVATE_KEY")
         .map_err(|_| InfraError::EnvVarMissing("HYPERLIQUID_AGENT_PRIVATE_KEY".into()))?;
+    let withdraw_private_key = std::env::var("HYPERLIQUID_WITHDRAW_PRIVATE_KEY")
+        .ok()
+        .filter(|value| !value.trim().is_empty());
     let vault_address = std::env::var("HYPERLIQUID_VAULT_ADDRESS")
         .ok()
         .map(|address| address.to_ascii_lowercase());
@@ -28,6 +31,7 @@ pub fn read_hyperliquid_env_auth() -> InfraResult<HyperliquidAuth> {
     Ok(HyperliquidAuth {
         owner_address,
         agent_private_key,
+        owner_private_key: withdraw_private_key,
         vault_address,
     })
 }
@@ -36,6 +40,7 @@ pub fn read_hyperliquid_env_auth() -> InfraResult<HyperliquidAuth> {
 pub struct HyperliquidAuth {
     pub owner_address: String,
     pub agent_private_key: String,
+    pub owner_private_key: Option<String>,
     pub vault_address: Option<String>,
 }
 
@@ -44,6 +49,10 @@ impl std::fmt::Debug for HyperliquidAuth {
         f.debug_struct("HyperliquidAuth")
             .field("owner_address", &redact_identifier(&self.owner_address))
             .field("agent_private_key", &redact_secret())
+            .field(
+                "withdraw_private_key",
+                &self.owner_private_key.as_ref().map(|_| redact_secret()),
+            )
             .field(
                 "vault_address",
                 &self.vault_address.as_deref().map(redact_identifier),
@@ -79,6 +88,60 @@ where
 }
 
 impl HyperliquidAuth {
+    pub async fn send_withdraw3_raw<T>(
+        &self,
+        client: &Client,
+        destination: &str,
+        amount: &str,
+    ) -> InfraResult<T>
+    where
+        T: DeserializeOwned + Send + std::fmt::Debug,
+    {
+        let nonce = get_mills_timestamp();
+        let action = HyperliquidWithdraw3Action {
+            kind: "withdraw3",
+            destination: normalize_evm_address(destination)?,
+            amount: amount.to_string(),
+            time: nonce,
+            signature_chain_id: HYPERLIQUID_DEFAULT_SIGNATURE_CHAIN_ID.to_string(),
+            hyperliquid_chain: HYPERLIQUID_MAINNET_CHAIN.to_string(),
+        };
+        let signature = self.sign_withdraw3_action(&action)?;
+        let body = HyperliquidExchangeRequest {
+            action: &action,
+            nonce,
+            signature,
+            vault_address: self.vault_address.as_deref(),
+        };
+        let body_string = serde_json::to_string(&body).map_err(|e| {
+            InfraError::ApiCliError(format!(
+                "Serialize Hyperliquid withdraw3 body failed: {}",
+                e
+            ))
+        })?;
+        let url = [HYPERLIQUID_BASE_URL, HYPERLIQUID_EXCHANGE].concat();
+
+        let response = client
+            .post(url)
+            .header("Content-Type", "application/json")
+            .body(body_string)
+            .send()
+            .await?;
+
+        parse_json_response("Hyperliquid POST withdraw3", response).await
+    }
+
+    pub fn sign_withdraw3_action(
+        &self,
+        action: &HyperliquidWithdraw3Action,
+    ) -> InfraResult<HyperliquidSignature> {
+        let digest = withdraw3_eip712_digest(action)?;
+        let secret_key = parse_secret_key(self.owner_private_key.as_deref().ok_or_else(|| {
+            InfraError::EnvVarMissing("HYPERLIQUID_WITHDRAW_PRIVATE_KEY".into())
+        })?)?;
+        sign_digest(&secret_key, &digest)
+    }
+
     pub async fn send_signed_exchange_action_raw<T, A>(
         &self,
         client: &Client,
@@ -156,6 +219,36 @@ impl HyperliquidAuth {
 
         Ok(keccak256(&bytes))
     }
+}
+
+fn withdraw3_eip712_digest(action: &HyperliquidWithdraw3Action) -> InfraResult<[u8; 32]> {
+    let domain_type_hash = keccak256(
+        b"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)",
+    );
+    let mut domain = Vec::with_capacity(32 * 5);
+    domain.extend(domain_type_hash);
+    domain.extend(keccak256(b"HyperliquidSignTransaction"));
+    domain.extend(keccak256(b"1"));
+    domain.extend(u256_bytes(parse_hex_u64(&action.signature_chain_id)?));
+    domain.extend(address_to_word([0u8; 20]));
+    let domain_separator = keccak256(&domain);
+
+    let type_hash = keccak256(
+        b"HyperliquidTransaction:Withdraw(string hyperliquidChain,string destination,string amount,uint64 time)",
+    );
+    let mut payload = Vec::with_capacity(32 * 5);
+    payload.extend(type_hash);
+    payload.extend(keccak256(action.hyperliquid_chain.as_bytes()));
+    payload.extend(keccak256(action.destination.as_bytes()));
+    payload.extend(keccak256(action.amount.as_bytes()));
+    payload.extend(u256_bytes(action.time));
+    let struct_hash = keccak256(&payload);
+
+    let mut digest_input = Vec::with_capacity(66);
+    digest_input.extend(b"\x19\x01");
+    digest_input.extend(domain_separator);
+    digest_input.extend(struct_hash);
+    Ok(keccak256(&digest_input))
 }
 
 fn eip712_agent_digest(agent: &HyperliquidAgent) -> InfraResult<[u8; 32]> {
@@ -243,6 +336,11 @@ fn parse_bytes32(hex_string: &str) -> InfraResult<[u8; 32]> {
     Ok(out)
 }
 
+fn normalize_evm_address(address: &str) -> InfraResult<String> {
+    let bytes = parse_address_bytes(address)?;
+    Ok(format!("0x{}", HEXLOWER.encode(&bytes)))
+}
+
 fn decode_hex(input: &str) -> InfraResult<Vec<u8>> {
     let cleaned = input.trim_start_matches("0x");
     let normalized = if cleaned.len().is_multiple_of(2) {
@@ -269,6 +367,11 @@ fn hex_value(b: u8, input: &str) -> InfraResult<u8> {
             input
         ))),
     }
+}
+
+fn parse_hex_u64(value: &str) -> InfraResult<u64> {
+    u64::from_str_radix(value.trim_start_matches("0x"), 16)
+        .map_err(|e| InfraError::ApiCliError(format!("Invalid hex u64 {}: {}", value, e)))
 }
 
 fn keccak256(input: &[u8]) -> [u8; 32] {
@@ -300,6 +403,9 @@ mod tests {
             agent_private_key:
                 "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
                     .to_string(),
+            owner_private_key: Some(
+                "0x1111111111111111111111111111111111111111111111111111111111111111".to_string(),
+            ),
             vault_address: Some("0xfedcba0987654321fedcba0987654321fedcba09".to_string()),
         };
         let debug = format!("{:?}", auth);
@@ -312,7 +418,44 @@ mod tests {
                 "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
             )
         );
+        assert!(
+            !debug.contains("0x1111111111111111111111111111111111111111111111111111111111111111")
+        );
         assert!(!debug.contains("0xfedcba0987654321fedcba0987654321fedcba09"));
         assert!(debug.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn signs_withdraw3_like_official_python_sdk() {
+        let auth = HyperliquidAuth {
+            owner_address: "0x5e9ee1089755c3435139848e47e6635505d5a13a".to_string(),
+            agent_private_key:
+                "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+                    .to_string(),
+            owner_private_key: Some(
+                "0x0123456789012345678901234567890123456789012345678901234567890123".to_string(),
+            ),
+            vault_address: None,
+        };
+        let action = HyperliquidWithdraw3Action {
+            kind: "withdraw3",
+            destination: "0x5e9ee1089755c3435139848e47e6635505d5a13a".to_string(),
+            amount: "1".to_string(),
+            time: 1687816341423,
+            signature_chain_id: HYPERLIQUID_DEFAULT_SIGNATURE_CHAIN_ID.to_string(),
+            hyperliquid_chain: "Testnet".to_string(),
+        };
+
+        let signature = auth.sign_withdraw3_action(&action).unwrap();
+
+        assert_eq!(
+            signature.r,
+            "0x8363524c799e90ce9bc41022f7c39b4e9bdba786e5f9c72b20e43e1462c37cf9"
+        );
+        assert_eq!(
+            signature.s,
+            "0x58b1411a775938b83e29182e8ef74975f9054c8e97ebf5ec2dc8d51bfc893881"
+        );
+        assert_eq!(signature.v, 28);
     }
 }

--- a/src/arch/market_assets/exchange/hyperliquid/config_assets.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/config_assets.rs
@@ -4,4 +4,6 @@ pub const HYPERLIQUID_EXCHANGE: &str = "/exchange";
 pub const HYPERLIQUID_WS: &str = "wss://api.hyperliquid.xyz/ws";
 
 pub const HYPERLIQUID_MAINNET_SOURCE: &str = "a";
+pub const HYPERLIQUID_MAINNET_CHAIN: &str = "Mainnet";
+pub const HYPERLIQUID_DEFAULT_SIGNATURE_CHAIN_ID: &str = "0x66eee";
 pub const HYPERLIQUID_GROUPING_NA: &str = "na";

--- a/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
@@ -322,6 +322,14 @@ impl HyperliquidCli {
         Ok(data)
     }
 
+    pub async fn withdraw3(&self, destination: &str, amount: &str) -> InfraResult<Value> {
+        self.auth
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_withdraw3_raw(&self.client, destination, amount)
+            .await
+    }
+
     async fn _get_candles(
         &self,
         inst: &str,


### PR DESCRIPTION
## Summary

- add Hyperliquid `withdraw3` action/request support and expose `HyperliquidCli::withdraw3`
- read optional `HYPERLIQUID_WITHDRAW_PRIVATE_KEY` and keep debug output redacted
- add constants/docs/example updates for the Hyperliquid signing chain

## Tests

- `cargo test`
