### PR TITLE
perf(runtime): prioritize private events in biased strategy dispatch

### DIFF
--- a/src/arch/strategy_base/handler/handler_core.rs
+++ b/src/arch/strategy_base/handler/handler_core.rs
@@ -292,42 +292,16 @@ pub(crate) async fn strategy_handler_loop<S>(
         tokio::select! {
             biased;
 
-            msg = recv_or_pending(&mut rx_trade) => {
+            // `biased` polls top-to-bottom. Keep websocket control and private
+            // account truth ahead of order generation and public market data.
+            msg = recv_or_pending(&mut rx_ws_event) => {
                 match msg {
-                    Ok(msg) => strategies.on_trade(msg).await,
+                    Ok(msg) => strategies.on_ws_event(msg).await,
                     Err(e) => {
-                        error!("rx_trade err: {:?}, reconnecting...", e);
-                        rx_trade =
-                            subscribe_if(event_mask, EventMask::TRADE, || find_trade(channels));
-                    },
-                };
-            },
-            msg = recv_or_pending(&mut rx_lob) => {
-                match msg {
-                    Ok(msg) => strategies.on_lob(msg).await,
-                    Err(e) => {
-                        error!("rx_lob err: {:?}, reconnecting...", e);
-                        rx_lob = subscribe_if(event_mask, EventMask::LOB, || find_lob(channels));
-                    },
-                };
-            },
-            msg = recv_or_pending(&mut rx_lob_mbo) => {
-                match msg {
-                    Ok(msg) => strategies.on_lob_mbo(msg).await,
-                    Err(e) => {
-                        error!("rx_lob_mbo err: {:?}, reconnecting...", e);
-                        rx_lob_mbo =
-                            subscribe_if(event_mask, EventMask::LOB_MBO, || find_lob_mbo(channels));
-                    },
-                };
-            },
-            msg = recv_or_pending(&mut rx_candle) => {
-                match msg {
-                    Ok(msg) => strategies.on_candle(msg).await,
-                    Err(e) => {
-                        error!("rx_candle err: {:?}, reconnecting...", e);
-                        rx_candle =
-                            subscribe_if(event_mask, EventMask::CANDLE, || find_candle(channels));
+                        error!("rx_ws_event err: {:?}, reconnecting...", e);
+                        rx_ws_event = subscribe_if(event_mask, EventMask::WS_EVENT, || {
+                            find_ws_event(channels)
+                        });
                     },
                 };
             },
@@ -375,28 +349,6 @@ pub(crate) async fn strategy_handler_loop<S>(
                     },
                 };
             },
-            msg = recv_or_pending(&mut rx_inst_intent) => {
-                match msg {
-                    Ok(msg) => strategies.on_inst_intent(msg).await,
-                    Err(e) => {
-                        error!("rx_inst_intent err: {:?}, reconnecting...", e);
-                        rx_inst_intent = subscribe_if(event_mask, EventMask::INST_INTENT, || {
-                            find_inst_intent(channels)
-                        });
-                    },
-                };
-            },
-             msg = recv_or_pending(&mut rx_preds) => {
-                match msg {
-                    Ok(msg) => strategies.on_preds(msg).await,
-                    Err(e) => {
-                        error!("rx_preds err: {:?}, reconnecting...", e);
-                        rx_preds = subscribe_if(event_mask, EventMask::MODEL_PREDS, || {
-                            find_model_preds(channels)
-                        });
-                    },
-                };
-            },
             msg = recv_or_pending(&mut rx_schedule) => {
                 match msg {
                     Ok(msg) => strategies.on_schedule(msg).await,
@@ -419,14 +371,64 @@ pub(crate) async fn strategy_handler_loop<S>(
                     },
                 };
             },
-            msg = recv_or_pending(&mut rx_ws_event) => {
+            msg = recv_or_pending(&mut rx_inst_intent) => {
                 match msg {
-                    Ok(msg) => strategies.on_ws_event(msg).await,
+                    Ok(msg) => strategies.on_inst_intent(msg).await,
                     Err(e) => {
-                        error!("rx_ws_event err: {:?}, reconnecting...", e);
-                        rx_ws_event = subscribe_if(event_mask, EventMask::WS_EVENT, || {
-                            find_ws_event(channels)
+                        error!("rx_inst_intent err: {:?}, reconnecting...", e);
+                        rx_inst_intent = subscribe_if(event_mask, EventMask::INST_INTENT, || {
+                            find_inst_intent(channels)
                         });
+                    },
+                };
+            },
+            msg = recv_or_pending(&mut rx_preds) => {
+                match msg {
+                    Ok(msg) => strategies.on_preds(msg).await,
+                    Err(e) => {
+                        error!("rx_preds err: {:?}, reconnecting...", e);
+                        rx_preds = subscribe_if(event_mask, EventMask::MODEL_PREDS, || {
+                            find_model_preds(channels)
+                        });
+                    },
+                };
+            },
+            msg = recv_or_pending(&mut rx_trade) => {
+                match msg {
+                    Ok(msg) => strategies.on_trade(msg).await,
+                    Err(e) => {
+                        error!("rx_trade err: {:?}, reconnecting...", e);
+                        rx_trade =
+                            subscribe_if(event_mask, EventMask::TRADE, || find_trade(channels));
+                    },
+                };
+            },
+            msg = recv_or_pending(&mut rx_lob) => {
+                match msg {
+                    Ok(msg) => strategies.on_lob(msg).await,
+                    Err(e) => {
+                        error!("rx_lob err: {:?}, reconnecting...", e);
+                        rx_lob = subscribe_if(event_mask, EventMask::LOB, || find_lob(channels));
+                    },
+                };
+            },
+            msg = recv_or_pending(&mut rx_lob_mbo) => {
+                match msg {
+                    Ok(msg) => strategies.on_lob_mbo(msg).await,
+                    Err(e) => {
+                        error!("rx_lob_mbo err: {:?}, reconnecting...", e);
+                        rx_lob_mbo =
+                            subscribe_if(event_mask, EventMask::LOB_MBO, || find_lob_mbo(channels));
+                    },
+                };
+            },
+            msg = recv_or_pending(&mut rx_candle) => {
+                match msg {
+                    Ok(msg) => strategies.on_candle(msg).await,
+                    Err(e) => {
+                        error!("rx_candle err: {:?}, reconnecting...", e);
+                        rx_candle =
+                            subscribe_if(event_mask, EventMask::CANDLE, || find_candle(channels));
                     },
                 };
             },


### PR DESCRIPTION
## Summary

Reorder the `biased` strategy-handler selector so lifecycle and private-account events are serviced before execution/control work, strategy outputs, and public market data:

```text
WS_EVENT
→ ACC_ORDER
→ ACC_BAL_POS
→ ACC_POS
→ ORDER_EXECUTION
→ SCHEDULE
→ ALT_EVENT
→ INST_INTENT
→ MODEL_PREDS
→ TRADE
→ LOB
→ LOB_MBO
→ CANDLE
```

This PR only moves complete `tokio::select!` branches. It does not change:

- `EventMask` subscription behavior;
- channel capacities;
- callbacks or message payloads;
- `Lagged`/re-subscription recovery behavior.

## Motivation

`tokio::select! { biased; }` polls ready branches from top to bottom. With public market data first, continuously-ready Trade traffic can delay private account and order-related events after the runtime crosses saturation.

The priority applies per handler and only among its active subscriptions. An event excluded by `EventMask` has a `None` receiver and resolves through `future::pending()`.

This is a priority-policy change, not a claim that every metric becomes faster. It deliberately protects correctness-sensitive private state under overload at the cost of lower-priority public-data freshness.

## Validation

```text
cargo fmt --check
cargo test --all-targets

21 passed; 0 failed
```

The diff contains one production file. All 13 receiver/callback/EventMask/sender mappings were checked for omissions and duplicates.

## Benchmark methodology

Unless otherwise stated:

- real `extrema_infra` `strategy_handler_loop`, not a duplicated selector;
- five exchange labels;
- 100 Signal handlers, one Orchestrator, five AccountReplica handlers, and five OrderExecutor handlers;
- 111 handler tasks and 346 producer tasks;
- exact role `EventMask`;
- all 13 streams start together;
- latency is monotonic time from immediately before `broadcast::send` to callback entry, before the current callback's synthetic work;
- fixed-count input; expected, delivered, missing, input-end backlog, and drain are tracked separately;
- a percentile for an event with missing callbacks is delivered-only and has survivorship bias.

The maximally optimized Release binary used for the worker experiments was built with `opt-level=3`, fat LTO, `codegen-units=1`, and `target-cpu=native`.

```text
Machine:       Apple M5 Pro, 15 logical CPUs, 48 GiB
Infra commit:  7280b4b2e3744cf30f1098272955d1f361e3df2b
Binary SHA256: 2aac7aad0caec31e5f2bfbecd5d7317443a1fea3541724e98308c270defca7fa
```

### Selector scan cost

Criterion configuration: 200 samples, five-second warm-up, 15-second measurement, 99% confidence intervals. One target branch is ready; the nine branches before target position 10 are either masked-out `None` or subscribed-but-empty broadcast receivers.

| Case | Target position 1 | Target position 10 | Added cost across nine branches |
|---|---:|---:|---:|
| masked-out `None` | 15.808ns | 24.527ns | 8.719ns, approximately 0.97ns/branch |
| active-empty receiver | 15.515ns | 148.650ns | 133.135ns, approximately 14.79ns/branch |

This is selector scanning only. It does not measure fairness, backlog, or starvation.

## Branch-order A/B

Two recursively compared source snapshots differed only in the complete Trade branch position:

```text
Trade after control SHA256: 5232f380e069ddf8e3692cd8a3a0d5aed3a43c0b232dc103305407fa12241ecf
Trade first SHA256:         89ede93b62bd243425f94e9e0ccf6dc4b12b74d2407e2e26328e6609e5a57eed
```

At 10k Trade messages/s, no synthetic callback work, three five-second runs per variant, all callbacks were delivered:

| p95 latency | Trade after control | Trade first |
|---|---:|---:|
| Signal Trade | 987.135µs | 253.567µs |
| Signal AccOrder | 1,039.871µs | 301.311µs |
| Orchestrator AccOrder | 1,009.663µs | 297.471µs |
| Orchestrator Intent | 1,000.447µs | 268.031µs |
| Order end-to-end | 1,239.039µs | 326.143µs |

Below saturation, Trade-first is faster because the high-frequency path avoids polling preceding branches, reducing total runtime pressure.

At the same nominal 10k/s with 20µs of relevant Trade callback work, the runtime crossed saturation:

| p95 latency | Trade after control | Trade first |
|---|---:|---:|
| Signal Trade | 271.843ms | 105.972ms |
| Signal AccOrder | 20.054ms | 1,799.356ms |
| Orchestrator AccOrder | 18.416ms | 2,512.388ms |
| Orchestrator AccPos | 18.317ms | 2,923.430ms |
| Orchestrator Intent | 18.416ms | 2,917.138ms |

Actual offered Trade rates were 9.18k/s and 9.37k/s respectively. No callback was missing after drain. This is the priority trade-off: Trade-first optimizes the hot public path but removes a private/control latency bound during saturation.

## Proposed full order: all 13 streams

Rates for the full-topology test:

| Event | Messages/s | Receivers |
|---|---:|---:|
| WS_EVENT | 5 | 1 |
| ACC_ORDER | 250 | 6 |
| ACC_BAL_POS | 50 | 6 |
| ACC_POS | 250 | 6 |
| ORDER_EXECUTION | 100 | 5 |
| SCHEDULE | 10 | 1 |
| ALT_EVENT | 5 | 1 |
| INST_INTENT | 100 | 1 |
| MODEL_PREDS | 1,000 | 1 |
| TRADE | 10,000 | 101 |
| LOB | 5,000 | 101 |
| LOB_MBO | 2,000 | 101 |
| CANDLE | 5 | 101 |

With 15 Tokio workers and 20µs of relevant callback work, three runs completed every callback with zero loss. Median total completion time was 4.990026s.

With four workers, the same workload intentionally requests more CPU than is available. Three-run medians:

| Event | p95 | Final missing |
|---|---:|---:|
| WS_EVENT | 21.135ms | 0 / 25 |
| ACC_ORDER | 13.910ms | 0 / 7,500 |
| ACC_BAL_POS | 14.189ms | 0 / 1,500 |
| ACC_POS | 13.894ms | 0 / 7,500 |
| ORDER_EXECUTION | 13.418ms | 0 / 2,500 |
| SCHEDULE | 21.840ms | 0 / 50 |
| ALT_EVENT | 21.709ms | 0 / 25 |
| INST_INTENT | 20.873ms | 0 / 500 |
| MODEL_PREDS | 21.135ms | 0 / 5,000 |
| TRADE | 580.911ms | 16,549 / 5,050,000 |
| LOB | 2,382.365ms* | 2,408,344 / 2,525,000 |
| LOB_MBO | 5,335.155ms | 0 / 1,010,000 |
| CANDLE | 6,358.565ms | 0 / 2,525 |

\* Delivered-only percentile. LOB lost approximately 95.38% of callbacks.

The result demonstrates both sides of the policy: high-priority lifecycle/private/order streams remain serviceable, while strict bias does not guarantee lower-priority market-data liveness during sustained overload.

## Worker-count rate sweep

This characterization uses the proposed order, empty payloads, 0µs callback work, fixed five-second input, five paired runs per worker/load group, deterministic randomized load order, and alternating `4→8` / `8→4` execution order. All input spans were 4.994–5.001s, so the producer did not silently reduce the offered rate.

| Workers | Load | Fan-out weighted callbacks/s | Complete | Median missing | Median drain | Average process CPU cores | System CPU share |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 4 | 1× | 1.724M | 5/5 | 0 | 240µs | 1.52 | 15.5% |
| 4 | 3× | 5.171M | 5/5 | 0 | 532µs | 2.89 | 17.6% |
| 4 | 4× | 6.893M | 5/5 | 0 | 278.472ms | 3.30 | 17.6% |
| 4 | 5× | 8.619M | 5/5 | 0 | 1.690s | 3.29 | 18.6% |
| 4 | 6× | 10.344M | 0/5 | 49,610 | incomplete | 2.04 | 16.1% |
| 8 | 1× | 1.724M | 5/5 | 0 | 357µs | 3.12 | 52.7% |
| 8 | 3× | 5.172M | 5/5 | 0 | 466.587ms | 5.52 | 53.1% |
| 8 | 4× | 6.897M | 0/5 | 17,148 | incomplete | 3.08 | 52.3% |
| 8 | 5× | 8.618M | 0/5 | 1,684,709 | incomplete | 3.56 | 51.3% |
| 8 | 6× | 10.345M | 0/5 | 4,317,187 | incomplete | 4.04 | 49.6% |

Only LOB was missing:

| Workers | Load | LOB missing median | Five-run range |
|---:|---:|---:|---:|
| 4 | 6× | 0.327% | 0.217%–2.501% |
| 8 | 4× | 0.170% | 0.162%–0.325% |
| 8 | 5× | 13.344% | 11.030%–16.212% |
| 8 | 6× | 28.496% | 27.951%–30.510% |

In this zero-work, 101-way fan-out case, more workers increase cross-thread scheduling and shared-recorder contention. Eight workers showed approximately 2–3 times as many involuntary context switches and substantially more system CPU.

The benchmark recorder itself uses shared atomic counters, so this result is an end-to-end characterization of the current harness and infra together; it must not be generalized to CPU-heavy strategy callbacks.

## Callback-work sweep

To test that limitation, base 1× rates were held fixed while relevant callbacks performed 2/5/10/20µs busy-spin work. There are approximately 359,425 relevant callbacks/s:

| Work | Approximate requested callback CPU |
|---:|---:|
| 2µs | 0.72 cores |
| 5µs | 1.80 cores |
| 10µs | 3.59 cores |
| 20µs | 7.19 cores |

Five paired runs per group:

| Work | Workers | Complete | Median missing | Drain | Average process CPU cores |
|---:|---:|---:|---:|---:|---:|
| 2µs | 4 | 5/5 | 0 | 488µs | 1.86 |
| 2µs | 8 | 5/5 | 0 | 164µs | 3.42 |
| 5µs | 4 | 5/5 | 0 | 326µs | 2.32 |
| 5µs | 8 | 5/5 | 0 | 489µs | 3.80 |
| 10µs | 4 | 5/5 | 0 | 712µs | 3.77 |
| 10µs | 8 | 5/5 | 0 | 613µs | 4.78 |
| 20µs | 4 | 0/5 | 2,408,639 | incomplete | 2.00* |
| 20µs | 8 | 5/5 | 0 | 126.884ms | 7.33 |

\* Includes the post-input completion timeout and is not the average CPU during the five-second input interval.

Selected p95 medians:

| Work | Workers | AccOrder | OrderExec | Trade | LOB | LOB_MBO | Candle | LOB missing |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 2µs | 4 | 798µs | 750µs | 802µs | 834µs | 859µs | 1.057ms | 0% |
| 2µs | 8 | 711µs | 655µs | 934µs | 988µs | 1.053ms | 1.210ms | 0% |
| 5µs | 4 | 988µs | 1.030ms | 1.020ms | 1.059ms | 1.089ms | 1.253ms | 0% |
| 5µs | 8 | 740µs | 759µs | 946µs | 1.005ms | 1.067ms | 1.150ms | 0% |
| 10µs | 4 | 3.631ms | 3.879ms | 3.912ms | 4.227ms | 4.694ms | 4.985ms | 0% |
| 10µs | 8 | 833µs | 841µs | 1.049ms | 1.127ms | 1.189ms | 1.356ms | 0% |
| 20µs | 4 | 13.910ms | 13.156ms | 591.397ms | 2.819s* | 5.352s | 6.245s | 95.064% |
| 20µs | 8 | 3.303ms | 2.073ms | 2.341ms | 2.599ms | 2.705ms | 3.600ms | 0% |

\* Delivered-only LOB percentile.

This shows the crossover clearly:

- for pure dispatch or light callbacks, four workers are more efficient in this topology;
- near four cores of callback work, eight available logical CPUs reduce latency;
- at approximately 7.2 cores of callback work, four workers cannot keep up while eight workers can.

This does **not** mean an actual 4-vCPU machine should run eight workers to obtain eight-core capacity. The eight-worker 20µs group consumed approximately 7.33 CPU cores on a 15-core host. A real 4C8G instance cannot reproduce that by oversubscribing Tokio threads; it requires more vCPUs, less callback work/fan-out, or separated lanes.

## Limitations and known trade-offs

- Synthetic payloads are empty; this does not test an 8GB memory ceiling.
- Synthetic busy-spin is a controllable CPU model, not real strategy math.
- Producer and handler tasks share the Tokio runtime. Fixed counts keep offered work exact; input span is reported to detect stretching.
- The fifth exchange is a synthetic topology label; no exchange network clients are created.
- The benchmark excludes websocket parsing, network, REST/WS order I/O, and exchange latency.
- Strict `biased` priority applies only when multiple branches are ready; it cannot preempt a callback already executing.
- Sustained high-priority readiness can starve lower branches.
- Existing `Lagged` handling re-subscribes at the channel tail and can skip messages still retained in the broadcast ring. This behavior is unchanged by this PR.

