### PR TITLE
Fix Gate decimal futures sizing

### DIFF
--- a/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
@@ -405,7 +405,12 @@ impl GateFuturesCli {
             format!("{}{}?{}", GATE_BASE_URL, endpoint, params.join("&"))
         };
 
-        let response = self.client.get(url).send().await?;
+        let response = self
+            .client
+            .get(url)
+            .header(GATE_SIZE_DECIMAL_HEADER, GATE_SIZE_DECIMAL_HEADER_VALUE)
+            .send()
+            .await?;
         let res: RestResGate<RestContractGateFutures> =
             parse_json_response("GateFutures futures_contracts", response).await?;
 

--- a/src/arch/market_assets/exchange/gate/schemas/futures_rest/contract_futures.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/futures_rest/contract_futures.rs
@@ -76,12 +76,8 @@ impl RestContractGateFutures {
 
 impl From<RestContractGateFutures> for InstrumentInfo {
     fn from(d: RestContractGateFutures) -> Self {
-        let lot_size = if d.enable_decimal {
-            0.0
-        } else {
-            d.order_size_min.parse().unwrap_or_default()
-        };
-        let min_size = if d.enable_decimal { 0.1 } else { lot_size };
+        let min_size = d.order_size_min.parse().unwrap_or_default();
+        let lot_size = if d.enable_decimal { 0.1 } else { min_size };
         let max_size = d.order_size_max.parse().unwrap_or_default();
         let tick_size = d.order_price_round.parse().unwrap_or_default();
         let state = d.instrument_status(get_seconds_timestamp());
@@ -178,27 +174,31 @@ mod tests {
     }
 
     #[test]
-    fn non_decimal_contract_uses_order_size_min_as_lot_and_min_size() {
+    fn non_decimal_contract_preserves_order_size_limits() {
         let info = InstrumentInfo::from(contract("trading"));
 
         assert_eq!(info.lot_size, 1.0);
         assert_eq!(info.min_lmt_size, 1.0);
+        assert_eq!(info.max_lmt_size, 680_000.0);
         assert_eq!(info.min_mkt_size, 1.0);
+        assert_eq!(info.max_mkt_size, 680_000.0);
         assert_eq!(info.contract_value, Some(0.1));
     }
 
     #[test]
-    fn decimal_contract_uses_hidden_min_without_fake_lot_step() {
+    fn decimal_contract_uses_order_size_min_as_lot_and_min_size() {
         let mut c = contract("trading");
-        c.order_size_min = "0".to_string();
+        c.order_size_min = "0.1".to_string();
         c.quanto_multiplier = "100".to_string();
         c.enable_decimal = true;
 
         let info = InstrumentInfo::from(c);
 
-        assert_eq!(info.lot_size, 0.0);
+        assert_eq!(info.lot_size, 0.1);
         assert_eq!(info.min_lmt_size, 0.1);
+        assert_eq!(info.max_lmt_size, 680_000.0);
         assert_eq!(info.min_mkt_size, 0.1);
+        assert_eq!(info.max_mkt_size, 680_000.0);
         assert_eq!(info.contract_value, Some(100.0));
     }
 }


### PR DESCRIPTION
## Summary

- request Gate futures contract metadata with `X-Gate-Size-Decimal: 1`
- expose a `0.1` lot size for decimal-enabled futures contracts
- preserve the existing integer-contract and min/max order-size mappings
- cover decimal and non-decimal mappings with focused tests

## Root cause

Gate omits decimal size metadata unless the decimal-size header is present. Infra therefore reported `lot_size = 0.0` for contracts such as LAB, allowing callers to submit quantities such as `0.35` that Gate silently truncated to `0.3`.

## Impact

Decimal Gate futures quantities can now be aligned to their supported `0.1` step before submission. Other exchanges, integer Gate contracts, and Gate min/max size fields are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --features lob_clients contract_futures`
- `cargo clippy --all-targets --features lob_clients -- -D warnings`
- `cargo check --features lob_clients`
- live metadata probe: LAB returned `lot_size = 0.1`, `min_lmt_size = 0.1`, and `min_mkt_size = 0.1`
