### PR TITLE
chore: prepare extrema_infra 0.2.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2024"
 
 readme = "README.md"
@@ -24,9 +24,9 @@ path = "src/lib.rs"
 
 [dependencies]
 # Async runtime
-tokio = { version = "1.52.3", features = ["full"] }
-futures = "0.3.32"
-futures-util = "0.3.32"
+tokio = { version = "1.53.0", features = ["full"] }
+futures = "0.3.33"
+futures-util = "0.3.33"
 
 # HTTP / WebSocket
 reqwest = { version = "0.13.4", features = ["json", "gzip"] }
@@ -34,7 +34,7 @@ tokio-tungstenite = { version = "0.30.0", features = ["rustls-tls-webpki-roots"]
 tungstenite = "0.30.0"
 
 # Serialization / JSON / Binary encoding
-serde = { version = "1.0.228", features = ["derive"] }
+serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.150"
 simd-json = "0.17.3"
 rmp-serde = "1.3.1"
@@ -60,7 +60,7 @@ tracing-subscriber = "0.3.23"
 
 # Environment & Error handling
 dotenvy = "0.15.7"
-thiserror = "2.0.18"
+thiserror = "2.0.19"
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A quantitative trading environment built in Rust.
 
 - Maximizes runtime efficiency through **static dispatch** and promotes scalability with **Heterogeneous Lists (HList)** for strategy registration.
 
-At its core: **One unified framework for multiple exchanges, multiple strategies, zero runtime boxing.**
+At its core: **One unified framework for multiple exchanges and strategies, with static dispatch at the strategy-registration boundary.**
 
 ---
 
@@ -176,7 +176,7 @@ With **HList**:
 |---------------------------|-----------------------------------|-------------------------------|
 | **Dispatch**              | Dynamic (runtime `vtable`)        | Static (compile-time inlined) |
 | **Type Safety**           | Runtime only                      | Compile-time enforced         |
-| **Performance**           | Extra indirection, heap alloc     | Zero overhead, no heap alloc  |
+| **Strategy registration** | Trait-object indirection          | Concrete types, static dispatch |
 | **Compile-time Checking** | Limited                           | Full (trait bounds enforced)  |
 
 ---
@@ -276,9 +276,11 @@ shape = list(tensor.shape)
 
 ## LOB Exchange API Traits
 
-These traits apply only to LOB-based exchanges (Binance, OKX, Hyperliquid, etc.)
+These traits apply to LOB-based exchanges such as Binance, OKX, Gate, and Hyperliquid.
 
-For connecting to exchanges, you need to implement these traits for each exchange client:
+Client implementors use these traits to expose exchange capabilities. Applications can
+use the built-in clients directly or dispatch through `LobClients`. Operations that a
+selected client does not support return `InfraError::Unimplemented`.
 
 - **LobWebsocket**  
   Defines how to build subscription/connect messages for websocket streams.
@@ -345,7 +347,7 @@ extrema_infra = { version = "0.2", features = ["all"] }
 # extrema_infra = { git = "https://github.com/Lqz13Th/extrema_infra", features = ["all"] }
 
 # Tokio async runtime
-tokio = { version = "1.52", features = ["full"] }
+tokio = { version = "1.53.0", features = ["full"] }
 
 # TLS / Cryptography
 rustls = { version = "0.23", features = ["aws-lc-rs"] }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -90,7 +90,7 @@ see [TLS Setup](#tls-setup).
 extrema_infra = { path = "../extrema_infra" }
 # Published crate usage:
 # extrema_infra = "0.2"
-tokio = { version = "1.52", features = ["full"] }
+tokio = { version = "1.53.0", features = ["full"] }
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/src/arch/market_assets/exchange/lob_clients.rs
+++ b/src/arch/market_assets/exchange/lob_clients.rs
@@ -13,6 +13,11 @@ use crate::arch::{
 };
 use crate::errors::{InfraError, InfraResult};
 
+/// Unified dispatcher for the built-in limit-order-book exchange clients.
+///
+/// Each trait call delegates to the selected concrete client. Exchange
+/// capabilities are not uniform, so unsupported operation and market
+/// combinations return [`InfraError::Unimplemented`].
 #[derive(Clone, Debug)]
 #[cfg(feature = "lob_clients")]
 pub enum LobClients {

--- a/src/arch/traits/market_lob.rs
+++ b/src/arch/traits/market_lob.rs
@@ -161,7 +161,9 @@ pub trait LobWebsocket: Send + Sync {
         ready(Err(InfraError::Unimplemented))
     }
 
-    /// Builds or returns a public websocket connection target.
+    /// Builds a structured public websocket connection target.
+    ///
+    /// The target can include connection metadata such as HTTP headers.
     fn get_public_connect_target(
         &self,
         _channel: &WsChannel,
@@ -169,7 +171,7 @@ pub trait LobWebsocket: Send + Sync {
         ready(Err(InfraError::Unimplemented))
     }
 
-    /// Builds or returns a private websocket connection target.
+    /// Returns the private websocket endpoint using the legacy string form.
     fn get_private_connect_msg(
         &self,
         _channel: &WsChannel,
@@ -177,7 +179,9 @@ pub trait LobWebsocket: Send + Sync {
         ready(Err(InfraError::Unimplemented))
     }
 
-    /// Builds or returns a private websocket connection target.
+    /// Builds a structured private websocket connection target.
+    ///
+    /// The target can include connection metadata such as HTTP headers.
     fn get_private_connect_target(
         &self,
         _channel: &WsChannel,


### PR DESCRIPTION
## Summary
- bump extrema_infra to 0.2.8 and refresh Tokio, Futures, Serde, and thiserror
- align README and usage examples with Tokio 1.53.0
- clarify LOB client capability and WebSocket connection target documentation

## Why
Keeps the published crate on current compatible runtime and dependency releases, while making the public docs accurately describe static dispatch and exchange capability boundaries.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- `cargo publish --dry-run --all-features`