### PR TITLE
fix: reject unknown order side and type

### DIFF
--- a/src/arch/market_assets/api_general.rs
+++ b/src/arch/market_assets/api_general.rs
@@ -277,6 +277,24 @@ pub struct OrderParams {
     pub extra: HashMap<String, String>, // general
 }
 
+impl OrderParams {
+    pub fn validate_side_and_type(&self) -> InfraResult<()> {
+        if matches!(&self.side, OrderSide::Unknown) {
+            return Err(InfraError::ApiCliError(
+                "Order side must be explicitly set".into(),
+            ));
+        }
+
+        if matches!(&self.order_type, OrderType::Unknown) {
+            return Err(InfraError::ApiCliError(
+                "Order type must be explicitly set".into(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -300,6 +318,32 @@ mod tests {
     #[test]
     fn rejects_custom_candle_interval_without_known_duration() {
         assert!(candle_interval_millis(&CandleParam::Custom("2m".into())).is_err());
+    }
+
+    #[test]
+    fn rejects_order_without_explicit_side_or_type() {
+        let missing_side = OrderParams {
+            order_type: OrderType::Market,
+            ..Default::default()
+        };
+        assert!(missing_side.validate_side_and_type().is_err());
+
+        let missing_type = OrderParams {
+            side: OrderSide::BUY,
+            ..Default::default()
+        };
+        assert!(missing_type.validate_side_and_type().is_err());
+    }
+
+    #[test]
+    fn accepts_order_with_explicit_side_and_type() {
+        let order = OrderParams {
+            side: OrderSide::SELL,
+            order_type: OrderType::Limit,
+            ..Default::default()
+        };
+
+        assert!(order.validate_side_and_type().is_ok());
     }
 
     #[test]

--- a/src/arch/market_assets/exchange/binance/binance_spot_cli.rs
+++ b/src/arch/market_assets/exchange/binance/binance_spot_cli.rs
@@ -530,6 +530,8 @@ impl BinanceSpotCli {
     }
 
     async fn _place_order(&self, order_params: OrderParams) -> InfraResult<OrderAckData> {
+        order_params.validate_side_and_type()?;
+
         let (quantity_param, quantity) =
             if let Some(quote_order_qty) = order_params.extra.get("quoteOrderQty") {
                 ("quoteOrderQty", quote_order_qty)

--- a/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
+++ b/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
@@ -703,6 +703,8 @@ impl BinanceUmCli {
     }
 
     async fn _place_order(&self, order_params: OrderParams) -> InfraResult<OrderAckData> {
+        order_params.validate_side_and_type()?;
+
         let mut query_string = format!(
             "symbol={}&side={}&type={}&quantity={}",
             cli_perp_to_pure_uppercase(&order_params.inst),

--- a/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
@@ -586,6 +586,8 @@ impl GateFuturesCli {
     }
 
     async fn _place_order(&self, order_params: OrderParams) -> InfraResult<OrderAckData> {
+        order_params.validate_side_and_type()?;
+
         let mut extra = order_params.extra;
         let gate_channel_id = take_gate_channel_id(&mut extra)?;
         let settle = extra

--- a/src/arch/market_assets/exchange/gate/gate_spot_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_spot_cli.rs
@@ -666,6 +666,8 @@ impl GateSpotCli {
     }
 
     async fn _place_order(&self, order_params: OrderParams) -> InfraResult<OrderAckData> {
+        order_params.validate_side_and_type()?;
+
         let mut body = json!({
             "currency_pair": order_params.inst,
             "side": match order_params.side {

--- a/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
@@ -595,6 +595,8 @@ impl HyperliquidCli {
     }
 
     async fn _place_order(&self, order_params: OrderParams) -> InfraResult<OrderAckData> {
+        order_params.validate_side_and_type()?;
+
         let mut order_params = order_params;
         let asset_id = self._inst_to_asset_id(&order_params.inst)?;
         order_params.inst = asset_id.to_string();

--- a/src/arch/market_assets/exchange/okx/okx_cli.rs
+++ b/src/arch/market_assets/exchange/okx/okx_cli.rs
@@ -1021,6 +1021,8 @@ impl OkxCli {
     }
 
     async fn _place_order(&self, order_params: OrderParams) -> InfraResult<OrderAckData> {
+        order_params.validate_side_and_type()?;
+
         let mut body = json!({
             "instId": cli_perp_to_okx_inst(&order_params.inst),
             "side": match order_params.side {


### PR DESCRIPTION
## Summary

- add a shared `OrderParams::validate_side_and_type` submission guard
- reject `OrderSide::Unknown` and `OrderType::Unknown` before any exchange request is built
- apply the guard to Binance Spot/UM, Gate Spot/Futures, Hyperliquid, and OKX order submission
- add unit coverage for rejected unknown values and accepted explicit values

## Why

`OrderParams` derives `Default`, so omitted side and order type become `Unknown`. Several exchange adapters previously mapped those values to `BUY` and `MARKET`, which could turn an incomplete order into a valid live order instead of failing closed.

## Impact

Explicitly configured orders are unchanged. Incomplete orders now return `InfraError::ApiCliError` before a network request is sent.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --all-features --all-targets` (107 passed)
- `cargo clippy --all-features --all-targets -- -D warnings`
- `git diff --check`
