### PR TITLE
chore(release): bump extrema_infra to 0.2.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 
 readme = "README.md"


### PR DESCRIPTION
## Summary

- bump `extrema_infra` from `0.2.4` to `0.2.5`
- prepare the merged Gate decimal futures sizing fix for a crates.io and GitHub release

## Included change

- request Gate decimal contract metadata and expose the supported `0.1` lot size for decimal-enabled futures contracts (#75)

## Validation

- `cargo check --features lob_clients`
- `cargo fmt --all -- --check`
- `cargo package --allow-dirty`

The package dry-run produced and verified `extrema_infra v0.2.5` successfully. Existing yanked-version warnings for `bitcoin-io v0.1.100` and `bitcoin_hashes v0.14.100` remain non-blocking and are unrelated to this version bump.
