### PR TITLE
fix(exchange): align API contracts for v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.2.10"
+version = "0.3.0"
 edition = "2024"
 
 readme = "README.md"
@@ -25,7 +25,7 @@ path = "src/lib.rs"
 [dependencies]
 # Async runtime
 tokio = { version = "1.53.1", features = ["full"] }
-tokio-stream = { version = "0.1.18", features = ["sync"] }
+tokio-stream = { version = "0.1.19", features = ["sync"] }
 futures = "0.3.33"
 futures-util = "0.3.33"
 
@@ -48,7 +48,7 @@ secp256k1 = { version = "0.31.1", features = ["recovery"] }
 data-encoding = "2.11.0"
 
 # TLS
-rustls = { version = "0.23.40", features = ["aws-lc-rs"] }
+rustls = { version = "0.23.43", features = ["aws-lc-rs"] }
 
 # IPC / Model inference / Data processing
 zeromq = { version = "0.6.0", optional = true }

--- a/src/arch/infra_core/env_mediator.rs
+++ b/src/arch/infra_core/env_mediator.rs
@@ -104,7 +104,6 @@ where
                     cmd_rx,
                     event_tx,
                     ws_info: ws_task_info.clone(),
-                    filter_channels: ws_task_info.filter_channels,
                     task_id,
                 };
 

--- a/src/arch/market_assets/api_general.rs
+++ b/src/arch/market_assets/api_general.rs
@@ -110,6 +110,16 @@ pub fn ts_to_micros(ts: u64) -> u64 {
     }
 }
 
+#[cfg(any(feature = "binance", feature = "okx", test))]
+pub(crate) fn micros_to_millis(timestamp_us: u64) -> u64 {
+    timestamp_us / 1_000
+}
+
+#[cfg(any(feature = "gate", test))]
+pub(crate) fn micros_to_seconds(timestamp_us: u64) -> u64 {
+    timestamp_us / 1_000_000
+}
+
 pub fn candle_interval_millis(interval: &CandleParam) -> InfraResult<u64> {
     match interval {
         CandleParam::OneSecond => Ok(1_000),
@@ -313,6 +323,14 @@ mod tests {
             candle_interval_millis(&CandleParam::OneWeek).unwrap(),
             7 * 24 * 60 * 60_000
         );
+    }
+
+    #[test]
+    fn converts_microsecond_timestamps_to_exchange_precision() {
+        let timestamp_us = 1_783_580_000_123_456;
+
+        assert_eq!(micros_to_millis(timestamp_us), 1_783_580_000_123);
+        assert_eq!(micros_to_seconds(timestamp_us), 1_783_580_000);
     }
 
     #[test]

--- a/src/arch/market_assets/exchange/binance/binance_spot_cli.rs
+++ b/src/arch/market_assets/exchange/binance/binance_spot_cli.rs
@@ -114,12 +114,12 @@ impl LobPrivateRest for BinanceSpotCli {
     async fn get_order_history(
         &self,
         inst: &str,
-        start_time: Option<u64>,
-        end_time: Option<u64>,
+        start_time_us: Option<u64>,
+        end_time_us: Option<u64>,
         limit: Option<u32>,
         order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
-        self._get_order_history(inst, start_time, end_time, limit, order_id)
+        self._get_order_history(inst, start_time_us, end_time_us, limit, order_id)
             .await
     }
 }
@@ -725,8 +725,8 @@ impl BinanceSpotCli {
     async fn _get_order_history(
         &self,
         inst: &str,
-        start_time: Option<u64>,
-        end_time: Option<u64>,
+        start_time_us: Option<u64>,
+        end_time_us: Option<u64>,
         limit: Option<u32>,
         order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
@@ -735,11 +735,11 @@ impl BinanceSpotCli {
             query_string.push_str(&format!("&orderId={order_id}"));
             BINANCE_SPOT_PLACE_ORDER
         } else {
-            if let Some(start_time) = start_time {
-                query_string.push_str(&format!("&startTime={start_time}"));
+            if let Some(start_time_us) = start_time_us {
+                query_string.push_str(&format!("&startTime={}", micros_to_millis(start_time_us)));
             }
-            if let Some(end_time) = end_time {
-                query_string.push_str(&format!("&endTime={end_time}"));
+            if let Some(end_time_us) = end_time_us {
+                query_string.push_str(&format!("&endTime={}", micros_to_millis(end_time_us)));
             }
             if let Some(limit) = limit {
                 query_string.push_str(&format!("&limit={limit}"));

--- a/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
+++ b/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
@@ -143,12 +143,12 @@ impl LobPrivateRest for BinanceUmCli {
     async fn get_order_history(
         &self,
         inst: &str,
-        start_time: Option<u64>,
-        end_time: Option<u64>,
+        start_time_us: Option<u64>,
+        end_time_us: Option<u64>,
         limit: Option<u32>,
         order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
-        self._get_order_history(inst, start_time, end_time, limit, order_id)
+        self._get_order_history(inst, start_time_us, end_time_us, limit, order_id)
             .await
     }
 }
@@ -921,8 +921,8 @@ impl BinanceUmCli {
     async fn _get_order_history(
         &self,
         inst: &str,
-        start_time: Option<u64>,
-        end_time: Option<u64>,
+        start_time_us: Option<u64>,
+        end_time_us: Option<u64>,
         limit: Option<u32>,
         order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
@@ -932,12 +932,12 @@ impl BinanceUmCli {
             query_string.push_str(&format!("&orderId={}", oid));
         }
 
-        if let Some(start) = start_time {
-            query_string.push_str(&format!("&startTime={}", start));
+        if let Some(start_time_us) = start_time_us {
+            query_string.push_str(&format!("&startTime={}", micros_to_millis(start_time_us)));
         }
 
-        if let Some(end) = end_time {
-            query_string.push_str(&format!("&endTime={}", end));
+        if let Some(end_time_us) = end_time_us {
+            query_string.push_str(&format!("&endTime={}", micros_to_millis(end_time_us)));
         }
 
         if let Some(l) = limit {

--- a/src/arch/market_assets/exchange/binance/config_assets.rs
+++ b/src/arch/market_assets/exchange/binance/config_assets.rs
@@ -52,6 +52,6 @@ pub const BINANCE_CM_FUTURES_WS_MKT: &str = "wss://dstream.binance.com/market/ws
 pub const BINANCE_CM_FUTURES_BASE_URL: &str = "https://dapi.binance.com";
 pub const BINANCE_CM_FUTURES_EXCHANGE_INFO: &str = "/dapi/v1/exchangeInfo";
 
-pub const BINANCE_CM_FUTURES_ACCOUNT_INFO: &str = "/dapi/v1/balance";
-pub const BINANCE_CM_FUTURES_BALANCE_INFO: &str = "/dapi/v1/account";
+pub const BINANCE_CM_FUTURES_ACCOUNT_INFO: &str = "/dapi/v1/account";
+pub const BINANCE_CM_FUTURES_BALANCE_INFO: &str = "/dapi/v1/balance";
 pub const BINANCE_CM_FUTURES_LISTEN_KEY: &str = "/dapi/v1/listenKey";

--- a/src/arch/market_assets/exchange/binance/schemas/um_futures_rest/account_position_risk.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/um_futures_rest/account_position_risk.rs
@@ -26,12 +26,12 @@ pub struct RestAccountPosRiskBinanceUM {
 
 impl From<RestAccountPosRiskBinanceUM> for PositionData {
     fn from(d: RestAccountPosRiskBinanceUM) -> Self {
-        let size = d.positionAmt.parse().unwrap_or_default();
-        let avg_price = d.entryPrice.parse().unwrap_or_default();
-        let mark_price = d.markPrice.parse().unwrap_or_default();
-        let margin = d.positionInitialMargin.parse().unwrap_or_default();
+        let size = d.positionAmt.parse::<f64>().unwrap_or_default();
+        let avg_price = d.entryPrice.parse::<f64>().unwrap_or_default();
+        let mark_price = d.markPrice.parse::<f64>().unwrap_or_default();
+        let margin = d.positionInitialMargin.parse::<f64>().unwrap_or_default();
         let leverage = if margin != 0.0 {
-            size * avg_price / margin
+            (size * avg_price).abs() / margin.abs()
         } else {
             0.0
         };
@@ -56,5 +56,44 @@ impl From<RestAccountPosRiskBinanceUM> for PositionData {
             margin,
             leverage,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn position(position_amount: &str, margin: &str) -> RestAccountPosRiskBinanceUM {
+        RestAccountPosRiskBinanceUM {
+            symbol: "BTCUSDT".into(),
+            positionSide: "BOTH".into(),
+            positionAmt: position_amount.into(),
+            entryPrice: "50000".into(),
+            markPrice: "51000".into(),
+            unRealizedProfit: "0".into(),
+            marginAsset: "USDT".into(),
+            isolatedMargin: "0".into(),
+            positionInitialMargin: margin.into(),
+            initialMargin: margin.into(),
+            maintMargin: "0".into(),
+            updateTime: 1_700_000_000_000,
+        }
+    }
+
+    #[test]
+    fn derives_non_negative_leverage_from_absolute_notional() {
+        let long = PositionData::from(position("0.2", "1000"));
+        let short = PositionData::from(position("-0.2", "1000"));
+
+        assert_eq!(long.leverage, 10.0);
+        assert_eq!(short.size, -0.2);
+        assert_eq!(short.leverage, 10.0);
+    }
+
+    #[test]
+    fn derives_zero_leverage_when_margin_is_zero() {
+        let position = PositionData::from(position("-0.2", "0"));
+
+        assert_eq!(position.leverage, 0.0);
     }
 }

--- a/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
@@ -11,7 +11,8 @@ use crate::arch::{
             utils_data::{FundingRateData, FundingRateInfo, InstrumentInfo},
         },
         api_general::{
-            OrderParams, RequestMethod, get_seconds_timestamp, parse_json_response, value_to_f64,
+            OrderParams, RequestMethod, get_seconds_timestamp, micros_to_seconds,
+            parse_json_response, value_to_f64,
         },
         base_data::{InstrumentType, MarginMode, OrderSide, OrderType, SUBSCRIBE_LOWER},
     },
@@ -136,12 +137,12 @@ impl LobPrivateRest for GateFuturesCli {
     async fn get_order_history(
         &self,
         inst: &str,
-        start_time: Option<u64>,
-        end_time: Option<u64>,
+        start_time_us: Option<u64>,
+        end_time_us: Option<u64>,
         limit: Option<u32>,
         order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
-        self._get_order_history(inst, start_time, end_time, limit, order_id)
+        self._get_order_history(inst, start_time_us, end_time_us, limit, order_id)
             .await
     }
 }
@@ -859,8 +860,8 @@ impl GateFuturesCli {
     async fn _get_order_history(
         &self,
         inst: &str,
-        start_time: Option<u64>,
-        end_time: Option<u64>,
+        start_time_us: Option<u64>,
+        end_time_us: Option<u64>,
         limit: Option<u32>,
         order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
@@ -876,11 +877,11 @@ impl GateFuturesCli {
             )
         } else {
             let mut query = format!("status=finished&contract={}", contract);
-            if let Some(start_time) = start_time {
-                query.push_str(&format!("&from={}", start_time));
+            if let Some(start_time_us) = start_time_us {
+                query.push_str(&format!("&from={}", micros_to_seconds(start_time_us)));
             }
-            if let Some(end_time) = end_time {
-                query.push_str(&format!("&to={}", end_time));
+            if let Some(end_time_us) = end_time_us {
+                query.push_str(&format!("&to={}", micros_to_seconds(end_time_us)));
             }
             if let Some(limit) = limit {
                 query.push_str(&format!("&limit={}", limit));

--- a/src/arch/market_assets/exchange/gate/gate_spot_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_spot_cli.rs
@@ -10,7 +10,10 @@ use crate::arch::{
             price_data::TickerData,
             utils_data::InstrumentInfo,
         },
-        api_general::{OrderParams, RequestMethod, get_seconds_timestamp, parse_json_response},
+        api_general::{
+            OrderParams, RequestMethod, get_seconds_timestamp, micros_to_seconds,
+            parse_json_response,
+        },
         base_data::{InstrumentType, OrderSide, OrderType, SUBSCRIBE_LOWER, TimeInForce},
         exchange::gate::{
             config_assets::*,
@@ -128,12 +131,12 @@ impl LobPrivateRest for GateSpotCli {
     async fn get_order_history(
         &self,
         inst: &str,
-        start_time: Option<u64>,
-        end_time: Option<u64>,
+        start_time_us: Option<u64>,
+        end_time_us: Option<u64>,
         limit: Option<u32>,
         order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
-        self._get_order_history(inst, start_time, end_time, limit, order_id)
+        self._get_order_history(inst, start_time_us, end_time_us, limit, order_id)
             .await
     }
 }
@@ -616,8 +619,8 @@ impl GateSpotCli {
     async fn _get_order_history(
         &self,
         inst: &str,
-        start_time: Option<u64>,
-        end_time: Option<u64>,
+        start_time_us: Option<u64>,
+        end_time_us: Option<u64>,
         limit: Option<u32>,
         order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
@@ -629,11 +632,11 @@ impl GateSpotCli {
             )
         } else {
             let mut query = format!("currency_pair={currency_pair}&status=finished");
-            if let Some(start_time) = start_time {
-                query.push_str(&format!("&from={}", timestamp_to_seconds(start_time)));
+            if let Some(start_time_us) = start_time_us {
+                query.push_str(&format!("&from={}", micros_to_seconds(start_time_us)));
             }
-            if let Some(end_time) = end_time {
-                query.push_str(&format!("&to={}", timestamp_to_seconds(end_time)));
+            if let Some(end_time_us) = end_time_us {
+                query.push_str(&format!("&to={}", micros_to_seconds(end_time_us)));
             }
             if let Some(limit) = limit {
                 query.push_str(&format!("&limit={limit}"));
@@ -814,17 +817,8 @@ impl GateSpotCli {
     }
 }
 
-fn timestamp_to_seconds(timestamp: u64) -> u64 {
-    match timestamp {
-        0..=9_999_999_999 => timestamp,
-        10_000_000_000..=9_999_999_999_999 => timestamp / 1_000,
-        _ => timestamp / 1_000_000,
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::timestamp_to_seconds;
     use crate::arch::{
         market_assets::exchange::gate::{
             config_assets::GATE_WS_BASE_URL, gate_spot_cli::GateSpotCli,
@@ -844,12 +838,5 @@ mod tests {
 
         assert_eq!(target.url, GATE_WS_BASE_URL);
         assert!(target.headers.is_empty());
-    }
-
-    #[test]
-    fn gate_spot_history_converts_millisecond_and_microsecond_ranges_to_seconds() {
-        assert_eq!(timestamp_to_seconds(1_783_580_000), 1_783_580_000);
-        assert_eq!(timestamp_to_seconds(1_783_580_000_123), 1_783_580_000);
-        assert_eq!(timestamp_to_seconds(1_783_580_000_123_456), 1_783_580_000);
     }
 }

--- a/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
@@ -148,12 +148,12 @@ impl LobPrivateRest for HyperliquidCli {
     async fn get_order_history(
         &self,
         inst: &str,
-        start_time: Option<u64>,
-        end_time: Option<u64>,
+        start_time_us: Option<u64>,
+        end_time_us: Option<u64>,
         limit: Option<u32>,
         order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
-        self._get_order_history(inst, start_time, end_time, limit, order_id)
+        self._get_order_history(inst, start_time_us, end_time_us, limit, order_id)
             .await
     }
 }
@@ -795,12 +795,12 @@ impl HyperliquidCli {
     async fn _get_order_history(
         &self,
         inst: &str,
-        start_time: Option<u64>,
-        end_time: Option<u64>,
+        start_time_us: Option<u64>,
+        end_time_us: Option<u64>,
         limit: Option<u32>,
         order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
-        validate_hyperliquid_order_history_range(start_time, end_time)?;
+        validate_hyperliquid_order_history_range(start_time_us, end_time_us)?;
 
         let user = self._owner_address()?;
         let body = match order_id {
@@ -839,8 +839,8 @@ impl HyperliquidCli {
         finalize_hyperliquid_order_history(
             data,
             &normalized_inst,
-            start_time,
-            end_time,
+            start_time_us,
+            end_time_us,
             limit,
             order_id.is_none(),
         )

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest/order_status.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest/order_status.rs
@@ -99,16 +99,16 @@ fn parse_order_status(status: &str, filled_size: f64) -> OrderStatus {
 }
 
 pub fn validate_hyperliquid_order_history_range(
-    start_time_ms: Option<u64>,
-    end_time_ms: Option<u64>,
+    start_time_us: Option<u64>,
+    end_time_us: Option<u64>,
 ) -> InfraResult<()> {
-    if let Some(end_time_ms) = end_time_ms
-        && let Some(start_time_ms) = start_time_ms
-        && end_time_ms < start_time_ms
+    if let Some(end_time_us) = end_time_us
+        && let Some(start_time_us) = start_time_us
+        && end_time_us < start_time_us
     {
         return Err(InfraError::ApiCliError(format!(
-            "Hyperliquid order history end_time_ms {} is earlier than start_time_ms {}",
-            end_time_ms, start_time_ms
+            "Hyperliquid order history end_time_us {} is earlier than start_time_us {}",
+            end_time_us, start_time_us
         )));
     }
 
@@ -118,20 +118,20 @@ pub fn validate_hyperliquid_order_history_range(
 pub fn finalize_hyperliquid_order_history(
     data: Vec<OrderDetailData>,
     normalized_inst: &str,
-    start_time_ms: Option<u64>,
-    end_time_ms: Option<u64>,
+    start_time_us: Option<u64>,
+    end_time_us: Option<u64>,
     limit: Option<u32>,
     require_recent_window_coverage: bool,
 ) -> InfraResult<Vec<OrderDetailData>> {
     if require_recent_window_coverage {
-        ensure_recent_orders_cover_start(&data, start_time_ms)?;
+        ensure_recent_orders_cover_start(&data, start_time_us)?;
     }
 
     Ok(filter_order_history(
         data,
         normalized_inst,
-        start_time_ms,
-        end_time_ms,
+        start_time_us,
+        end_time_us,
         limit,
     ))
 }
@@ -140,20 +140,13 @@ fn order_history_time(order: &OrderDetailData) -> u64 {
     order.update_time.max(order.timestamp)
 }
 
-fn millis_to_micros(timestamp_ms: u64) -> u64 {
-    timestamp_ms.saturating_mul(1_000)
-}
-
 fn filter_order_history(
     mut data: Vec<OrderDetailData>,
     normalized_inst: &str,
-    start_time_ms: Option<u64>,
-    end_time_ms: Option<u64>,
+    start_time_us: Option<u64>,
+    end_time_us: Option<u64>,
     limit: Option<u32>,
 ) -> Vec<OrderDetailData> {
-    let start_time_us = start_time_ms.map(millis_to_micros);
-    let end_time_us = end_time_ms.map(millis_to_micros);
-
     data.retain(|order| {
         if order.inst != normalized_inst {
             return false;
@@ -174,9 +167,9 @@ fn filter_order_history(
 
 fn ensure_recent_orders_cover_start(
     data: &[OrderDetailData],
-    start_time_ms: Option<u64>,
+    start_time_us: Option<u64>,
 ) -> InfraResult<()> {
-    let Some(start_time_ms) = start_time_ms else {
+    let Some(start_time_us) = start_time_us else {
         return Ok(());
     };
 
@@ -188,13 +181,10 @@ fn ensure_recent_orders_cover_start(
         return Ok(());
     };
 
-    let start_time_us = millis_to_micros(start_time_ms);
     if earliest_returned_us > start_time_us {
         return Err(InfraError::ApiCliError(format!(
-            "Hyperliquid historicalOrders only returns the most recent {} orders; requested startTime={}ms is older than earliest returned order update_time={}ms",
-            HYPERLIQUID_HISTORICAL_ORDERS_RECENT_LIMIT,
-            start_time_ms,
-            earliest_returned_us / 1_000
+            "Hyperliquid historicalOrders only returns the most recent {} orders; requested start_time_us={} is older than earliest returned order update_time_us={}",
+            HYPERLIQUID_HISTORICAL_ORDERS_RECENT_LIMIT, start_time_us, earliest_returned_us
         )));
     }
 
@@ -239,8 +229,8 @@ mod tests {
         let filtered = finalize_hyperliquid_order_history(
             data,
             "BTC_USDC_PERP",
-            Some(1_500),
-            Some(3_500),
+            Some(1_500_000),
+            Some(3_500_000),
             Some(2),
             true,
         )
@@ -264,7 +254,7 @@ mod tests {
         let err = finalize_hyperliquid_order_history(
             data,
             "BTC_USDC_PERP",
-            Some(1_000),
+            Some(1_000_000),
             None,
             None,
             true,

--- a/src/arch/market_assets/exchange/lob_clients.rs
+++ b/src/arch/market_assets/exchange/lob_clients.rs
@@ -244,34 +244,34 @@ impl LobPrivateRest for LobClients {
     async fn get_order_history(
         &self,
         inst: &str,
-        start_time: Option<u64>,
-        end_time: Option<u64>,
+        start_time_us: Option<u64>,
+        end_time_us: Option<u64>,
         limit: Option<u32>,
         order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
         match self {
             LobClients::Hyperliquid(c) => {
-                c.get_order_history(inst, start_time, end_time, limit, order_id)
+                c.get_order_history(inst, start_time_us, end_time_us, limit, order_id)
                     .await
             },
             LobClients::BinanceSpot(c) => {
-                c.get_order_history(inst, start_time, end_time, limit, order_id)
+                c.get_order_history(inst, start_time_us, end_time_us, limit, order_id)
                     .await
             },
             LobClients::BinanceUm(c) => {
-                c.get_order_history(inst, start_time, end_time, limit, order_id)
+                c.get_order_history(inst, start_time_us, end_time_us, limit, order_id)
                     .await
             },
             LobClients::GateFutures(c) => {
-                c.get_order_history(inst, start_time, end_time, limit, order_id)
+                c.get_order_history(inst, start_time_us, end_time_us, limit, order_id)
                     .await
             },
             LobClients::GateSpot(c) => {
-                c.get_order_history(inst, start_time, end_time, limit, order_id)
+                c.get_order_history(inst, start_time_us, end_time_us, limit, order_id)
                     .await
             },
             LobClients::Okx(c) => {
-                c.get_order_history(inst, start_time, end_time, limit, order_id)
+                c.get_order_history(inst, start_time_us, end_time_us, limit, order_id)
                     .await
             },
             _ => Err(InfraError::Unimplemented),

--- a/src/arch/market_assets/exchange/okx/okx_cli.rs
+++ b/src/arch/market_assets/exchange/okx/okx_cli.rs
@@ -157,12 +157,12 @@ impl LobPrivateRest for OkxCli {
     async fn get_order_history(
         &self,
         inst: &str,
-        start_time: Option<u64>,
-        end_time: Option<u64>,
+        start_time_us: Option<u64>,
+        end_time_us: Option<u64>,
         limit: Option<u32>,
         order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
-        self._get_order_history(inst, start_time, end_time, limit, order_id)
+        self._get_order_history(inst, start_time_us, end_time_us, limit, order_id)
             .await
     }
 }
@@ -1285,8 +1285,8 @@ impl OkxCli {
     async fn _get_order_history(
         &self,
         inst: &str,
-        start_time: Option<u64>,
-        end_time: Option<u64>,
+        start_time_us: Option<u64>,
+        end_time_us: Option<u64>,
         limit: Option<u32>,
         order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
@@ -1297,11 +1297,11 @@ impl OkxCli {
             OKX_TRADE_ORDER
         } else {
             query.push_str("&instType=SWAP");
-            if let Some(start_time) = start_time {
-                query.push_str(&format!("&begin={}", start_time));
+            if let Some(start_time_us) = start_time_us {
+                query.push_str(&format!("&begin={}", micros_to_millis(start_time_us)));
             }
-            if let Some(end_time) = end_time {
-                query.push_str(&format!("&end={}", end_time));
+            if let Some(end_time_us) = end_time_us {
+                query.push_str(&format!("&end={}", micros_to_millis(end_time_us)));
             }
             if let Some(limit) = limit {
                 query.push_str(&format!("&limit={}", limit));

--- a/src/arch/task_execution/ws_runner.rs
+++ b/src/arch/task_execution/ws_runner.rs
@@ -53,7 +53,6 @@ pub(crate) struct WsTaskRunner {
     pub cmd_rx: mpsc::Receiver<TaskCommand>,
     pub event_tx: broadcast::Sender<TaskEvent>,
     pub ws_info: Arc<WsTaskInfo>,
-    pub filter_channels: bool,
     pub task_id: u64,
 }
 
@@ -101,7 +100,7 @@ impl WsTaskRunner {
                         }));
                     },
                     Err(e) => {
-                        if self.filter_channels {
+                        if self.ws_info.filter_channels {
                             return false;
                         }
 
@@ -121,7 +120,7 @@ impl WsTaskRunner {
                         }));
                     },
                     Err(e) => {
-                        if self.filter_channels {
+                        if self.ws_info.filter_channels {
                             return false;
                         }
 

--- a/src/arch/traits/market_lob.rs
+++ b/src/arch/traits/market_lob.rs
@@ -129,11 +129,14 @@ pub trait LobPrivateRest: Send + Sync {
     }
 
     /// Fetches historical orders.
+    ///
+    /// `start_time_us` and `end_time_us` are Unix timestamps in microseconds.
+    /// Exchange adapters convert them to the precision required by the venue.
     fn get_order_history(
         &self,
         _inst: &str,
-        _start_time: Option<u64>,
-        _end_time: Option<u64>,
+        _start_time_us: Option<u64>,
+        _end_time_us: Option<u64>,
         _limit: Option<u32>,
         _order_id: Option<&str>,
     ) -> impl Future<Output = InfraResult<Vec<OrderDetailData>>> + Send {


### PR DESCRIPTION
## Summary

- define `LobPrivateRest::get_order_history` ranges as Unix microseconds and convert once at each exchange boundary
- correct Binance COIN-M account endpoints and preserve signed UM short positions while deriving non-negative leverage
- remove duplicated websocket filter state and update the crate, tokio-stream, and rustls patch versions

## Breaking Changes

`get_order_history` callers must now pass `start_time_us` and `end_time_us` as Unix timestamps in microseconds. The Rust parameter types remain `Option<u64>`, so existing callers that supplied milliseconds or seconds will still compile but must migrate their values to microseconds.

## Database Migrations

None.

## Merge Order

None.

## Related

None.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo test` (48 unit, 7 integration, 9 doctests passed)
- [x] `cargo test --all-features` (135 unit, 7 integration, 9 doctests passed)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`
- [x] `cargo audit`
- [x] `cargo deny check`
- [x] `cargo publish --dry-run --all-features --allow-dirty`

## Notes

The proposed OKX authentication timestamp rewrite was intentionally excluded because existing REST order placement and private WebSocket login are working, so it was not established as a production bug.