### PR TITLE
chore: prepare 0.2.2 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 
 readme = "README.md"


### PR DESCRIPTION
## Summary

- bump `extrema_infra` crate version to `0.2.2`
- prepare the release for Hyperliquid `withdraw3` support from #70

## Tests

- `cargo test`
- `cargo package --allow-dirty`

## Packaging

- Publish verification passed with 244 packaged files, about 2.3 MiB unpacked and 1.5 MiB compressed.
- `cargo package` reported yanked dependency warnings for `bitcoin-io v0.1.100` and `bitcoin_hashes v0.14.100` from the existing lockfile.
