### PR TITLE
feat: support OKX preopen instruments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 
 readme = "README.md"
@@ -36,7 +36,7 @@ tungstenite = "0.29.0"
 # Serialization / JSON / Binary encoding
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
-simd-json = "0.17.0"
+simd-json = "0.17.3"
 rmp-serde = "1.3.1"
 
 # Cryptography / Signing / Encoding
@@ -51,7 +51,7 @@ rustls = { version = "0.23.40", features = ["aws-lc-rs"] }
 
 # IPC / Model inference / Data processing
 zeromq = { version = "0.6.0", optional = true }
-tract-onnx = { version = "0.23.3", optional = true }
+tract-onnx = { version = "0.23.4", optional = true }
 polars = { version = "0.54.4", default-features = false, optional = true }
 
 # Logging & Tracing

--- a/src/arch/market_assets/exchange/okx/api_utils.rs
+++ b/src/arch/market_assets/exchange/okx/api_utils.rs
@@ -92,6 +92,21 @@ pub fn okx_inst_to_cli(symbol: &str) -> String {
     }
 }
 
+pub fn okx_preopen_inst(symbol: &str) -> Option<(InstrumentType, String)> {
+    let (inst_type, inst) = symbol.strip_prefix("LISTING-")?.split_once('-')?;
+    if !inst.contains('-') {
+        return None;
+    }
+
+    match inst_type {
+        "SPOT" => Some((InstrumentType::Spot, inst.to_string())),
+        "SWAP" => Some((InstrumentType::Perpetual, format!("{inst}-SWAP"))),
+        "FUTURES" => Some((InstrumentType::Futures, inst.to_string())),
+        "OPTION" => Some((InstrumentType::Options, inst.to_string())),
+        _ => None,
+    }
+}
+
 pub fn okx_candle_interval(interval: &CandleParam) -> &str {
     match interval {
         CandleParam::OneSecond => "1s",
@@ -423,5 +438,18 @@ mod tests {
             cli_inst_to_okx_inst("BTC_USD_FUT_240329", &InstrumentType::Futures).unwrap(),
             "BTC-USD-240329"
         );
+    }
+
+    #[test]
+    fn parses_okx_preopen_listing_symbol() {
+        assert_eq!(
+            okx_preopen_inst("LISTING-SPOT-SLX-USDT"),
+            Some((InstrumentType::Spot, "SLX-USDT".into()))
+        );
+        assert_eq!(
+            okx_preopen_inst("LISTING-SWAP-SLX-USDT"),
+            Some((InstrumentType::Perpetual, "SLX-USDT-SWAP".into()))
+        );
+        assert_eq!(okx_preopen_inst("SLX-USDT"), None);
     }
 }

--- a/src/arch/market_assets/exchange/okx/schemas/rest/public_instruments.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/rest/public_instruments.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use crate::arch::market_assets::{
     api_data::utils_data::InstrumentInfo,
     base_data::{InstrumentStatus, InstrumentType},
-    exchange::okx::api_utils::okx_inst_to_cli,
+    exchange::okx::api_utils::{okx_inst_to_cli, okx_preopen_inst},
 };
 
 #[allow(non_snake_case)]
@@ -30,16 +30,30 @@ impl From<RestInstrumentsOkx> for InstrumentInfo {
             .as_deref()
             .map(str::trim)
             .is_some_and(|v| !v.is_empty() && v != "0");
-
-        InstrumentInfo {
-            inst: okx_inst_to_cli(&d.instId),
-            inst_code: d.instIdCode.map(|x| x.to_string()),
-            inst_type: match d.instType.as_str() {
+        let preopen_inst = d
+            .state
+            .eq_ignore_ascii_case("preopen")
+            .then(|| okx_preopen_inst(&d.instId))
+            .flatten();
+        let inst = okx_inst_to_cli(
+            preopen_inst
+                .as_ref()
+                .map(|(_, inst)| inst.as_str())
+                .unwrap_or(&d.instId),
+        );
+        let inst_type = preopen_inst
+            .map(|(inst_type, _)| inst_type)
+            .unwrap_or_else(|| match d.instType.as_str() {
                 "SWAP" => InstrumentType::Perpetual,
                 "FUTURES" => InstrumentType::Futures,
                 "SPOT" => InstrumentType::Spot,
                 _ => InstrumentType::Unknown,
-            },
+            });
+
+        InstrumentInfo {
+            inst,
+            inst_code: d.instIdCode.map(|x| x.to_string()),
+            inst_type,
             lot_size: d.lotSz.parse().unwrap_or_default(),
             tick_size: d.tickSz.parse().unwrap_or_default(),
             min_lmt_size: d.minSz.parse().unwrap_or_default(),
@@ -55,9 +69,37 @@ impl From<RestInstrumentsOkx> for InstrumentInfo {
                 match d.state.as_str() {
                     "live" => InstrumentStatus::Live,
                     "suspend" => InstrumentStatus::Suspend,
+                    "preopen" => InstrumentStatus::PreOpen,
                     _ => InstrumentStatus::Unknown,
                 }
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_okx_preopen_listing_instrument() {
+        let info = InstrumentInfo::from(RestInstrumentsOkx {
+            instId: "LISTING-SPOT-SLX-USDT".into(),
+            instType: "SPOT".into(),
+            lotSz: String::new(),
+            tickSz: String::new(),
+            minSz: String::new(),
+            maxLmtSz: String::new(),
+            maxMktSz: String::new(),
+            ctVal: None,
+            ctMult: None,
+            state: "preopen".into(),
+            expTime: None,
+            instIdCode: None,
+        });
+
+        assert_eq!(info.inst, "SLX_USDT");
+        assert_eq!(info.inst_type, InstrumentType::Spot);
+        assert_eq!(info.state, InstrumentStatus::PreOpen);
     }
 }


### PR DESCRIPTION
## Summary

- parse OKX `LISTING-*` preopen instrument identifiers into their native symbol and instrument type
- expose OKX preopen instruments as `InstrumentStatus::PreOpen` instead of filtering or logging them as invalid symbols
- prepare crate version `0.2.4` and refresh `simd-json` and `tract-onnx` patch versions

## Why

OKX now returns placeholder identifiers such as `LISTING-SPOT-SLX-USDT` from its public instruments endpoint. Passing those identifiers through the regular symbol parser produced repeated invalid-symbol errors and lost the useful preopen state.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
