### PR TITLE
docs: align installation and runtime flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,20 +337,13 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-extrema_infra = { version = "0.2", features = ["all"] }
-
-# Enable exchange clients explicitly when needed.
-# extrema_infra = { version = "0.2", features = ["hyperliquid", "okx"] }
-# extrema_infra = { version = "0.2", features = ["lob_clients"] }
+extrema_infra = { version = "0.3", features = ["all"] }
 
 # For local development.
 # extrema_infra = { path = "../extrema_infra", features = ["all"] }
 
-# Or use the latest default branch directly.
-# extrema_infra = { git = "https://github.com/Lqz13Th/extrema_infra", features = ["all"] }
-
 # Tokio async runtime
-tokio = { version = "1.53.0", features = ["full"] }
+tokio = { version = "1.53", features = ["full"] }
 
 # TLS / Cryptography
 rustls = { version = "0.23", features = ["aws-lc-rs"] }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -92,9 +92,7 @@ see [TLS Setup](#tls-setup).
 [dependencies]
 # Local workspace development:
 extrema_infra = { path = "../extrema_infra" }
-# Published crate usage:
-# extrema_infra = "0.2"
-tokio = { version = "1.53.0", features = ["full"] }
+tokio = { version = "1.53", features = ["full"] }
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,8 +77,7 @@
 //!       -> Strategy::initialize()
 //!       -> prepare AltTask/WsTask workers and command handles
 //!       -> CommandEmitter::command_init()
-//!       -> spawn strategy event loops
-//!       -> strategy loops subscribe to all or selected task streams
+//!       -> subscribe strategies and spawn their event loops
 //!       -> spawn prepared task workers
 //!       -> tasks publish InfraMsg<T>
 //!       -> EventHandler callbacks react


### PR DESCRIPTION
## Summary
- point current API examples at the default branch instead of incompatible v0.2 releases
- remove the stale v0.2 dependency example from the usage guide
- document that strategy subscriptions are created before event loops are spawned

## Breaking Changes
None.

## Database Migrations
None.

## Merge Order
None.

## Related
None.

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo check --all-features --all-targets`
- [x] `cargo test --all-features`