### PR TITLE
fix: preserve aligned decimal step values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2024"
 
 readme = "README.md"

--- a/src/arch/market_assets/api_general.rs
+++ b/src/arch/market_assets/api_general.rs
@@ -144,8 +144,10 @@ pub fn normalize_to_string(value: f64, step: f64) -> String {
         .nth(1)
         .map(|s| s.len())
         .unwrap_or(0);
+    let units = value / step;
+    let tolerance = f64::EPSILON * units.abs().max(1.0) * 8.0;
 
-    format!("{:.*}", precision, (value / step).floor() * step)
+    format!("{:.*}", precision, (units + tolerance).floor() * step)
 }
 
 pub fn normalize_to_string_reduce_only(value: f64, step: f64) -> String {
@@ -159,8 +161,10 @@ pub fn normalize_to_string_reduce_only(value: f64, step: f64) -> String {
         .nth(1)
         .map(|s| s.len())
         .unwrap_or(0);
+    let units = value / step;
+    let tolerance = f64::EPSILON * units.abs().max(1.0) * 8.0;
 
-    format!("{:.*}", precision, (value / step).ceil() * step)
+    format!("{:.*}", precision, (units - tolerance).ceil() * step)
 }
 
 pub fn de_string_from_any<'de, D>(deserializer: D) -> Result<String, D::Error>
@@ -296,5 +300,37 @@ mod tests {
     #[test]
     fn rejects_custom_candle_interval_without_known_duration() {
         assert!(candle_interval_millis(&CandleParam::Custom("2m".into())).is_err());
+    }
+
+    #[test]
+    fn normalizes_values_already_on_decimal_steps() {
+        for (value, step, expected) in [
+            (0.3, 0.1, "0.3"),
+            (0.6, 0.1, "0.6"),
+            (5.1, 0.1, "5.1"),
+            (0.15, 0.05, "0.15"),
+            (1.23, 0.01, "1.23"),
+            (1.234, 0.001, "1.234"),
+        ] {
+            assert_eq!(normalize_to_string(value, step), expected);
+        }
+    }
+
+    #[test]
+    fn normalizes_real_off_step_values_down() {
+        assert_eq!(normalize_to_string(0.299_999, 0.1), "0.2");
+        assert_eq!(normalize_to_string(0.35, 0.1), "0.3");
+    }
+
+    #[test]
+    fn normalizes_reduce_only_values_already_on_decimal_steps() {
+        assert_eq!(normalize_to_string_reduce_only(0.1 + 0.2, 0.1), "0.3");
+        assert_eq!(normalize_to_string_reduce_only(0.15, 0.05), "0.15");
+    }
+
+    #[test]
+    fn normalizes_real_off_step_reduce_only_values_up() {
+        assert_eq!(normalize_to_string_reduce_only(0.300_001, 0.1), "0.4");
+        assert_eq!(normalize_to_string_reduce_only(0.35, 0.1), "0.4");
     }
 }


### PR DESCRIPTION
## Summary

- preserve values that are already aligned to decimal quantity steps despite binary floating-point noise
- keep genuine off-step values rounding down for regular orders and up for reduce-only orders
- add regression coverage for `0.1`, `0.05`, `0.01`, and `0.001` steps
- bump `extrema_infra` from `0.2.5` to `0.2.6` in the same PR

## Root cause

The shared normalization helpers applied `floor` or `ceil` directly to `value / step`. Values such as `0.3 / 0.1` can evaluate to `2.9999999999999996`, causing a regular order to lose one full step. Conversely, a reduce-only value computed as `0.1 + 0.2` can sit just above the grid and gain one full step.

The fix applies a small, scale-aware machine-precision tolerance before the existing directional rounding. It does not change lot sizes, minimum sizes, maximum sizes, or the behavior of genuinely off-step quantities.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --features lob_clients` (98 unit, 3 integration, and 9 passing doctests)
- `cargo clippy --all-targets --features lob_clients -- -D warnings`
- `cargo build --release --features lob_clients`
- `cargo package --allow-dirty` for `extrema_infra v0.2.6`

The package dry-run produced and verified 246 files successfully. Existing yanked-version warnings for `bitcoin-io v0.1.100` and `bitcoin_hashes v0.14.100` remain non-blocking and unrelated.
