### PR TITLE
chore: bump crate to 0.2.7 and tungstenite to 0.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2024"
 
 readme = "README.md"
@@ -30,8 +30,8 @@ futures-util = "0.3.32"
 
 # HTTP / WebSocket
 reqwest = { version = "0.13.4", features = ["json", "gzip"] }
-tokio-tungstenite = { version = "0.29.0", features = ["rustls-tls-webpki-roots"] }
-tungstenite = "0.29.0"
+tokio-tungstenite = { version = "0.30.0", features = ["rustls-tls-webpki-roots"] }
+tungstenite = "0.30.0"
 
 # Serialization / JSON / Binary encoding
 serde = { version = "1.0.228", features = ["derive"] }


### PR DESCRIPTION
## Summary

- bump `extrema_infra` from `0.2.6` to `0.2.7`
- update `tokio-tungstenite` and `tungstenite` from `0.29` to `0.30`

## Why

Prepare the next patch release and keep the WebSocket dependency pair aligned on the same release line.

## Impact

The existing Infra WebSocket client code compiles without changes. The current downstream dependency requirement of `0.2.6` can resolve `0.2.7` after publication.

Compatibility was also checked against:

- `portfolio_orchestrator`
- `funding_carry`
- `hyper_portfolio`

## Validation

- `cargo check --all-features --offline --locked`
- `cargo test --all-features --offline --locked`
- downstream compile checks with crates.io `extrema_infra` patched to this local `0.2.7`
