### PR TITLE
chore: prepare extrema_infra 0.2.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2024"
 
 readme = "README.md"
@@ -24,7 +24,7 @@ path = "src/lib.rs"
 
 [dependencies]
 # Async runtime
-tokio = { version = "1.53.0", features = ["full"] }
+tokio = { version = "1.53.1", features = ["full"] }
 futures = "0.3.33"
 futures-util = "0.3.33"
 
@@ -35,7 +35,7 @@ tungstenite = "0.30.0"
 
 # Serialization / JSON / Binary encoding
 serde = { version = "1.0.229", features = ["derive"] }
-serde_json = "1.0.150"
+serde_json = "1.0.151"
 simd-json = "0.17.3"
 rmp-serde = "1.3.1"
 

--- a/src/arch/market_assets/exchange/binance/binance_spot_cli.rs
+++ b/src/arch/market_assets/exchange/binance/binance_spot_cli.rs
@@ -522,8 +522,14 @@ impl BinanceSpotCli {
     }
 
     async fn _place_order(&self, order_params: OrderParams) -> InfraResult<OrderAckData> {
+        let (quantity_param, quantity) =
+            if let Some(quote_order_qty) = order_params.extra.get("quoteOrderQty") {
+                ("quoteOrderQty", quote_order_qty)
+            } else {
+                ("quantity", &order_params.size)
+            };
         let mut query_string = format!(
-            "symbol={}&side={}&type={}&quantity={}&newOrderRespType=RESULT",
+            "symbol={}&side={}&type={}&{}={}&newOrderRespType=RESULT",
             order_params.inst.to_uppercase(),
             match order_params.side {
                 OrderSide::BUY => "BUY",
@@ -538,7 +544,8 @@ impl BinanceSpotCli {
                 OrderType::Ioc => "IOC",
                 OrderType::Unknown => "MARKET",
             },
-            order_params.size,
+            quantity_param,
+            quantity,
         );
 
         if let Some(price) = &order_params.price {
@@ -561,6 +568,9 @@ impl BinanceSpotCli {
         }
 
         for (k, v) in &order_params.extra {
+            if k == "quoteOrderQty" {
+                continue;
+            }
             query_string.push_str(&format!("&{}={}", k, v));
         }
 


### PR DESCRIPTION
## Summary

- allow Binance Spot callers to opt into `quoteOrderQty` through `OrderParams.extra`
- serialize `quoteOrderQty` instead of the default `quantity`, so the request never contains both parameters
- preserve existing `quantity` behavior for every caller that does not opt in
- bump `extrema_infra` to `0.2.9`, Tokio to `1.53.1`, and serde_json to `1.0.151`

## Why

Binance market buys interpret `quantity` as base-asset quantity. Funding bridge
conversions need a quote-asset spending cap, and adding `quoteOrderQty` through
`extra` previously produced an invalid request containing both amount fields.

## Validation

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- live Large PO Binance Master Spot probe using this Infra build:
  `OrderParams.size=999999` with `quoteOrderQty=7` filled only 6 USDC, proving
  `quantity` was omitted; the 6 USDC was immediately sold back, USDC balance
  returned exactly to baseline, and round-trip spread was 0.00006 USDT
