### PR TITLE
feat(market): expose instrument max leverage

### DIFF
--- a/src/arch/market_assets/api_data/utils_data.rs
+++ b/src/arch/market_assets/api_data/utils_data.rs
@@ -12,6 +12,7 @@ pub struct InstrumentInfo {
     pub max_lmt_size: f64,
     pub min_mkt_size: f64,
     pub max_mkt_size: f64,
+    pub max_leverage: Option<u32>,
     pub min_notional: Option<f64>,
     pub contract_value: Option<f64>,
     pub contract_multiplier: Option<f64>,

--- a/src/arch/market_assets/exchange/binance/schemas/cm_futures_rest/exchange_info.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/cm_futures_rest/exchange_info.rs
@@ -144,6 +144,7 @@ impl From<InstrumentInfoBinanceCM> for InstrumentInfo {
             max_lmt_size,
             min_mkt_size,
             max_mkt_size,
+            max_leverage: None,
             min_notional: (min_notional > 0.0).then_some(min_notional),
             contract_value: None,
             contract_multiplier: None,

--- a/src/arch/market_assets/exchange/binance/schemas/spot_rest/exchange_info.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/spot_rest/exchange_info.rs
@@ -129,6 +129,7 @@ impl From<InstrumentInfoBinanceSpot> for InstrumentInfo {
             max_lmt_size,
             min_mkt_size,
             max_mkt_size,
+            max_leverage: None,
             min_notional: (min_notional > 0.0).then_some(min_notional),
             contract_value: None,
             contract_multiplier: None,

--- a/src/arch/market_assets/exchange/binance/schemas/um_futures_rest/exchange_info.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/um_futures_rest/exchange_info.rs
@@ -144,6 +144,7 @@ impl From<InstrumentInfoBinanceUM> for InstrumentInfo {
             max_lmt_size,
             min_mkt_size,
             max_mkt_size,
+            max_leverage: None,
             min_notional: (min_notional > 0.0).then_some(min_notional),
             contract_value: None,
             contract_multiplier: None,

--- a/src/arch/market_assets/exchange/gate/schemas/delivery_rest/contract_delivery.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/delivery_rest/contract_delivery.rs
@@ -73,6 +73,7 @@ impl From<RestContractGateDelivery> for InstrumentInfo {
             max_lmt_size: max_size,
             min_mkt_size: lot_size,
             max_mkt_size: max_size,
+            max_leverage: None,
             min_notional: None,
             contract_value: d.quanto_multiplier.parse().ok(),
             contract_multiplier: None,

--- a/src/arch/market_assets/exchange/gate/schemas/futures_rest/contract_futures.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/futures_rest/contract_futures.rs
@@ -92,6 +92,7 @@ impl From<RestContractGateFutures> for InstrumentInfo {
             max_lmt_size: max_size,
             min_mkt_size: min_size,
             max_mkt_size: max_size,
+            max_leverage: None,
             min_notional: None,
             contract_value: d.quanto_multiplier.parse().ok(),
             contract_multiplier: None,

--- a/src/arch/market_assets/exchange/gate/schemas/spot_rest/currency_pair.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/spot_rest/currency_pair.rs
@@ -45,6 +45,7 @@ impl From<RestCurrencyPairGateSpot> for InstrumentInfo {
             max_lmt_size: max_base_amount,
             min_mkt_size: min_base_amount.max(lot_size),
             max_mkt_size: market_order_max_stock,
+            max_leverage: None,
             min_notional: d.min_quote_amount.parse::<f64>().ok().filter(|v| *v > 0.0),
             contract_value: None,
             contract_multiplier: None,

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest/meta.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest/meta.rs
@@ -52,6 +52,7 @@ impl RestMetaUniverseHyperliquid {
             max_lmt_size: f64::MAX,
             min_mkt_size: lot_size,
             max_mkt_size: f64::MAX,
+            max_leverage: self.maxLeverage,
             min_notional: None,
             contract_value: None,
             contract_multiplier: None,

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest/spot_meta.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest/spot_meta.rs
@@ -117,6 +117,7 @@ impl RestSpotUniverseHyperliquid {
             max_lmt_size: 0.0,
             min_mkt_size: lot_size,
             max_mkt_size: 0.0,
+            max_leverage: None,
             min_notional: None,
             contract_value: None,
             contract_multiplier: None,

--- a/src/arch/market_assets/exchange/okx/schemas/rest/public_instruments.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/rest/public_instruments.rs
@@ -60,6 +60,7 @@ impl From<RestInstrumentsOkx> for InstrumentInfo {
             max_lmt_size: d.maxLmtSz.parse().unwrap_or_default(),
             min_mkt_size: d.minSz.parse().unwrap_or_default(),
             max_mkt_size: d.maxMktSz.parse().unwrap_or_default(),
+            max_leverage: None,
             min_notional: None,
             contract_value: d.ctVal.and_then(|p| p.parse().ok()),
             contract_multiplier: d.ctMult.and_then(|p| p.parse().ok()),


### PR DESCRIPTION
## Summary
- add an optional `max_leverage` capability to the shared `InstrumentInfo` model
- propagate Hyperliquid perpetual `maxLeverage` metadata into that field
- leave the capability unset for spot markets and exchanges that do not currently expose it

## Why
Portfolio-level leverage initialization needs an exchange-agnostic way to cap the configured target by each instrument's supported maximum, avoiding expected failed leverage requests.

This PR only exposes metadata. It does not change leverage-setting behavior.

## Validation
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test --lib` (16 passed)