### PR TITLE
feat: add cross-exchange order cancellation

### DIFF
--- a/src/arch/market_assets/exchange/binance/binance_spot_cli.rs
+++ b/src/arch/market_assets/exchange/binance/binance_spot_cli.rs
@@ -523,7 +523,7 @@ impl BinanceSpotCli {
 
     async fn _place_order(&self, order_params: OrderParams) -> InfraResult<OrderAckData> {
         let mut query_string = format!(
-            "symbol={}&side={}&type={}&quantity={}",
+            "symbol={}&side={}&type={}&quantity={}&newOrderRespType=RESULT",
             order_params.inst.to_uppercase(),
             match order_params.side {
                 OrderSide::BUY => "BUY",
@@ -593,7 +593,13 @@ impl BinanceSpotCli {
         order_id: Option<&str>,
         cli_order_id: Option<&str>,
     ) -> InfraResult<OrderAckData> {
-        let mut query_string = format!("symbol={}", inst.to_uppercase());
+        if order_id.is_none() && cli_order_id.is_none() {
+            return Err(InfraError::ApiCliError(
+                "Binance Spot cancel_order requires order_id or cli_order_id".into(),
+            ));
+        }
+
+        let mut query_string = format!("symbol={}", cli_spot_to_binance_spot(inst));
 
         if let Some(oid) = order_id {
             query_string.push_str(&format!("&orderId={}", oid));

--- a/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
+++ b/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
@@ -115,6 +115,15 @@ impl LobPrivateRest for BinanceUmCli {
         self._place_order(order_params).await
     }
 
+    async fn cancel_order(
+        &self,
+        inst: &str,
+        order_id: Option<&str>,
+        cli_order_id: Option<&str>,
+    ) -> InfraResult<OrderAckData> {
+        self._cancel_order(inst, order_id, cli_order_id).await
+    }
+
     async fn get_balance(&self, assets: Option<&[String]>) -> InfraResult<Vec<BalanceData>> {
         self._get_balance(assets).await
     }
@@ -761,6 +770,51 @@ impl BinanceUmCli {
             .map(OrderAckData::from)
             .next()
             .ok_or(InfraError::ApiCliError("No order ack data returned".into()))?;
+
+        Ok(data)
+    }
+
+    async fn _cancel_order(
+        &self,
+        inst: &str,
+        order_id: Option<&str>,
+        cli_order_id: Option<&str>,
+    ) -> InfraResult<OrderAckData> {
+        if order_id.is_none() && cli_order_id.is_none() {
+            return Err(InfraError::ApiCliError(
+                "Binance UM cancel_order requires order_id or cli_order_id".into(),
+            ));
+        }
+
+        let mut query_string = format!("symbol={}", cli_perp_to_pure_uppercase(inst));
+        if let Some(order_id) = order_id {
+            query_string.push_str(&format!("&orderId={order_id}"));
+        }
+        if let Some(cli_order_id) = cli_order_id {
+            query_string.push_str(&format!("&origClientOrderId={cli_order_id}"));
+        }
+
+        let res: RestResBinance<RestOrderAckBinanceUM> = self
+            .api_key
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_signed_request(
+                &self.client,
+                RequestMethod::Delete,
+                Some(&query_string),
+                BINANCE_UM_FUTURES_BASE_URL,
+                BINANCE_UM_FUTURES_CANCEL_ORDER,
+            )
+            .await?;
+
+        let data: OrderAckData = res
+            .into_vec()?
+            .into_iter()
+            .map(OrderAckData::from)
+            .next()
+            .ok_or(InfraError::ApiCliError(
+                "No Binance UM cancel ack data returned".into(),
+            ))?;
 
         Ok(data)
     }

--- a/src/arch/market_assets/exchange/binance/config_assets.rs
+++ b/src/arch/market_assets/exchange/binance/config_assets.rs
@@ -28,6 +28,7 @@ pub const BINANCE_UM_FUTURES_EXCHANGE_INFO: &str = "/fapi/v1/exchangeInfo";
 pub const BINANCE_UM_FUTURES_ACCOUNT_INFO: &str = "/fapi/v3/account";
 pub const BINANCE_UM_FUTURES_BALANCE_INFO: &str = "/fapi/v3/balance";
 pub const BINANCE_UM_FUTURES_PLACE_ORDER_INFO: &str = "/fapi/v1/order";
+pub const BINANCE_UM_FUTURES_CANCEL_ORDER: &str = "/fapi/v1/order";
 pub const BINANCE_UM_FUTURES_CHANGE_LEVERAGE: &str = "/fapi/v1/leverage";
 pub const BINANCE_UM_FUTURES_POSITION_MODE: &str = "/fapi/v1/positionSide/dual";
 pub const BINANCE_UM_FUTURES_ACCOUNT_CONFIG: &str = "/fapi/v1/accountConfig";

--- a/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
@@ -110,6 +110,15 @@ impl LobPrivateRest for GateFuturesCli {
         self._place_order(order_params).await
     }
 
+    async fn cancel_order(
+        &self,
+        inst: &str,
+        order_id: Option<&str>,
+        cli_order_id: Option<&str>,
+    ) -> InfraResult<OrderAckData> {
+        self._cancel_order(inst, order_id, cli_order_id).await
+    }
+
     async fn get_positions(&self, insts: Option<&[String]>) -> InfraResult<Vec<PositionData>> {
         self._get_positions(insts).await
     }
@@ -645,6 +654,52 @@ impl GateFuturesCli {
             .map(OrderAckData::from)
             .next()
             .ok_or(InfraError::ApiCliError("No order ack data returned".into()))?;
+
+        Ok(data)
+    }
+
+    async fn _cancel_order(
+        &self,
+        inst: &str,
+        order_id: Option<&str>,
+        cli_order_id: Option<&str>,
+    ) -> InfraResult<OrderAckData> {
+        let order_id = match (order_id, cli_order_id) {
+            (Some(order_id), _) => order_id.to_string(),
+            (None, Some(cli_order_id)) => normalize_gate_text(cli_order_id),
+            (None, None) => {
+                return Err(InfraError::ApiCliError(
+                    "Gate Futures cancel_order requires order_id or cli_order_id".into(),
+                ));
+            },
+        };
+        let settle = infer_settle_from_inst(inst);
+        let endpoint = GATE_FUTURES_ORDER
+            .replace("{settle}", &settle)
+            .replace("{order_id}", &order_id);
+
+        let res: RestResGate<RestFuturesOrderGateFutures> = self
+            .api_key
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_signed_request(
+                &self.client,
+                RequestMethod::Delete,
+                None,
+                None,
+                GATE_BASE_URL,
+                &endpoint,
+            )
+            .await?;
+
+        let data = res
+            .into_vec()?
+            .into_iter()
+            .map(OrderAckData::from)
+            .next()
+            .ok_or(InfraError::ApiCliError(
+                "No Gate Futures cancel ack data returned".into(),
+            ))?;
 
         Ok(data)
     }

--- a/src/arch/market_assets/exchange/gate/gate_spot_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_spot_cli.rs
@@ -102,6 +102,15 @@ impl LobPrivateRest for GateSpotCli {
         self._place_order(order_params).await
     }
 
+    async fn cancel_order(
+        &self,
+        inst: &str,
+        order_id: Option<&str>,
+        cli_order_id: Option<&str>,
+    ) -> InfraResult<OrderAckData> {
+        self._cancel_order(inst, order_id, cli_order_id).await
+    }
+
     async fn get_balance(&self, assets: Option<&[String]>) -> InfraResult<Vec<BalanceData>> {
         self._get_balance(assets).await
     }
@@ -666,6 +675,51 @@ impl GateSpotCli {
             .map(OrderAckData::from)
             .next()
             .ok_or(InfraError::ApiCliError("No order ack data returned".into()))?;
+
+        Ok(data)
+    }
+
+    async fn _cancel_order(
+        &self,
+        inst: &str,
+        order_id: Option<&str>,
+        cli_order_id: Option<&str>,
+    ) -> InfraResult<OrderAckData> {
+        let order_id = match (order_id, cli_order_id) {
+            (Some(order_id), _) => order_id.to_string(),
+            (None, Some(cli_order_id)) => normalize_gate_text(cli_order_id),
+            (None, None) => {
+                return Err(InfraError::ApiCliError(
+                    "Gate Spot cancel_order requires order_id or cli_order_id".into(),
+                ));
+            },
+        };
+        let currency_pair = inst.to_uppercase();
+        let endpoint = GATE_SPOT_ORDER.replace("{order_id}", &order_id);
+        let query_string = format!("currency_pair={currency_pair}");
+
+        let res: RestResGate<RestOrderGateSpot> = self
+            .api_key
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_signed_request(
+                &self.client,
+                RequestMethod::Delete,
+                Some(&query_string),
+                None,
+                GATE_BASE_URL,
+                &endpoint,
+            )
+            .await?;
+
+        let data = res
+            .into_vec()?
+            .into_iter()
+            .map(OrderAckData::from)
+            .next()
+            .ok_or(InfraError::ApiCliError(
+                "No Gate Spot cancel ack data returned".into(),
+            ))?;
 
         Ok(data)
     }

--- a/src/arch/market_assets/exchange/hyperliquid/api_utils.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/api_utils.rs
@@ -387,6 +387,33 @@ pub struct HyperliquidOrderAction {
 }
 
 #[derive(Clone, Debug, Serialize)]
+#[serde(tag = "type")]
+pub enum HyperliquidCancelAction {
+    #[serde(rename = "cancel")]
+    ByOid {
+        cancels: Vec<HyperliquidCancelByOidRequest>,
+    },
+    #[serde(rename = "cancelByCloid")]
+    ByCloid {
+        cancels: Vec<HyperliquidCancelByCloidRequest>,
+    },
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct HyperliquidCancelByOidRequest {
+    #[serde(rename = "a")]
+    pub asset: u32,
+    #[serde(rename = "o")]
+    pub order_id: u64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct HyperliquidCancelByCloidRequest {
+    pub asset: u32,
+    pub cloid: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
 pub struct HyperliquidBuilderFee {
     pub b: String,
     pub f: u32,
@@ -569,6 +596,26 @@ pub fn normalize_hyperliquid_num_str(input: &str) -> String {
     }
 }
 
+pub fn normalize_hyperliquid_cloid(cloid: &str) -> InfraResult<String> {
+    let cloid = cloid.trim();
+    let Some(hex) = cloid
+        .strip_prefix("0x")
+        .or_else(|| cloid.strip_prefix("0X"))
+    else {
+        return Err(InfraError::ApiCliError(format!(
+            "Invalid Hyperliquid cloid, expected 0x-prefixed 128-bit hex: {cloid}"
+        )));
+    };
+
+    if hex.len() != 32 || !hex.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        return Err(InfraError::ApiCliError(format!(
+            "Invalid Hyperliquid cloid, expected 0x-prefixed 128-bit hex: {cloid}"
+        )));
+    }
+
+    Ok(format!("0x{}", hex.to_ascii_lowercase()))
+}
+
 fn is_hyperliquid_kilo_symbol(symbol: &str) -> bool {
     !symbol.is_empty()
         && symbol
@@ -579,6 +626,7 @@ fn is_hyperliquid_kilo_symbol(symbol: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn normalizes_perp_names_with_explicit_quote() {
@@ -630,6 +678,40 @@ mod tests {
         assert_eq!(
             hyperliquid_perp_asset_id_for_dex(7, Some(2)).unwrap(),
             120007
+        );
+    }
+
+    #[test]
+    fn serializes_cancel_actions_and_normalizes_cloid() {
+        let by_oid = serde_json::to_value(HyperliquidCancelAction::ByOid {
+            cancels: vec![HyperliquidCancelByOidRequest {
+                asset: 120_007,
+                order_id: 42,
+            }],
+        })
+        .unwrap();
+        assert_eq!(
+            by_oid,
+            json!({"type":"cancel","cancels":[{"a":120007,"o":42}]})
+        );
+
+        let cloid = normalize_hyperliquid_cloid("0xABCDEF0123456789ABCDEF0123456789").unwrap();
+        let by_cloid = serde_json::to_value(HyperliquidCancelAction::ByCloid {
+            cancels: vec![HyperliquidCancelByCloidRequest {
+                asset: 10_000,
+                cloid,
+            }],
+        })
+        .unwrap();
+        assert_eq!(
+            by_cloid,
+            json!({
+                "type":"cancelByCloid",
+                "cancels":[{
+                    "asset":10000,
+                    "cloid":"0xabcdef0123456789abcdef0123456789"
+                }]
+            })
         );
     }
 }

--- a/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
@@ -32,6 +32,7 @@ use super::{
     schemas::rest::{
         all_mids::RestAllMidsHyperliquid,
         asset_ctxs::RestMetaAndAssetCtxsHyperliquid,
+        cancel_order::RestCancelAckHyperliquid,
         candle::RestCandleHyperliquid,
         clearinghouse_state::RestClearinghouseStateHyperliquid,
         funding_history::RestFundingHistoryHyperliquid,
@@ -116,6 +117,15 @@ impl LobPrivateRest for HyperliquidCli {
 
     async fn place_order(&self, order_params: OrderParams) -> InfraResult<OrderAckData> {
         self._place_order(order_params).await
+    }
+
+    async fn cancel_order(
+        &self,
+        inst: &str,
+        order_id: Option<&str>,
+        cli_order_id: Option<&str>,
+    ) -> InfraResult<OrderAckData> {
+        self._cancel_order(inst, order_id, cli_order_id).await
     }
 
     async fn get_balance(&self, assets: Option<&[String]>) -> InfraResult<Vec<BalanceData>> {
@@ -603,6 +613,73 @@ impl HyperliquidCli {
             .ok_or(InfraError::ApiCliError(
                 "No Hyperliquid order ack data returned".into(),
             ))?;
+
+        Ok(data)
+    }
+
+    async fn _cancel_order(
+        &self,
+        inst: &str,
+        order_id: Option<&str>,
+        cli_order_id: Option<&str>,
+    ) -> InfraResult<OrderAckData> {
+        if order_id.is_none() && cli_order_id.is_none() {
+            return Err(InfraError::ApiCliError(
+                "Hyperliquid cancel_order requires order_id or cli_order_id".into(),
+            ));
+        }
+
+        let asset = self._inst_to_asset_id(inst)?;
+        let (action, returned_order_id, returned_cli_order_id) = match order_id {
+            Some(order_id) => {
+                let oid = order_id.parse::<u64>().map_err(|_| {
+                    InfraError::ApiCliError(format!(
+                        "Invalid Hyperliquid order_id, expected u64 string: {order_id}"
+                    ))
+                })?;
+                (
+                    HyperliquidCancelAction::ByOid {
+                        cancels: vec![HyperliquidCancelByOidRequest {
+                            asset,
+                            order_id: oid,
+                        }],
+                    },
+                    Some(order_id.to_string()),
+                    cli_order_id.map(str::to_string),
+                )
+            },
+            None => {
+                let cloid =
+                    normalize_hyperliquid_cloid(cli_order_id.ok_or(InfraError::ApiCliError(
+                        "Hyperliquid cancel_order requires order_id or cli_order_id".into(),
+                    ))?)?;
+                (
+                    HyperliquidCancelAction::ByCloid {
+                        cancels: vec![HyperliquidCancelByCloidRequest {
+                            asset,
+                            cloid: cloid.clone(),
+                        }],
+                    },
+                    None,
+                    Some(cloid),
+                )
+            },
+        };
+        let res: RestResHyperliquid<RestCancelAckHyperliquid> = self
+            .auth
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_signed_exchange_action_raw(&self.client, &action)
+            .await?;
+
+        let data = res
+            .into_vec()?
+            .into_iter()
+            .next()
+            .ok_or(InfraError::ApiCliError(
+                "No Hyperliquid cancel ack data returned".into(),
+            ))?
+            .into_cancel_ack(returned_order_id, returned_cli_order_id)?;
 
         Ok(data)
     }

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest.rs
@@ -1,5 +1,6 @@
 pub mod all_mids;
 pub mod asset_ctxs;
+pub mod cancel_order;
 pub mod candle;
 pub mod clearinghouse_state;
 pub mod funding_history;

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest/cancel_order.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest/cancel_order.rs
@@ -1,0 +1,72 @@
+use serde::Deserialize;
+
+use crate::{
+    arch::market_assets::{
+        api_data::account_data::OrderAckData, api_general::get_micros_timestamp,
+        base_data::OrderStatus,
+    },
+    errors::{InfraError, InfraResult},
+};
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestCancelAckHyperliquid {
+    pub statuses: Vec<RestCancelStatusHyperliquid>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+pub enum RestCancelStatusHyperliquid {
+    Status(String),
+    Error { error: String },
+}
+
+impl RestCancelAckHyperliquid {
+    pub fn into_cancel_ack(
+        self,
+        order_id: Option<String>,
+        cli_order_id: Option<String>,
+    ) -> InfraResult<OrderAckData> {
+        let status = self
+            .statuses
+            .into_iter()
+            .next()
+            .ok_or(InfraError::ApiCliError(
+                "No Hyperliquid cancel ack status returned".into(),
+            ))?;
+        let (order_status, msg) = match status {
+            RestCancelStatusHyperliquid::Status(status) if status == "success" => {
+                (OrderStatus::Canceled, None)
+            },
+            RestCancelStatusHyperliquid::Status(status) => (OrderStatus::Rejected, Some(status)),
+            RestCancelStatusHyperliquid::Error { error } => (OrderStatus::Rejected, Some(error)),
+        };
+
+        Ok(OrderAckData {
+            timestamp: get_micros_timestamp(),
+            order_status,
+            order_id: order_id.unwrap_or_default(),
+            cli_order_id,
+            msg,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_success_and_error_statuses() {
+        let success: RestCancelAckHyperliquid =
+            serde_json::from_str(r#"{"statuses":["success"]}"#).unwrap();
+        let success = success.into_cancel_ack(Some("42".into()), None).unwrap();
+        assert_eq!(success.order_status, OrderStatus::Canceled);
+        assert_eq!(success.order_id, "42");
+
+        let error: RestCancelAckHyperliquid =
+            serde_json::from_str(r#"{"statuses":[{"error":"Order was never placed"}]}"#).unwrap();
+        let error = error.into_cancel_ack(None, Some("0x123".into())).unwrap();
+        assert_eq!(error.order_status, OrderStatus::Rejected);
+        assert_eq!(error.msg.as_deref(), Some("Order was never placed"));
+    }
+}

--- a/src/arch/market_assets/exchange/okx/config_assets.rs
+++ b/src/arch/market_assets/exchange/okx/config_assets.rs
@@ -19,6 +19,7 @@ pub const OKX_ASSET_TRANSFER_STATE: &str = "/api/v5/asset/transfer-state";
 pub const OKX_ASSET_WITHDRAWAL: &str = "/api/v5/asset/withdrawal";
 pub const OKX_ASSET_WITHDRAWAL_HISTORY: &str = "/api/v5/asset/withdrawal-history";
 pub const OKX_TRADE_ORDER: &str = "/api/v5/trade/order";
+pub const OKX_TRADE_CANCEL_ORDER: &str = "/api/v5/trade/cancel-order";
 pub const OKX_TRADE_ORDERS_HISTORY: &str = "/api/v5/trade/orders-history";
 pub const OKX_PUBLIC_INSTRUMENTS: &str = "/api/v5/public/instruments";
 pub const OKX_PUBLIC_FUNDING_RATE: &str = "/api/v5/public/funding-rate";

--- a/src/arch/market_assets/exchange/okx/okx_cli.rs
+++ b/src/arch/market_assets/exchange/okx/okx_cli.rs
@@ -127,6 +127,15 @@ impl LobPrivateRest for OkxCli {
         self._place_order(order_params).await
     }
 
+    async fn cancel_order(
+        &self,
+        inst: &str,
+        order_id: Option<&str>,
+        cli_order_id: Option<&str>,
+    ) -> InfraResult<OrderAckData> {
+        self._cancel_order(inst, order_id, cli_order_id).await
+    }
+
     async fn get_balance(&self, assets: Option<&[String]>) -> InfraResult<Vec<BalanceData>> {
         self._get_balance(assets).await
     }
@@ -1072,6 +1081,51 @@ impl OkxCli {
             .map(OrderAckData::from)
             .next()
             .ok_or(InfraError::ApiCliError("No order ack data returned".into()))?;
+
+        Ok(data)
+    }
+
+    async fn _cancel_order(
+        &self,
+        inst: &str,
+        order_id: Option<&str>,
+        cli_order_id: Option<&str>,
+    ) -> InfraResult<OrderAckData> {
+        if order_id.is_none() && cli_order_id.is_none() {
+            return Err(InfraError::ApiCliError(
+                "OKX cancel_order requires order_id or cli_order_id".into(),
+            ));
+        }
+
+        let mut body = json!({ "instId": cli_perp_to_okx_inst(inst) });
+        if let Some(order_id) = order_id {
+            body["ordId"] = json!(order_id);
+        }
+        if let Some(cli_order_id) = cli_order_id {
+            body["clOrdId"] = json!(cli_order_id);
+        }
+
+        let res: RestResOkx<RestOrderAckOkx> = self
+            .api_key
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_signed_request(
+                &self.client,
+                RequestMethod::Post,
+                body.to_string(),
+                OKX_BASE_URL,
+                OKX_TRADE_CANCEL_ORDER,
+            )
+            .await?;
+
+        let data = res
+            .into_vec()?
+            .into_iter()
+            .map(RestOrderAckOkx::into_cancel_ack)
+            .next()
+            .ok_or(InfraError::ApiCliError(
+                "No OKX cancel ack data returned".into(),
+            ))?;
 
         Ok(data)
     }

--- a/src/arch/market_assets/exchange/okx/schemas/rest/trade_order.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/rest/trade_order.rs
@@ -36,3 +36,45 @@ impl From<RestOrderAckOkx> for OrderAckData {
         }
     }
 }
+
+impl RestOrderAckOkx {
+    pub fn into_cancel_ack(self) -> OrderAckData {
+        let msg = (!self.sMsg.is_empty()).then_some(self.sMsg);
+
+        OrderAckData {
+            timestamp: ts_to_micros(self.ts.parse().unwrap_or_default()),
+            order_status: if self.sCode == "0" {
+                OrderStatus::Canceled
+            } else {
+                OrderStatus::Rejected
+            },
+            order_id: self.ordId,
+            cli_order_id: self.clOrdId,
+            msg,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cancel_ack_maps_success_and_rejection() {
+        let success: RestOrderAckOkx = serde_json::from_str(
+            r#"{"clOrdId":"cancel1","ordId":"42","tag":"","ts":"1000","sCode":"0","sMsg":""}"#,
+        )
+        .unwrap();
+        let success = success.into_cancel_ack();
+        assert_eq!(success.order_status, OrderStatus::Canceled);
+        assert_eq!(success.order_id, "42");
+
+        let rejected: RestOrderAckOkx = serde_json::from_str(
+            r#"{"clOrdId":"cancel2","ordId":"43","tag":"","ts":"1001","sCode":"51400","sMsg":"Order cancellation failed"}"#,
+        )
+        .unwrap();
+        let rejected = rejected.into_cancel_ack();
+        assert_eq!(rejected.order_status, OrderStatus::Rejected);
+        assert_eq!(rejected.msg.as_deref(), Some("Order cancellation failed"));
+    }
+}


### PR DESCRIPTION
## Summary

- implement `LobPrivateRest::cancel_order` for Binance Spot and UM, Gate Spot and Futures, OKX Spot and Perp, and Hyperliquid Spot and perp DEXes
- support exchange order IDs across all clients and client order IDs where each exchange protocol permits them
- model Hyperliquid `cancel` and `cancelByCloid` as one typed action and move cancel response conversion into its schema
- request Binance Spot `newOrderRespType=RESULT` so accepted `LIMIT_MAKER` orders include a parseable status

## Why

The shared LOB interface exposed cancellation, but most concrete clients still returned `Unimplemented`. Live probing also found that Binance Spot defaults `LIMIT_MAKER` to an ACK response without `status`, which could leave the caller unable to identify and cancel an accepted order.

## Validation

- `cargo fmt`
- `cargo test --features lob_clients`: 101 unit tests, 3 integration tests, and doctests passed
- `cargo clippy --all-targets --features lob_clients -- -D warnings`
- live `all_test` smoke coverage on large PO: Binance Spot/UM, Gate unified Spot/Futures, OKX Spot/Perp, Hyperliquid Spot/default perp/xyz perp
- every live test order reached `Canceled` with zero executed size
