### PR TITLE
fix: dispatch spot order history clients

### DIFF
--- a/src/arch/market_assets/exchange/lob_clients.rs
+++ b/src/arch/market_assets/exchange/lob_clients.rs
@@ -233,11 +233,19 @@ impl LobPrivateRest for LobClients {
                 c.get_order_history(inst, start_time, end_time, limit, order_id)
                     .await
             },
+            LobClients::BinanceSpot(c) => {
+                c.get_order_history(inst, start_time, end_time, limit, order_id)
+                    .await
+            },
             LobClients::BinanceUm(c) => {
                 c.get_order_history(inst, start_time, end_time, limit, order_id)
                     .await
             },
             LobClients::GateFutures(c) => {
+                c.get_order_history(inst, start_time, end_time, limit, order_id)
+                    .await
+            },
+            LobClients::GateSpot(c) => {
                 c.get_order_history(inst, start_time, end_time, limit, order_id)
                     .await
             },


### PR DESCRIPTION
## Summary
- dispatch Binance Spot order-history calls through `LobClients`
- dispatch Gate Spot order-history calls through `LobClients`
- keep Gate Unified account responsibilities unchanged

## Validation
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- live read-only Binance Spot history -> single-order probe
- live read-only Gate Spot history -> single-order probe on unified UID 52145814