### PR TITLE
feat: add spot order history support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 
 readme = "README.md"

--- a/src/arch/market_assets/exchange/binance/binance_spot_cli.rs
+++ b/src/arch/market_assets/exchange/binance/binance_spot_cli.rs
@@ -25,8 +25,8 @@ use super::{
     schemas::{
         spot_rest::{
             account_balance::RestAccountInfoBinanceSpot,
-            exchange_info::RestExchangeInfoBinanceSpot, ticker::RestTickerBinanceSpot,
-            trade_order::RestOrderAckBinanceSpot,
+            exchange_info::RestExchangeInfoBinanceSpot, order_history::RestOrderHistoryBinanceSpot,
+            ticker::RestTickerBinanceSpot, trade_order::RestOrderAckBinanceSpot,
         },
         wallet_rest::{
             all_coins_info::RestCapitalConfigCoinBinance,
@@ -101,6 +101,18 @@ impl LobPrivateRest for BinanceSpotCli {
 
     async fn get_balance(&self, assets: Option<&[String]>) -> InfraResult<Vec<BalanceData>> {
         self._get_balance(assets).await
+    }
+
+    async fn get_order_history(
+        &self,
+        inst: &str,
+        start_time: Option<u64>,
+        end_time: Option<u64>,
+        limit: Option<u32>,
+        order_id: Option<&str>,
+    ) -> InfraResult<Vec<HistoOrderData>> {
+        self._get_order_history(inst, start_time, end_time, limit, order_id)
+            .await
     }
 }
 
@@ -644,6 +656,53 @@ impl BinanceSpotCli {
                 _ => true,
             })
             .map(BalanceData::from)
+            .collect();
+
+        Ok(data)
+    }
+
+    async fn _get_order_history(
+        &self,
+        inst: &str,
+        start_time: Option<u64>,
+        end_time: Option<u64>,
+        limit: Option<u32>,
+        order_id: Option<&str>,
+    ) -> InfraResult<Vec<HistoOrderData>> {
+        let mut query_string = format!("symbol={}", cli_spot_to_binance_spot(inst));
+        let endpoint = if let Some(order_id) = order_id {
+            query_string.push_str(&format!("&orderId={order_id}"));
+            BINANCE_SPOT_PLACE_ORDER
+        } else {
+            if let Some(start_time) = start_time {
+                query_string.push_str(&format!("&startTime={start_time}"));
+            }
+            if let Some(end_time) = end_time {
+                query_string.push_str(&format!("&endTime={end_time}"));
+            }
+            if let Some(limit) = limit {
+                query_string.push_str(&format!("&limit={limit}"));
+            }
+            BINANCE_SPOT_ALL_ORDERS
+        };
+
+        let res: RestResBinance<RestOrderHistoryBinanceSpot> = self
+            .api_key
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_signed_request(
+                &self.client,
+                RequestMethod::Get,
+                Some(&query_string),
+                BINANCE_SPOT_BASE_URL,
+                endpoint,
+            )
+            .await?;
+
+        let data: Vec<HistoOrderData> = res
+            .into_vec()?
+            .into_iter()
+            .map(HistoOrderData::from)
             .collect();
 
         Ok(data)

--- a/src/arch/market_assets/exchange/binance/config_assets.rs
+++ b/src/arch/market_assets/exchange/binance/config_assets.rs
@@ -5,6 +5,7 @@ pub const BINANCE_SPOT_EXCHANGE_INFO: &str = "/api/v3/exchangeInfo";
 pub const BINANCE_SPOT_TICKERS: &str = "/api/v3/ticker/price";
 pub const BINANCE_SPOT_PLACE_ORDER: &str = "/api/v3/order";
 pub const BINANCE_SPOT_CANCEL_ORDER: &str = "/api/v3/order";
+pub const BINANCE_SPOT_ALL_ORDERS: &str = "/api/v3/allOrders";
 pub const BINANCE_SPOT_ACCOUNT_INFO: &str = "/api/v3/account";
 pub const BINANCE_SPOT_MY_TRADES: &str = "/api/v3/myTrades";
 pub const SPOT_USER_DATA_STREAM: &str = "/api/v3/userDataStream";

--- a/src/arch/market_assets/exchange/binance/schemas/spot_rest.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/spot_rest.rs
@@ -1,4 +1,5 @@
 pub mod account_balance;
 pub mod exchange_info;
+pub mod order_history;
 pub mod ticker;
 pub mod trade_order;

--- a/src/arch/market_assets/exchange/binance/schemas/spot_rest/order_history.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/spot_rest/order_history.rs
@@ -1,0 +1,160 @@
+use serde::Deserialize;
+use tracing::warn;
+
+use crate::arch::market_assets::{
+    api_data::account_data::HistoOrderData,
+    api_general::ts_to_micros,
+    base_data::{OrderSide, OrderStatus, OrderType, TimeInForce},
+    exchange::binance::api_utils::binance_spot_inst_to_cli,
+};
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestOrderHistoryBinanceSpot {
+    pub symbol: String,
+    pub orderId: u64,
+    pub clientOrderId: Option<String>,
+    pub price: String,
+    pub origQty: String,
+    pub executedQty: String,
+    pub cummulativeQuoteQty: Option<String>,
+    pub status: String,
+    pub timeInForce: String,
+    pub r#type: String,
+    pub side: String,
+    pub time: u64,
+    pub updateTime: u64,
+}
+
+impl From<RestOrderHistoryBinanceSpot> for HistoOrderData {
+    fn from(d: RestOrderHistoryBinanceSpot) -> Self {
+        let executed_size = d.executedQty.parse::<f64>().unwrap_or_default().abs();
+        let cumulative_quote = d
+            .cummulativeQuoteQty
+            .as_deref()
+            .and_then(|value| value.parse::<f64>().ok())
+            .unwrap_or_default()
+            .abs();
+
+        HistoOrderData {
+            timestamp: ts_to_micros(d.time),
+            inst: binance_spot_inst_to_cli(&d.symbol),
+            order_id: d.orderId.to_string(),
+            cli_order_id: d.clientOrderId.filter(|id| !id.is_empty()),
+            side: match d.side.as_str() {
+                "BUY" => OrderSide::BUY,
+                "SELL" => OrderSide::SELL,
+                other => {
+                    warn!("Unknown Binance Spot order side: {other}");
+                    OrderSide::Unknown
+                },
+            },
+            position_side: None,
+            order_type: match d.r#type.as_str() {
+                "MARKET" => OrderType::Market,
+                "LIMIT" => OrderType::Limit,
+                "LIMIT_MAKER" => OrderType::PostOnly,
+                other => {
+                    warn!("Unknown Binance Spot order type: {other}");
+                    OrderType::Unknown
+                },
+            },
+            order_status: match d.status.as_str() {
+                "PENDING_NEW" | "NEW" => OrderStatus::Live,
+                "PARTIALLY_FILLED" => OrderStatus::PartiallyFilled,
+                "FILLED" => OrderStatus::Filled,
+                "PENDING_CANCEL" | "CANCELED" => OrderStatus::Canceled,
+                "REJECTED" => OrderStatus::Rejected,
+                "EXPIRED" | "EXPIRED_IN_MATCH" => OrderStatus::Expired,
+                other => {
+                    warn!("Unknown Binance Spot order status: {other}");
+                    OrderStatus::Unknown
+                },
+            },
+            price: d.price.parse().unwrap_or_default(),
+            avg_price: if executed_size > 0.0 {
+                cumulative_quote / executed_size
+            } else {
+                0.0
+            },
+            size: d.origQty.parse::<f64>().unwrap_or_default().abs(),
+            executed_size,
+            fee: None,
+            fee_currency: None,
+            reduce_only: None,
+            time_in_force: match d.timeInForce.as_str() {
+                "GTC" => Some(TimeInForce::GTC),
+                "IOC" => Some(TimeInForce::IOC),
+                "FOK" => Some(TimeInForce::FOK),
+                "" => None,
+                other => {
+                    warn!("Unknown Binance Spot time in force: {other}");
+                    Some(TimeInForce::Unknown)
+                },
+            },
+            update_time: ts_to_micros(d.updateTime),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn converts_filled_market_order_with_computed_average_price() {
+        let raw: RestOrderHistoryBinanceSpot = serde_json::from_value(json!({
+            "symbol": "USDCUSDT",
+            "orderId": 1198981242_u64,
+            "clientOrderId": "bridge-order-1",
+            "price": "0.00000000",
+            "origQty": "7.00000000",
+            "executedQty": "7.00000000",
+            "cummulativeQuoteQty": "6.99930000",
+            "status": "FILLED",
+            "timeInForce": "GTC",
+            "type": "MARKET",
+            "side": "BUY",
+            "time": 1783580000123_u64,
+            "updateTime": 1783580000456_u64
+        }))
+        .unwrap();
+
+        let order = HistoOrderData::from(raw);
+
+        assert_eq!(order.inst, "USDC_USDT");
+        assert_eq!(order.order_status, OrderStatus::Filled);
+        assert_eq!(order.executed_size, 7.0);
+        assert!((order.avg_price - 0.9999).abs() < 1e-12);
+        assert_eq!(order.update_time, 1_783_580_000_456_000);
+    }
+
+    #[test]
+    fn maps_partially_filled_post_only_order() {
+        let raw: RestOrderHistoryBinanceSpot = serde_json::from_value(json!({
+            "symbol": "BTCUSDT",
+            "orderId": 42_u64,
+            "clientOrderId": "",
+            "price": "60000",
+            "origQty": "0.01",
+            "executedQty": "0.004",
+            "cummulativeQuoteQty": "240",
+            "status": "PARTIALLY_FILLED",
+            "timeInForce": "GTC",
+            "type": "LIMIT_MAKER",
+            "side": "SELL",
+            "time": 1783580000123_u64,
+            "updateTime": 1783580000456_u64
+        }))
+        .unwrap();
+
+        let order = HistoOrderData::from(raw);
+
+        assert_eq!(order.order_type, OrderType::PostOnly);
+        assert_eq!(order.order_status, OrderStatus::PartiallyFilled);
+        assert_eq!(order.cli_order_id, None);
+        assert_eq!(order.avg_price, 60_000.0);
+    }
+}

--- a/src/arch/market_assets/exchange/gate/config_assets.rs
+++ b/src/arch/market_assets/exchange/gate/config_assets.rs
@@ -11,6 +11,7 @@ pub const GATE_WS_SPOT_BALANCES: &str = "spot.balances";
 pub const GATE_WS_SPOT_CROSS_BALANCES: &str = "spot.cross_balances";
 pub const GATE_SPOT_CURRENCY_PAIRS: &str = "/api/v4/spot/currency_pairs";
 pub const GATE_SPOT_ORDERS: &str = "/api/v4/spot/orders";
+pub const GATE_SPOT_ORDER: &str = "/api/v4/spot/orders/{order_id}";
 pub const GATE_SPOT_TICKERS: &str = "/api/v4/spot/tickers";
 pub const GATE_SPOT_ACCOUNTS: &str = "/api/v4/spot/accounts";
 

--- a/src/arch/market_assets/exchange/gate/gate_spot_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_spot_cli.rs
@@ -6,7 +6,7 @@ use tracing::error;
 use crate::arch::{
     market_assets::{
         api_data::{
-            account_data::{BalanceData, OrderAckData},
+            account_data::{BalanceData, HistoOrderData, OrderAckData},
             price_data::TickerData,
             utils_data::InstrumentInfo,
         },
@@ -19,7 +19,7 @@ use crate::arch::{
                 spot_rest::{
                     account_balance::RestAccountBalGateSpot,
                     currency_pair::RestCurrencyPairGateSpot, order::RestOrderGateSpot,
-                    ticker::RestTickerGateSpot,
+                    order_history::RestOrderHistoryGateSpot, ticker::RestTickerGateSpot,
                 },
                 wallet_rest::{
                     currency_chains::RestCurrencyChainGate,
@@ -104,6 +104,18 @@ impl LobPrivateRest for GateSpotCli {
 
     async fn get_balance(&self, assets: Option<&[String]>) -> InfraResult<Vec<BalanceData>> {
         self._get_balance(assets).await
+    }
+
+    async fn get_order_history(
+        &self,
+        inst: &str,
+        start_time: Option<u64>,
+        end_time: Option<u64>,
+        limit: Option<u32>,
+        order_id: Option<&str>,
+    ) -> InfraResult<Vec<HistoOrderData>> {
+        self._get_order_history(inst, start_time, end_time, limit, order_id)
+            .await
     }
 }
 
@@ -513,6 +525,58 @@ impl GateSpotCli {
         Ok(filtered)
     }
 
+    async fn _get_order_history(
+        &self,
+        inst: &str,
+        start_time: Option<u64>,
+        end_time: Option<u64>,
+        limit: Option<u32>,
+        order_id: Option<&str>,
+    ) -> InfraResult<Vec<HistoOrderData>> {
+        let currency_pair = inst.to_uppercase();
+        let (endpoint, query_string) = if let Some(order_id) = order_id {
+            (
+                GATE_SPOT_ORDER.replace("{order_id}", order_id),
+                format!("currency_pair={currency_pair}"),
+            )
+        } else {
+            let mut query = format!("currency_pair={currency_pair}&status=finished");
+            if let Some(start_time) = start_time {
+                query.push_str(&format!("&from={}", timestamp_to_seconds(start_time)));
+            }
+            if let Some(end_time) = end_time {
+                query.push_str(&format!("&to={}", timestamp_to_seconds(end_time)));
+            }
+            if let Some(limit) = limit {
+                query.push_str(&format!("&limit={limit}"));
+            }
+            (GATE_SPOT_ORDERS.into(), query)
+        };
+
+        let res: RestResGate<RestOrderHistoryGateSpot> = self
+            .api_key
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_signed_request(
+                &self.client,
+                RequestMethod::Get,
+                Some(&query_string),
+                None,
+                GATE_BASE_URL,
+                &endpoint,
+            )
+            .await?;
+
+        let data: Vec<HistoOrderData> = res
+            .into_vec()?
+            .into_iter()
+            .filter(|order| order.currency_pair.eq_ignore_ascii_case(&currency_pair))
+            .map(HistoOrderData::from)
+            .collect();
+
+        Ok(data)
+    }
+
     async fn _place_order(&self, order_params: OrderParams) -> InfraResult<OrderAckData> {
         let mut body = json!({
             "currency_pair": order_params.inst,
@@ -615,8 +679,17 @@ impl GateSpotCli {
     }
 }
 
+fn timestamp_to_seconds(timestamp: u64) -> u64 {
+    match timestamp {
+        0..=9_999_999_999 => timestamp,
+        10_000_000_000..=9_999_999_999_999 => timestamp / 1_000,
+        _ => timestamp / 1_000_000,
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::timestamp_to_seconds;
     use crate::arch::{
         market_assets::exchange::gate::{
             config_assets::GATE_WS_BASE_URL, gate_spot_cli::GateSpotCli,
@@ -636,5 +709,12 @@ mod tests {
 
         assert_eq!(target.url, GATE_WS_BASE_URL);
         assert!(target.headers.is_empty());
+    }
+
+    #[test]
+    fn gate_spot_history_converts_millisecond_and_microsecond_ranges_to_seconds() {
+        assert_eq!(timestamp_to_seconds(1_783_580_000), 1_783_580_000);
+        assert_eq!(timestamp_to_seconds(1_783_580_000_123), 1_783_580_000);
+        assert_eq!(timestamp_to_seconds(1_783_580_000_123_456), 1_783_580_000);
     }
 }

--- a/src/arch/market_assets/exchange/gate/schemas/spot_rest.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/spot_rest.rs
@@ -1,4 +1,5 @@
 pub mod account_balance;
 pub mod currency_pair;
 pub mod order;
+pub mod order_history;
 pub mod ticker;

--- a/src/arch/market_assets/exchange/gate/schemas/spot_rest/order_history.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/spot_rest/order_history.rs
@@ -1,0 +1,247 @@
+use serde::Deserialize;
+use tracing::warn;
+
+use crate::arch::market_assets::{
+    api_data::account_data::HistoOrderData,
+    api_general::ts_to_micros,
+    base_data::{OrderSide, OrderStatus, OrderType, TimeInForce},
+};
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestOrderHistoryGateSpot {
+    pub id: String,
+    pub text: Option<String>,
+    pub create_time: Option<String>,
+    pub update_time: Option<String>,
+    #[serde(default)]
+    pub create_time_ms: u64,
+    #[serde(default)]
+    pub update_time_ms: u64,
+    pub currency_pair: String,
+    pub status: String,
+    pub r#type: String,
+    pub side: String,
+    pub amount: String,
+    pub price: String,
+    pub time_in_force: Option<String>,
+    pub left: String,
+    pub filled_amount: Option<String>,
+    pub filled_total: Option<String>,
+    pub avg_deal_price: Option<String>,
+    pub fee: Option<String>,
+    pub fee_currency: Option<String>,
+    pub finish_as: Option<String>,
+}
+
+impl From<RestOrderHistoryGateSpot> for HistoOrderData {
+    fn from(d: RestOrderHistoryGateSpot) -> Self {
+        let amount = d.amount.parse::<f64>().unwrap_or_default().abs();
+        let left = d.left.parse::<f64>().unwrap_or_default().abs();
+        let filled_total = d
+            .filled_total
+            .as_deref()
+            .and_then(|value| value.parse::<f64>().ok())
+            .unwrap_or_default()
+            .abs();
+        let reported_filled = d
+            .filled_amount
+            .as_deref()
+            .and_then(|value| value.parse::<f64>().ok())
+            .unwrap_or_default()
+            .abs();
+        let reported_avg_price = d
+            .avg_deal_price
+            .as_deref()
+            .and_then(|value| value.parse::<f64>().ok())
+            .unwrap_or_default()
+            .abs();
+        let avg_price = if reported_avg_price > 0.0 {
+            reported_avg_price
+        } else if reported_filled > 0.0 {
+            filled_total / reported_filled
+        } else {
+            0.0
+        };
+        let is_market_buy = d.r#type == "market" && d.side == "buy";
+        let executed_size = if reported_filled > 0.0 {
+            reported_filled
+        } else if is_market_buy && avg_price > 0.0 {
+            filled_total / avg_price
+        } else if !is_market_buy {
+            (amount - left).max(0.0)
+        } else {
+            0.0
+        };
+        let timestamp = if d.create_time_ms > 0 {
+            d.create_time_ms
+        } else {
+            d.create_time
+                .as_deref()
+                .and_then(|value| value.parse::<f64>().ok())
+                .map(|value| value as u64)
+                .unwrap_or_default()
+        };
+        let update_time = if d.update_time_ms > 0 {
+            d.update_time_ms
+        } else {
+            d.update_time
+                .as_deref()
+                .and_then(|value| value.parse::<f64>().ok())
+                .map(|value| value as u64)
+                .unwrap_or_default()
+        };
+
+        HistoOrderData {
+            timestamp: ts_to_micros(timestamp),
+            inst: d.currency_pair,
+            order_id: d.id,
+            cli_order_id: d.text.filter(|text| !text.is_empty() && text != "-"),
+            side: match d.side.as_str() {
+                "buy" => OrderSide::BUY,
+                "sell" => OrderSide::SELL,
+                other => {
+                    warn!("Unknown Gate Spot order side: {other}");
+                    OrderSide::Unknown
+                },
+            },
+            position_side: None,
+            order_type: if d.r#type == "market" {
+                OrderType::Market
+            } else {
+                match d.time_in_force.as_deref().unwrap_or_default() {
+                    "poc" => OrderType::PostOnly,
+                    "ioc" => OrderType::Ioc,
+                    "fok" => OrderType::Fok,
+                    _ if d.r#type == "limit" => OrderType::Limit,
+                    _ => {
+                        warn!("Unknown Gate Spot order type: {}", d.r#type);
+                        OrderType::Unknown
+                    },
+                }
+            },
+            order_status: match d.status.as_str() {
+                "open" => {
+                    if executed_size > 0.0 {
+                        OrderStatus::PartiallyFilled
+                    } else {
+                        OrderStatus::Live
+                    }
+                },
+                "closed" | "cancelled" => match d.finish_as.as_deref() {
+                    Some("filled") => OrderStatus::Filled,
+                    Some(
+                        "cancelled"
+                        | "liquidate_cancelled"
+                        | "small"
+                        | "depth_not_enough"
+                        | "trader_not_enough"
+                        | "ioc"
+                        | "poc"
+                        | "fok"
+                        | "stp",
+                    ) => OrderStatus::Canceled,
+                    _ if left == 0.0 && executed_size > 0.0 => OrderStatus::Filled,
+                    _ => OrderStatus::Canceled,
+                },
+                other => {
+                    warn!("Unknown Gate Spot order status: {other}");
+                    OrderStatus::Unknown
+                },
+            },
+            price: d.price.parse::<f64>().unwrap_or_default().abs(),
+            avg_price,
+            size: if is_market_buy { executed_size } else { amount },
+            executed_size,
+            fee: d.fee.and_then(|value| value.parse::<f64>().ok()),
+            fee_currency: d.fee_currency.filter(|currency| !currency.is_empty()),
+            reduce_only: None,
+            time_in_force: match d.time_in_force.as_deref().unwrap_or_default() {
+                "gtc" | "poc" => Some(TimeInForce::GTC),
+                "ioc" => Some(TimeInForce::IOC),
+                "fok" => Some(TimeInForce::FOK),
+                "" => None,
+                other => {
+                    warn!("Unknown Gate Spot time in force: {other}");
+                    Some(TimeInForce::Unknown)
+                },
+            },
+            update_time: ts_to_micros(update_time),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn converts_filled_market_buy_to_base_executed_size() {
+        let raw: RestOrderHistoryGateSpot = serde_json::from_value(json!({
+            "id": "241787005244120542",
+            "text": "t-bridge-order-1",
+            "create_time": "1783580000",
+            "update_time": "1783580001",
+            "create_time_ms": 1783580000123_u64,
+            "update_time_ms": 1783580001456_u64,
+            "currency_pair": "USDC_USDT",
+            "status": "closed",
+            "type": "market",
+            "side": "buy",
+            "amount": "7.0",
+            "price": "0",
+            "time_in_force": "ioc",
+            "left": "0",
+            "filled_amount": "7.00105016",
+            "filled_total": "7.0",
+            "avg_deal_price": "0.99985",
+            "fee": "0.00700105",
+            "fee_currency": "USDC",
+            "finish_as": "filled"
+        }))
+        .unwrap();
+
+        let order = HistoOrderData::from(raw);
+
+        assert_eq!(order.order_status, OrderStatus::Filled);
+        assert_eq!(order.order_type, OrderType::Market);
+        assert_eq!(order.executed_size, 7.00105016);
+        assert_eq!(order.size, order.executed_size);
+        assert_eq!(order.avg_price, 0.99985);
+        assert_eq!(order.fee_currency.as_deref(), Some("USDC"));
+    }
+
+    #[test]
+    fn preserves_partial_fill_when_ioc_remainder_is_cancelled() {
+        let raw: RestOrderHistoryGateSpot = serde_json::from_value(json!({
+            "id": "43",
+            "text": "-",
+            "create_time": "1783580000",
+            "update_time": "1783580001",
+            "currency_pair": "LA_USDT",
+            "status": "cancelled",
+            "type": "limit",
+            "side": "sell",
+            "amount": "19",
+            "price": "0.0579",
+            "time_in_force": "ioc",
+            "left": "3",
+            "filled_amount": "16",
+            "filled_total": "0.9264",
+            "avg_deal_price": "0.0579",
+            "fee": "0.001",
+            "fee_currency": "USDT",
+            "finish_as": "ioc"
+        }))
+        .unwrap();
+
+        let order = HistoOrderData::from(raw);
+
+        assert_eq!(order.order_status, OrderStatus::Canceled);
+        assert_eq!(order.order_type, OrderType::Ioc);
+        assert_eq!(order.executed_size, 16.0);
+        assert_eq!(order.cli_order_id, None);
+        assert_eq!(order.timestamp, 1_783_580_000_000_000);
+    }
+}

--- a/src/arch/market_assets/exchange/gate/schemas/spot_ws/account_order.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/spot_ws/account_order.rs
@@ -93,13 +93,7 @@ impl IntoWsData for WsAccountOrderGateSpot {
                 OrderType::Limit
             },
             order_id,
-            cli_order_id: self.text.and_then(|t| {
-                if t.is_empty() || t == "-" {
-                    None
-                } else {
-                    Some(t)
-                }
-            }),
+            cli_order_id: self.text.filter(|t| !t.is_empty() && t != "-"),
         }
     }
 }


### PR DESCRIPTION
## Summary
- implement `LobPrivateRest::get_order_history` for Binance Spot using single-order and all-orders endpoints
- implement Gate Spot single-order and finished-order history queries with timestamp normalization
- normalize Binance and Gate responses into `HistoOrderData` with coverage for fills, partial fills, statuses, order types, and time-in-force
- bump crate version to `0.2.3`

## Validation
- `cargo test --features lob_clients`
- `cargo clippy --all-targets --features lob_clients -- -D warnings`
- `cargo fmt --all -- --check`
- read-only Binance Spot history list to single-order API probe passed

This PR does not publish the crate or create a release.
