### PR TITLE
perf(ws): add channel-aware decoders with envelope fallback

### DIFF
--- a/src/arch/market_assets/exchange/binance/binance_ws_msg.rs
+++ b/src/arch/market_assets/exchange/binance/binance_ws_msg.rs
@@ -1,8 +1,10 @@
-use serde::Deserialize;
+use serde::{Deserialize, de::DeserializeOwned};
 use serde_json::Value;
 use tracing::{info, warn};
 
-use crate::arch::traits::conversion::IntoWsData;
+use crate::arch::{
+    task_execution::ws_runner::ws_decode::decode_preferred, traits::conversion::IntoWsData,
+};
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(untagged)]
@@ -37,6 +39,16 @@ pub struct BinanceWsRes {
 pub struct BinanceWsError {
     pub code: i64,
     pub msg: String,
+}
+
+impl<T: DeserializeOwned> BinanceWsData<T> {
+    pub(crate) fn decode_single(frame: &[u8]) -> serde_json::Result<Self> {
+        decode_preferred(frame, Self::ChannelSingle)
+    }
+
+    pub(crate) fn decode_account_positions(frame: &[u8]) -> serde_json::Result<Self> {
+        decode_preferred(frame, Self::AccountPositions)
+    }
 }
 
 impl<T> IntoWsData for BinanceWsData<T>
@@ -78,6 +90,40 @@ where
 
                 Vec::new()
             },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Deserialize;
+
+    use super::BinanceWsData;
+
+    #[derive(Debug, Deserialize)]
+    struct TestPayload {
+        value: u64,
+    }
+
+    #[test]
+    fn single_decoder_preserves_control_and_error_frames() {
+        let cases: &[(&[u8], bool)] = &[
+            (br#"{"status":200,"result":null,"id":42}"#, false),
+            (
+                br#"{"status":400,"id":42,"error":{"code":-1,"msg":"bad request"}}"#,
+                true,
+            ),
+            (br#"{"code":-1,"msg":"bad request","id":42}"#, false),
+        ];
+
+        for (frame, has_nested_error) in cases {
+            let BinanceWsData::Event(event) =
+                BinanceWsData::<TestPayload>::decode_single(frame).unwrap()
+            else {
+                panic!("expected Binance control frame");
+            };
+
+            assert_eq!(event.error.is_some(), *has_nested_error);
         }
     }
 }

--- a/src/arch/market_assets/exchange/binance/schemas/cm_futures_ws/lob.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/cm_futures_ws/lob.rs
@@ -184,7 +184,8 @@ mod tests {
             "a":[["63298.7","333"]]
         }"#;
 
-        let parsed: BinanceWsData<WsPartialDepthBinanceCM> = serde_json::from_str(raw).unwrap();
+        let parsed =
+            BinanceWsData::<WsPartialDepthBinanceCM>::decode_single(raw.as_bytes()).unwrap();
         let lob = parsed.into_ws();
 
         assert_eq!(lob.len(), 1);

--- a/src/arch/market_assets/exchange/binance/schemas/um_futures_ws/account_position.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/um_futures_ws/account_position.rs
@@ -46,3 +46,46 @@ impl IntoWsData for WsAccountPositionBinanceUM {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::arch::{
+        market_assets::exchange::binance::binance_ws_msg::BinanceWsData,
+        traits::conversion::IntoWsData,
+    };
+
+    use super::*;
+
+    #[test]
+    fn decodes_positions_from_account_update_frame() {
+        let frame = br#"{
+            "e":"ACCOUNT_UPDATE",
+            "E":1781905826733,
+            "T":1781905826733,
+            "a":{
+                "m":"ORDER",
+                "B":[],
+                "P":[{
+                    "s":"BTCUSDT",
+                    "pa":"1.5",
+                    "ep":"63900.1",
+                    "cr":"0",
+                    "up":"0",
+                    "mt":"cross",
+                    "iw":"0",
+                    "ps":"BOTH"
+                }]
+            }
+        }"#;
+
+        let positions =
+            BinanceWsData::<WsAccountPositionBinanceUM>::decode_account_positions(frame)
+                .unwrap()
+                .into_ws();
+
+        assert_eq!(positions.len(), 1);
+        assert_eq!(positions[0].inst, "BTC_USDT_PERP");
+        assert_eq!(positions[0].size, 1.5);
+        assert_eq!(positions[0].margin_mode, MarginMode::Cross);
+    }
+}

--- a/src/arch/market_assets/exchange/binance/schemas/um_futures_ws/agg_trades.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/um_futures_ws/agg_trades.rs
@@ -42,3 +42,31 @@ impl IntoWsData for WsAggTradeBinanceUM {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::arch::market_assets::exchange::binance::binance_ws_msg::BinanceWsData;
+
+    use super::*;
+
+    #[test]
+    fn decodes_aggregate_trade_frame() {
+        let frame = br#"{
+            "e":"aggTrade","E":1780563843114,"a":987654321,
+            "s":"BTCUSDT","p":"63405.40","q":"0.125",
+            "f":100,"l":101,"T":1780563843113,"m":true
+        }"#;
+
+        let trade = BinanceWsData::<WsAggTradeBinanceUM>::decode_single(frame)
+            .unwrap()
+            .into_ws()
+            .pop()
+            .unwrap();
+
+        assert_eq!(trade.inst, "BTC_USDT_PERP");
+        assert_eq!(trade.price, 63_405.40);
+        assert_eq!(trade.size, 0.125);
+        assert_eq!(trade.side, OrderSide::SELL);
+        assert_eq!(trade.trade_id, 987654321);
+    }
+}

--- a/src/arch/market_assets/exchange/binance/schemas/um_futures_ws/lob.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/um_futures_ws/lob.rs
@@ -183,7 +183,7 @@ mod tests {
             "E":1780563843114
         }"#;
 
-        let parsed: BinanceWsData<WsBookTickerBinanceUM> = serde_json::from_str(raw).unwrap();
+        let parsed = BinanceWsData::<WsBookTickerBinanceUM>::decode_single(raw.as_bytes()).unwrap();
         let lob = parsed.into_ws();
 
         assert_eq!(lob.len(), 1);
@@ -209,7 +209,7 @@ mod tests {
             "a":[["63436.10","1.801"]]
         }"#;
 
-        let parsed: BinanceWsData<WsDiffDepthBinanceUM> = serde_json::from_str(raw).unwrap();
+        let parsed = BinanceWsData::<WsDiffDepthBinanceUM>::decode_single(raw.as_bytes()).unwrap();
         let lob = parsed.into_ws();
 
         assert_eq!(lob.len(), 1);

--- a/src/arch/market_assets/exchange/gate/gate_ws_msg.rs
+++ b/src/arch/market_assets/exchange/gate/gate_ws_msg.rs
@@ -1,8 +1,10 @@
-use serde::Deserialize;
+use serde::{Deserialize, de::DeserializeOwned};
 use serde_json::Value;
 use tracing::{info, warn};
 
-use crate::arch::traits::conversion::IntoWsData;
+use crate::arch::{
+    task_execution::ws_runner::ws_decode::decode_preferred, traits::conversion::IntoWsData,
+};
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(untagged)]
@@ -38,6 +40,16 @@ pub struct GateWsEvent {
 pub struct GateWsError {
     pub code: i64,
     pub message: String,
+}
+
+impl<T: DeserializeOwned> GateWsData<T> {
+    pub(crate) fn decode_single(frame: &[u8]) -> serde_json::Result<Self> {
+        decode_preferred(frame, Self::Single)
+    }
+
+    pub(crate) fn decode_batch(frame: &[u8]) -> serde_json::Result<Self> {
+        decode_preferred(frame, Self::Channel)
+    }
 }
 
 impl<T> IntoWsData for GateWsData<T>
@@ -76,5 +88,35 @@ where
                 Vec::new()
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Deserialize;
+
+    use super::GateWsData;
+
+    #[derive(Debug, Deserialize)]
+    struct TestPayload {
+        value: u64,
+    }
+
+    #[test]
+    fn preferred_decoders_preserve_control_and_error_frames() {
+        let control = GateWsData::<TestPayload>::decode_single(
+            br#"{"channel":"futures.book_ticker","event":"subscribe","result":{"status":"success"}}"#,
+        )
+        .unwrap();
+        let error = GateWsData::<TestPayload>::decode_batch(
+            br#"{"channel":"futures.trades","event":"subscribe","error":{"code":2,"message":"bad request"}}"#,
+        )
+        .unwrap();
+
+        assert!(matches!(control, GateWsData::Event(_)));
+        assert!(matches!(
+            error,
+            GateWsData::Event(super::GateWsEvent { error: Some(_), .. })
+        ));
     }
 }

--- a/src/arch/market_assets/exchange/gate/schemas/futures_ws/lob.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/futures_ws/lob.rs
@@ -215,7 +215,8 @@ mod tests {
             }
         });
 
-        let data: GateWsData<WsBookTickerGateFutures> = serde_json::from_value(raw).unwrap();
+        let raw = serde_json::to_vec(&raw).unwrap();
+        let data = GateWsData::<WsBookTickerGateFutures>::decode_single(&raw).unwrap();
         let lob: Vec<WsLob> = data.into_ws();
 
         assert_eq!(lob.len(), 1);
@@ -243,7 +244,8 @@ mod tests {
             }
         });
 
-        let data: GateWsData<WsOrderBookGateFutures> = serde_json::from_value(raw).unwrap();
+        let raw = serde_json::to_vec(&raw).unwrap();
+        let data = GateWsData::<WsOrderBookGateFutures>::decode_single(&raw).unwrap();
         let lob: Vec<WsLob> = data.into_ws();
 
         assert_eq!(lob.len(), 1);
@@ -268,7 +270,8 @@ mod tests {
             }
         });
 
-        let data: GateWsData<WsOrderBookUpdateGateFutures> = serde_json::from_value(raw).unwrap();
+        let raw = serde_json::to_vec(&raw).unwrap();
+        let data = GateWsData::<WsOrderBookUpdateGateFutures>::decode_single(&raw).unwrap();
         let lob: Vec<WsLob> = data.into_ws();
 
         assert_eq!(lob.len(), 1);

--- a/src/arch/market_assets/exchange/gate/schemas/futures_ws/trades.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/futures_ws/trades.rs
@@ -50,3 +50,32 @@ impl IntoWsData for WsTradeGateFutures {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::arch::market_assets::exchange::gate::gate_ws_msg::GateWsData;
+
+    use super::*;
+
+    #[test]
+    fn decodes_trade_batch_frame() {
+        let frame = br#"{
+            "channel":"futures.trades","event":"update","result":[{
+                "contract":"BTC_USDT","size":-3,"id":987654321,
+                "create_time_ms":1780563843113,"price":"63405.40"
+            }]
+        }"#;
+
+        let trade = GateWsData::<WsTradeGateFutures>::decode_batch(frame)
+            .unwrap()
+            .into_ws()
+            .pop()
+            .unwrap();
+
+        assert_eq!(trade.inst, "BTC_USDT_PERP");
+        assert_eq!(trade.price, 63_405.40);
+        assert_eq!(trade.size, 3.0);
+        assert_eq!(trade.side, OrderSide::SELL);
+        assert_eq!(trade.trade_id, 987654321);
+    }
+}

--- a/src/arch/market_assets/exchange/gate/schemas/spot_ws/account_order.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/spot_ws/account_order.rs
@@ -173,32 +173,41 @@ fn value_to_u64_ms(v: &Value) -> Option<u64> {
 mod tests {
     use serde_json::json;
 
-    use crate::arch::traits::conversion::IntoWsData;
+    use crate::arch::{
+        market_assets::exchange::gate::gate_ws_msg::GateWsData, traits::conversion::IntoWsData,
+    };
 
     use super::*;
 
     #[test]
-    fn into_ws_preserves_exchange_and_client_order_ids() {
-        let raw: WsAccountOrderGateSpot = serde_json::from_value(json!({
-            "id": "370702544401581041",
-            "currency_pair": "RE_USDT",
-            "side": "buy",
-            "type": "market",
-            "amount": "16",
-            "price": "0",
-            "left": "0",
-            "filled_amount": "16",
-            "avg_deal_price": "0.87295",
-            "status": "closed",
-            "finish_as": "filled",
-            "event": "finish",
-            "update_time_ms": 1781905826733_u64,
-            "create_time_ms": 1781905826733_u64,
-            "text": "gate-spot-client-id"
+    fn decodes_spot_orders_v2_and_preserves_order_ids() {
+        let raw = serde_json::to_vec(&json!({
+            "channel": "spot.orders_v2",
+            "event": "update",
+            "result": [{
+                "id": "370702544401581041",
+                "currency_pair": "RE_USDT",
+                "side": "buy",
+                "type": "market",
+                "amount": "16",
+                "price": "0",
+                "left": "0",
+                "filled_amount": "16",
+                "avg_deal_price": "0.87295",
+                "status": "closed",
+                "finish_as": "filled",
+                "event": "finish",
+                "update_time_ms": 1781905826733_u64,
+                "create_time_ms": 1781905826733_u64,
+                "text": "gate-spot-client-id"
+            }]
         }))
         .unwrap();
-
-        let ws = raw.into_ws();
+        let ws = GateWsData::<WsAccountOrderGateSpot>::decode_batch(&raw)
+            .unwrap()
+            .into_ws()
+            .pop()
+            .unwrap();
 
         assert_eq!(ws.order_id.as_deref(), Some("370702544401581041"));
         assert_eq!(ws.cli_order_id.as_deref(), Some("gate-spot-client-id"));

--- a/src/arch/market_assets/exchange/hyperliquid/hyperliquid_ws_msg.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/hyperliquid_ws_msg.rs
@@ -1,8 +1,12 @@
-use serde::Deserialize;
+use serde::{Deserialize, de::DeserializeOwned};
 use serde_json::Value;
 use tracing::info;
 
-use crate::arch::traits::conversion::IntoWsData;
+use crate::arch::{
+    task_execution::ws_runner::ws_decode::decode_preferred, traits::conversion::IntoWsData,
+};
+
+use super::schemas::ws::lob::WsLobHyperliquid;
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(untagged)]
@@ -15,6 +19,12 @@ pub enum HyperliquidWsData<T> {
 pub struct HyperliquidWsChannel<T> {
     pub channel: String,
     pub data: HyperliquidWsState<T>,
+}
+
+#[derive(Deserialize)]
+struct HyperliquidWsTypedChannel<T> {
+    channel: String,
+    data: T,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -46,6 +56,49 @@ pub struct WsClearinghouseStateHyperliquid<T> {
 pub struct HyperliquidWsEvent {
     pub channel: Option<String>,
     pub data: Option<Value>,
+}
+
+impl<T: DeserializeOwned> HyperliquidWsData<T> {
+    pub(crate) fn decode_batch(frame: &[u8]) -> serde_json::Result<Self> {
+        Self::decode_state(frame, HyperliquidWsState::ChannelBatch)
+    }
+
+    pub(crate) fn decode_clearinghouse(frame: &[u8]) -> serde_json::Result<Self> {
+        Self::decode_state(frame, HyperliquidWsState::Clearinghouse)
+    }
+
+    fn decode_single_with<Message, Wrap>(frame: &[u8], wrap: Wrap) -> serde_json::Result<Self>
+    where
+        Message: DeserializeOwned,
+        Wrap: FnOnce(Message) -> T,
+    {
+        Self::decode_state(frame, |message| {
+            HyperliquidWsState::ChannelSingle(wrap(message))
+        })
+    }
+
+    fn decode_state<Message, Wrap>(frame: &[u8], wrap: Wrap) -> serde_json::Result<Self>
+    where
+        Message: DeserializeOwned,
+        Wrap: FnOnce(Message) -> HyperliquidWsState<T>,
+    {
+        decode_preferred(frame, |message: HyperliquidWsTypedChannel<Message>| {
+            Self::Channel(HyperliquidWsChannel {
+                channel: message.channel,
+                data: wrap(message.data),
+            })
+        })
+    }
+}
+
+impl HyperliquidWsData<WsLobHyperliquid> {
+    pub(crate) fn decode_l2_book(frame: &[u8]) -> serde_json::Result<Self> {
+        Self::decode_single_with(frame, WsLobHyperliquid::Book)
+    }
+
+    pub(crate) fn decode_bbo(frame: &[u8]) -> serde_json::Result<Self> {
+        Self::decode_single_with(frame, WsLobHyperliquid::Bbo)
+    }
 }
 
 impl<T> IntoWsData for HyperliquidWsData<T>

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/ws/account_position.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/ws/account_position.rs
@@ -67,3 +67,47 @@ impl IntoWsData for WsAccountPositionHyperliquid {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::arch::{
+        market_assets::exchange::hyperliquid::hyperliquid_ws_msg::HyperliquidWsData,
+        traits::conversion::IntoWsData,
+    };
+
+    use super::*;
+
+    #[test]
+    fn decodes_clearinghouse_state_positions() {
+        let frame = br#"{
+            "channel":"clearinghouseState",
+            "data":{
+                "clearinghouseState":{
+                    "assetPositions":[{
+                        "type":"oneWay",
+                        "position":{
+                            "coin":"BTC",
+                            "szi":"1.5",
+                            "entryPx":"63900.1",
+                            "leverage":{"type":"cross","value":10}
+                        }
+                    }],
+                    "time":1781905826733
+                }
+            }
+        }"#;
+
+        let position =
+            HyperliquidWsData::<WsAccountPositionHyperliquid>::decode_clearinghouse(frame)
+                .unwrap()
+                .into_ws()
+                .pop()
+                .unwrap();
+
+        assert_eq!(position.inst, "BTC_USDC_PERP");
+        assert_eq!(position.size, 1.5);
+        assert_eq!(position.avg_price, 63_900.1);
+        assert_eq!(position.position_side, PositionSide::Long);
+        assert_eq!(position.margin_mode, MarginMode::Cross);
+    }
+}

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/ws/lob.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/ws/lob.rs
@@ -120,7 +120,7 @@ mod tests {
             }
         }"#;
 
-        let parsed: HyperliquidWsData<WsLobHyperliquid> = serde_json::from_str(raw).unwrap();
+        let parsed = HyperliquidWsData::<WsLobHyperliquid>::decode_l2_book(raw.as_bytes()).unwrap();
         let lob = parsed.into_ws();
 
         assert_eq!(lob.len(), 1);
@@ -146,7 +146,7 @@ mod tests {
             }
         }"#;
 
-        let parsed: HyperliquidWsData<WsLobHyperliquid> = serde_json::from_str(raw).unwrap();
+        let parsed = HyperliquidWsData::<WsLobHyperliquid>::decode_bbo(raw.as_bytes()).unwrap();
         let lob = parsed.into_ws();
 
         assert_eq!(lob.len(), 1);
@@ -155,5 +155,33 @@ mod tests {
         assert_eq!(lob[0].bids[0].order_count, Some(1));
         assert_eq!(lob[0].asks[0].price, 63900.0);
         assert_eq!(lob[0].asks[0].order_count, Some(4));
+    }
+
+    #[test]
+    fn lob_decoder_accepts_control_and_error_payloads() {
+        let frames: &[&[u8]] = &[
+            br#"{"channel":"pong"}"#,
+            br#"{"channel":"error","data":{"message":"bad request"}}"#,
+        ];
+
+        for frame in frames {
+            let parsed = HyperliquidWsData::<WsLobHyperliquid>::decode_l2_book(frame).unwrap();
+            assert!(parsed.into_ws().is_empty());
+        }
+    }
+
+    #[test]
+    fn lob_decoders_fall_back_to_the_other_lob_shape() {
+        let l2_book = HyperliquidWsData::<WsLobHyperliquid>::decode_bbo(
+            br#"{"channel":"l2Book","data":{"coin":"BTC","time":1,"levels":[[],[]]}}"#,
+        )
+        .unwrap();
+        let bbo = HyperliquidWsData::<WsLobHyperliquid>::decode_l2_book(
+            br#"{"channel":"bbo","data":{"coin":"BTC","time":1,"bbo":[null,null]}}"#,
+        )
+        .unwrap();
+
+        assert!(matches!(l2_book.into_ws()[0].event, LobEventKind::Snapshot));
+        assert!(matches!(bbo.into_ws()[0].event, LobEventKind::Bbo));
     }
 }

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/ws/trades.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/ws/trades.rs
@@ -38,3 +38,32 @@ impl IntoWsData for WsTradeHyperliquid {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::arch::market_assets::exchange::hyperliquid::hyperliquid_ws_msg::HyperliquidWsData;
+
+    use super::*;
+
+    #[test]
+    fn decodes_trade_batch_frame() {
+        let frame = br#"{
+            "channel":"trades","data":[{
+                "coin":"BTC","side":"B","px":"63405.40","sz":"0.125",
+                "time":1780563843113,"tid":987654321
+            }]
+        }"#;
+
+        let trade = HyperliquidWsData::<WsTradeHyperliquid>::decode_batch(frame)
+            .unwrap()
+            .into_ws()
+            .pop()
+            .unwrap();
+
+        assert_eq!(trade.inst, "BTC_USDC_PERP");
+        assert_eq!(trade.price, 63_405.40);
+        assert_eq!(trade.size, 0.125);
+        assert_eq!(trade.side, OrderSide::BUY);
+        assert_eq!(trade.trade_id, 987654321);
+    }
+}

--- a/src/arch/market_assets/exchange/okx/okx_ws_msg.rs
+++ b/src/arch/market_assets/exchange/okx/okx_ws_msg.rs
@@ -1,7 +1,9 @@
-use serde::Deserialize;
+use serde::{Deserialize, de::DeserializeOwned};
 use tracing::{info, warn};
 
-use crate::arch::traits::conversion::IntoWsData;
+use crate::arch::{
+    task_execution::ws_runner::ws_decode::decode_preferred, traits::conversion::IntoWsData,
+};
 
 pub(crate) trait IntoOkxWsData {
     type Output;
@@ -49,6 +51,12 @@ pub(crate) struct OkxWsChannel<T> {
     pub arg: WsArg,
     pub action: Option<String>,
     pub data: Vec<T>,
+}
+
+impl<T: DeserializeOwned> OkxWsData<T> {
+    pub(crate) fn decode_batch(frame: &[u8]) -> serde_json::Result<Self> {
+        decode_preferred(frame, Self::ChannelBatch)
+    }
 }
 
 impl<T> IntoWsData for OkxWsData<T>

--- a/src/arch/market_assets/exchange/okx/schemas/ws/lob.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/ws/lob.rs
@@ -152,7 +152,7 @@ mod tests {
             }]
         }"#;
 
-        let parsed: OkxWsData<OkxWsLobBook> = serde_json::from_str(raw).unwrap();
+        let parsed = OkxWsData::<OkxWsLobBook>::decode_batch(raw.as_bytes()).unwrap();
         let lob = parsed.into_ws();
 
         assert_eq!(lob.len(), 1);
@@ -176,7 +176,7 @@ mod tests {
             }]
         }"#;
 
-        let parsed: OkxWsData<OkxWsLobBook> = serde_json::from_str(raw).unwrap();
+        let parsed = OkxWsData::<OkxWsLobBook>::decode_batch(raw.as_bytes()).unwrap();
         let lob = parsed.into_ws();
 
         assert_eq!(lob.len(), 1);
@@ -200,7 +200,7 @@ mod tests {
             }]
         }"#;
 
-        let parsed: OkxWsData<OkxWsLobBook> = serde_json::from_str(raw).unwrap();
+        let parsed = OkxWsData::<OkxWsLobBook>::decode_batch(raw.as_bytes()).unwrap();
         let lob = parsed.into_ws();
 
         assert_eq!(lob.len(), 1);
@@ -212,14 +212,22 @@ mod tests {
 
     #[test]
     fn okx_lob_event_messages_produce_no_data() {
-        let raw = r#"{
-            "event": "error",
-            "code": "64003",
-            "msg": "Only API users who are VIP4 and above are allowed.",
-            "arg": {"channel": "books-l2-tbt", "instId": "BTC-USDT-SWAP"}
-        }"#;
+        let frames = [
+            r#"{
+                "event": "subscribe",
+                "arg": {"channel": "books", "instId": "BTC-USDT-SWAP"}
+            }"#,
+            r#"{
+                "event": "error",
+                "code": "64003",
+                "msg": "Only API users who are VIP4 and above are allowed.",
+                "arg": {"channel": "books-l2-tbt", "instId": "BTC-USDT-SWAP"}
+            }"#,
+        ];
 
-        let parsed: OkxWsData<OkxWsLobBook> = serde_json::from_str(raw).unwrap();
-        assert!(parsed.into_ws().is_empty());
+        for frame in frames {
+            let parsed = OkxWsData::<OkxWsLobBook>::decode_batch(frame.as_bytes()).unwrap();
+            assert!(parsed.into_ws().is_empty());
+        }
     }
 }

--- a/src/arch/market_assets/exchange/okx/schemas/ws/trades.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/ws/trades.rs
@@ -39,3 +39,33 @@ impl IntoWsData for WsTradesOkx {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::arch::market_assets::exchange::okx::okx_ws_msg::OkxWsData;
+
+    use super::*;
+
+    #[test]
+    fn decodes_trade_batch_frame() {
+        let frame = br#"{
+            "arg":{"channel":"trades","instId":"BTC-USDT-SWAP"},
+            "data":[{
+                "instId":"BTC-USDT-SWAP","tradeId":"987654321",
+                "px":"63405.40","sz":"0.125","side":"buy","ts":"1780563843113"
+            }]
+        }"#;
+
+        let trade = OkxWsData::<WsTradesOkx>::decode_batch(frame)
+            .unwrap()
+            .into_ws()
+            .pop()
+            .unwrap();
+
+        assert_eq!(trade.inst, "BTC_USDT_PERP");
+        assert_eq!(trade.price, 63_405.40);
+        assert_eq!(trade.size, 0.125);
+        assert_eq!(trade.side, OrderSide::BUY);
+        assert_eq!(trade.trade_id, 987654321);
+    }
+}

--- a/src/arch/task_execution/ws_runner.rs
+++ b/src/arch/task_execution/ws_runner.rs
@@ -10,9 +10,15 @@ mod gate;
 #[cfg(feature = "okx")]
 mod okx;
 
+#[cfg(any(
+    feature = "hyperliquid",
+    feature = "binance",
+    feature = "gate",
+    feature = "okx"
+))]
+pub(crate) mod ws_decode;
+
 use futures_util::{SinkExt, StreamExt};
-use serde::de::DeserializeOwned;
-use serde_json::from_slice;
 use std::sync::Arc;
 use tokio::{
     net::TcpStream,
@@ -80,19 +86,21 @@ impl WsTaskRunner {
         })?;
         Ok(ws_stream)
     }
-    async fn handle_ws_msg<WsData>(
+    async fn handle_ws_msg<WsData, Decode>(
         &mut self,
         msg: Result<Option<Result<Message, Error>>, Elapsed>,
         ws_stream: &mut WsStream,
         into_event: impl Fn(InfraMsg<WsData::Output>) -> TaskEvent + Copy + Send,
+        decode: Decode,
     ) -> bool
     where
-        WsData: DeserializeOwned + IntoWsData + Send + 'static,
+        WsData: IntoWsData + Send + 'static,
         WsData::Output: Send + Sync + 'static,
+        Decode: Fn(&[u8]) -> serde_json::Result<WsData> + Copy + Send,
     {
         match msg {
             Ok(Some(Ok(Message::Text(text)))) => {
-                match from_slice::<WsData>(text.as_ref()) {
+                match decode(text.as_ref()) {
                     Ok(parsed_raw) => {
                         let _ = self.event_tx.send(into_event(InfraMsg {
                             task_id: self.task_id,
@@ -112,7 +120,7 @@ impl WsTaskRunner {
                 };
             },
             Ok(Some(Ok(Message::Binary(bytes)))) => {
-                match from_slice::<WsData>(bytes.as_ref()) {
+                match decode(bytes.as_ref()) {
                     Ok(parsed_raw) => {
                         let _ = self.event_tx.send(into_event(InfraMsg {
                             task_id: self.task_id,
@@ -210,20 +218,22 @@ impl WsTaskRunner {
         ack_handle.respond(ack_status);
     }
 
-    async fn ws_loop<WsData>(
+    async fn ws_loop<WsData, Decode>(
         &mut self,
         into_event: impl Fn(InfraMsg<WsData::Output>) -> TaskEvent + Copy + Send,
         ws_stream: &mut WsStream,
+        decode: Decode,
     ) where
-        WsData: DeserializeOwned + IntoWsData + Send + 'static,
+        WsData: IntoWsData + Send + 'static,
         WsData::Output: Send + Sync + 'static,
+        Decode: Fn(&[u8]) -> serde_json::Result<WsData> + Copy + Send,
     {
         let timeout_sec = Duration::from_secs(10);
 
         loop {
             tokio::select! {
                 msg = timeout(timeout_sec, ws_stream.next()) => {
-                    if self.handle_ws_msg::<WsData>(msg, ws_stream, into_event).await {
+                    if self.handle_ws_msg::<WsData, Decode>(msg, ws_stream, into_event, decode).await {
                         break;
                     };
                 },

--- a/src/arch/task_execution/ws_runner/binance.rs
+++ b/src/arch/task_execution/ws_runner/binance.rs
@@ -29,49 +29,69 @@ impl WsTaskRunner {
     pub(super) async fn ws_channel_binance_um(&mut self, ws_stream: &mut WsStream) {
         match &self.ws_info.ws_channel {
             WsChannel::AccountOrders => {
-                self.ws_loop::<BinanceWsData<WsAccountOrderBinanceUM>>(
+                self.ws_loop(
                     TaskEvent::AccOrder,
                     ws_stream,
+                    BinanceWsData::<WsAccountOrderBinanceUM>::decode_single,
                 )
                 .await;
             },
             WsChannel::AccountBalAndPos => {
-                self.ws_loop::<BinanceWsData<WsBalAndPosBinanceUM>>(
+                self.ws_loop(
                     TaskEvent::AccBalPos,
                     ws_stream,
+                    BinanceWsData::<WsBalAndPosBinanceUM>::decode_single,
                 )
                 .await;
             },
             WsChannel::AccountPositions => {
-                self.ws_loop::<BinanceWsData<WsAccountPositionBinanceUM>>(
+                self.ws_loop(
                     TaskEvent::AccPos,
                     ws_stream,
+                    BinanceWsData::<WsAccountPositionBinanceUM>::decode_account_positions,
                 )
                 .await;
             },
             WsChannel::Candles(..) => {
-                self.ws_loop::<BinanceWsData<WsCandleBinanceUM>>(TaskEvent::Candle, ws_stream)
-                    .await;
+                self.ws_loop(
+                    TaskEvent::Candle,
+                    ws_stream,
+                    BinanceWsData::<WsCandleBinanceUM>::decode_single,
+                )
+                .await;
             },
             WsChannel::Trades(..) => {
-                self.ws_loop::<BinanceWsData<WsAggTradeBinanceUM>>(TaskEvent::Trade, ws_stream)
-                    .await;
+                self.ws_loop(
+                    TaskEvent::Trade,
+                    ws_stream,
+                    BinanceWsData::<WsAggTradeBinanceUM>::decode_single,
+                )
+                .await;
             },
             WsChannel::Lob(lob_param) => match lob_param {
                 Some(LobParam::Bbo { .. }) => {
-                    self.ws_loop::<BinanceWsData<WsBookTickerBinanceUM>>(TaskEvent::Lob, ws_stream)
-                        .await;
-                },
-                Some(LobParam::Snapshot { .. }) => {
-                    self.ws_loop::<BinanceWsData<WsPartialDepthBinanceUM>>(
+                    self.ws_loop(
                         TaskEvent::Lob,
                         ws_stream,
+                        BinanceWsData::<WsBookTickerBinanceUM>::decode_single,
+                    )
+                    .await;
+                },
+                Some(LobParam::Snapshot { .. }) => {
+                    self.ws_loop(
+                        TaskEvent::Lob,
+                        ws_stream,
+                        BinanceWsData::<WsPartialDepthBinanceUM>::decode_single,
                     )
                     .await;
                 },
                 None | Some(LobParam::Incremental { .. }) => {
-                    self.ws_loop::<BinanceWsData<WsDiffDepthBinanceUM>>(TaskEvent::Lob, ws_stream)
-                        .await;
+                    self.ws_loop(
+                        TaskEvent::Lob,
+                        ws_stream,
+                        BinanceWsData::<WsDiffDepthBinanceUM>::decode_single,
+                    )
+                    .await;
                 },
             },
             c => {
@@ -86,9 +106,10 @@ impl WsTaskRunner {
     pub(super) async fn ws_channel_binance_spot(&mut self, ws_stream: &mut WsStream) {
         match &self.ws_info.ws_channel {
             WsChannel::AccountOrders => {
-                self.ws_loop::<BinanceWsData<WsAccountOrderEnvelopeBinanceSpot>>(
+                self.ws_loop(
                     TaskEvent::AccOrder,
                     ws_stream,
+                    BinanceWsData::<WsAccountOrderEnvelopeBinanceSpot>::decode_single,
                 )
                 .await;
             },
@@ -105,19 +126,28 @@ impl WsTaskRunner {
         match &self.ws_info.ws_channel {
             WsChannel::Lob(lob_param) => match lob_param {
                 Some(LobParam::Bbo { .. }) => {
-                    self.ws_loop::<BinanceWsData<WsBookTickerBinanceCM>>(TaskEvent::Lob, ws_stream)
-                        .await;
-                },
-                Some(LobParam::Snapshot { .. }) => {
-                    self.ws_loop::<BinanceWsData<WsPartialDepthBinanceCM>>(
+                    self.ws_loop(
                         TaskEvent::Lob,
                         ws_stream,
+                        BinanceWsData::<WsBookTickerBinanceCM>::decode_single,
+                    )
+                    .await;
+                },
+                Some(LobParam::Snapshot { .. }) => {
+                    self.ws_loop(
+                        TaskEvent::Lob,
+                        ws_stream,
+                        BinanceWsData::<WsPartialDepthBinanceCM>::decode_single,
                     )
                     .await;
                 },
                 None | Some(LobParam::Incremental { .. }) => {
-                    self.ws_loop::<BinanceWsData<WsDiffDepthBinanceCM>>(TaskEvent::Lob, ws_stream)
-                        .await;
+                    self.ws_loop(
+                        TaskEvent::Lob,
+                        ws_stream,
+                        BinanceWsData::<WsDiffDepthBinanceCM>::decode_single,
+                    )
+                    .await;
                 },
             },
             c => {

--- a/src/arch/task_execution/ws_runner/gate.rs
+++ b/src/arch/task_execution/ws_runner/gate.rs
@@ -23,40 +23,59 @@ impl WsTaskRunner {
     pub(super) async fn ws_channel_gate_futures(&mut self, ws_stream: &mut WsStream) {
         match &self.ws_info.ws_channel {
             WsChannel::AccountOrders => {
-                self.ws_loop::<GateWsData<WsAccountOrderGateFutures>>(
+                self.ws_loop(
                     TaskEvent::AccOrder,
                     ws_stream,
+                    GateWsData::<WsAccountOrderGateFutures>::decode_batch,
                 )
                 .await;
             },
             WsChannel::AccountPositions => {
-                self.ws_loop::<GateWsData<WsAccountPositionGateFutures>>(
+                self.ws_loop(
                     TaskEvent::AccPos,
                     ws_stream,
+                    GateWsData::<WsAccountPositionGateFutures>::decode_batch,
                 )
                 .await;
             },
             WsChannel::Candles(..) => {
-                self.ws_loop::<GateWsData<WsCandleGateFutures>>(TaskEvent::Candle, ws_stream)
-                    .await;
+                self.ws_loop(
+                    TaskEvent::Candle,
+                    ws_stream,
+                    GateWsData::<WsCandleGateFutures>::decode_batch,
+                )
+                .await;
             },
             WsChannel::Trades(..) => {
-                self.ws_loop::<GateWsData<WsTradeGateFutures>>(TaskEvent::Trade, ws_stream)
-                    .await;
+                self.ws_loop(
+                    TaskEvent::Trade,
+                    ws_stream,
+                    GateWsData::<WsTradeGateFutures>::decode_batch,
+                )
+                .await;
             },
             WsChannel::Lob(lob_param) => match lob_param {
                 Some(LobParam::Bbo { .. }) => {
-                    self.ws_loop::<GateWsData<WsBookTickerGateFutures>>(TaskEvent::Lob, ws_stream)
-                        .await;
-                },
-                Some(LobParam::Snapshot { .. }) => {
-                    self.ws_loop::<GateWsData<WsOrderBookGateFutures>>(TaskEvent::Lob, ws_stream)
-                        .await;
-                },
-                None | Some(LobParam::Incremental { .. }) => {
-                    self.ws_loop::<GateWsData<WsOrderBookUpdateGateFutures>>(
+                    self.ws_loop(
                         TaskEvent::Lob,
                         ws_stream,
+                        GateWsData::<WsBookTickerGateFutures>::decode_single,
+                    )
+                    .await;
+                },
+                Some(LobParam::Snapshot { .. }) => {
+                    self.ws_loop(
+                        TaskEvent::Lob,
+                        ws_stream,
+                        GateWsData::<WsOrderBookGateFutures>::decode_single,
+                    )
+                    .await;
+                },
+                None | Some(LobParam::Incremental { .. }) => {
+                    self.ws_loop(
+                        TaskEvent::Lob,
+                        ws_stream,
+                        GateWsData::<WsOrderBookUpdateGateFutures>::decode_single,
                     )
                     .await;
                 },
@@ -73,8 +92,12 @@ impl WsTaskRunner {
     pub(super) async fn ws_channel_gate_spot(&mut self, ws_stream: &mut WsStream) {
         match &self.ws_info.ws_channel {
             WsChannel::AccountOrders => {
-                self.ws_loop::<GateWsData<WsAccountOrderGateSpot>>(TaskEvent::AccOrder, ws_stream)
-                    .await;
+                self.ws_loop(
+                    TaskEvent::AccOrder,
+                    ws_stream,
+                    GateWsData::<WsAccountOrderGateSpot>::decode_batch,
+                )
+                .await;
             },
             c => {
                 self.log(

--- a/src/arch/task_execution/ws_runner/hyperliquid.rs
+++ b/src/arch/task_execution/ws_runner/hyperliquid.rs
@@ -8,7 +8,10 @@ use crate::arch::{
         },
     },
     strategy_base::handler::task_channel::TaskEvent,
-    task_execution::{task_general::LogLevel, task_ws::WsChannel},
+    task_execution::{
+        task_general::LogLevel,
+        task_ws::{LobParam, WsChannel},
+    },
 };
 
 use super::{WsStream, WsTaskRunner};
@@ -17,26 +20,44 @@ impl WsTaskRunner {
     pub(super) async fn ws_channel_hyperliquid(&mut self, ws_stream: &mut WsStream) {
         match &self.ws_info.ws_channel {
             WsChannel::AccountOrders => {
-                self.ws_loop::<HyperliquidWsData<WsAccountOrderHyperliquid>>(
+                self.ws_loop(
                     TaskEvent::AccOrder,
                     ws_stream,
+                    HyperliquidWsData::<WsAccountOrderHyperliquid>::decode_batch,
                 )
                 .await;
             },
             WsChannel::AccountPositions => {
-                self.ws_loop::<HyperliquidWsData<WsAccountPositionHyperliquid>>(
+                self.ws_loop(
                     TaskEvent::AccPos,
                     ws_stream,
+                    HyperliquidWsData::<WsAccountPositionHyperliquid>::decode_clearinghouse,
                 )
                 .await;
             },
             WsChannel::Trades(..) => {
-                self.ws_loop::<HyperliquidWsData<WsTradeHyperliquid>>(TaskEvent::Trade, ws_stream)
-                    .await;
+                self.ws_loop(
+                    TaskEvent::Trade,
+                    ws_stream,
+                    HyperliquidWsData::<WsTradeHyperliquid>::decode_batch,
+                )
+                .await;
             },
-            WsChannel::Lob(..) => {
-                self.ws_loop::<HyperliquidWsData<WsLobHyperliquid>>(TaskEvent::Lob, ws_stream)
-                    .await;
+            WsChannel::Lob(Some(LobParam::Bbo { .. })) => {
+                self.ws_loop(
+                    TaskEvent::Lob,
+                    ws_stream,
+                    HyperliquidWsData::<WsLobHyperliquid>::decode_bbo,
+                )
+                .await;
+            },
+            WsChannel::Lob(_) => {
+                self.ws_loop(
+                    TaskEvent::Lob,
+                    ws_stream,
+                    HyperliquidWsData::<WsLobHyperliquid>::decode_l2_book,
+                )
+                .await;
             },
             c => {
                 self.log(

--- a/src/arch/task_execution/ws_runner/okx.rs
+++ b/src/arch/task_execution/ws_runner/okx.rs
@@ -16,24 +16,44 @@ impl WsTaskRunner {
     pub(super) async fn ws_channel_okx(&mut self, ws_stream: &mut WsStream) {
         match &self.ws_info.ws_channel {
             WsChannel::AccountOrders => {
-                self.ws_loop::<OkxWsData<WsAccountOrderOkx>>(TaskEvent::AccOrder, ws_stream)
-                    .await;
+                self.ws_loop(
+                    TaskEvent::AccOrder,
+                    ws_stream,
+                    OkxWsData::<WsAccountOrderOkx>::decode_batch,
+                )
+                .await;
             },
             WsChannel::AccountBalAndPos => {
-                self.ws_loop::<OkxWsData<WsBalAndPosOkx>>(TaskEvent::AccBalPos, ws_stream)
-                    .await;
+                self.ws_loop(
+                    TaskEvent::AccBalPos,
+                    ws_stream,
+                    OkxWsData::<WsBalAndPosOkx>::decode_batch,
+                )
+                .await;
             },
             WsChannel::AccountPositions => {
-                self.ws_loop::<OkxWsData<WsAccountPositionOkx>>(TaskEvent::AccPos, ws_stream)
-                    .await;
+                self.ws_loop(
+                    TaskEvent::AccPos,
+                    ws_stream,
+                    OkxWsData::<WsAccountPositionOkx>::decode_batch,
+                )
+                .await;
             },
             WsChannel::Trades(..) => {
-                self.ws_loop::<OkxWsData<WsTradesOkx>>(TaskEvent::Trade, ws_stream)
-                    .await;
+                self.ws_loop(
+                    TaskEvent::Trade,
+                    ws_stream,
+                    OkxWsData::<WsTradesOkx>::decode_batch,
+                )
+                .await;
             },
             WsChannel::Lob(..) => {
-                self.ws_loop::<OkxWsData<OkxWsLobBook>>(TaskEvent::Lob, ws_stream)
-                    .await;
+                self.ws_loop(
+                    TaskEvent::Lob,
+                    ws_stream,
+                    OkxWsData::<OkxWsLobBook>::decode_batch,
+                )
+                .await;
             },
             c => {
                 self.log(LogLevel::Warn, &format!("Unknown Okx channel: {:?}", c));

--- a/src/arch/task_execution/ws_runner/ws_decode.rs
+++ b/src/arch/task_execution/ws_runner/ws_decode.rs
@@ -1,0 +1,78 @@
+use serde::de::DeserializeOwned;
+
+/// Tries the runner's expected data shape before falling back to the full frame.
+pub(crate) fn decode_preferred<Frame, Preferred, Wrap>(
+    frame: &[u8],
+    wrap: Wrap,
+) -> serde_json::Result<Frame>
+where
+    Frame: DeserializeOwned,
+    Preferred: DeserializeOwned,
+    Wrap: FnOnce(Preferred) -> Frame,
+{
+    match serde_json::from_slice::<Preferred>(frame) {
+        Ok(message) => Ok(wrap(message)),
+        Err(error) => {
+            tracing::trace!(
+                preferred = std::any::type_name::<Preferred>(),
+                error = %error,
+                "WS preferred decoder fallback"
+            );
+            serde_json::from_slice(frame)
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Deserialize;
+
+    use super::decode_preferred;
+
+    #[derive(Debug, Deserialize)]
+    #[serde(untagged)]
+    enum TestFrame {
+        Data(TestData),
+        Event(TestEvent),
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct TestData {
+        value: u64,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct TestEvent {
+        event: String,
+    }
+
+    #[test]
+    fn decodes_preferred_shape_and_falls_back_to_full_frame() {
+        let data = decode_preferred::<TestFrame, TestData, _>(br#"{"value":42}"#, TestFrame::Data)
+            .unwrap();
+        let event = decode_preferred::<TestFrame, TestData, _>(
+            br#"{"event":"subscribe"}"#,
+            TestFrame::Data,
+        )
+        .unwrap();
+
+        assert!(matches!(data, TestFrame::Data(TestData { value: 42 })));
+        assert!(matches!(
+            event,
+            TestFrame::Event(TestEvent { event }) if event == "subscribe"
+        ));
+    }
+
+    #[test]
+    fn returns_the_full_frame_decoder_error() {
+        let frame = br#"{"value":"#;
+        let expected = serde_json::from_slice::<TestFrame>(frame)
+            .unwrap_err()
+            .to_string();
+        let actual = decode_preferred::<TestFrame, TestData, _>(frame, TestFrame::Data)
+            .unwrap_err()
+            .to_string();
+
+        assert_eq!(actual, expected);
+    }
+}


### PR DESCRIPTION
## Summary

- let `WsTaskRunner` use a decoder selected from the configured WebSocket channel
- decode the expected typed data shape first for Binance, Gate, Hyperliquid, and OKX
- fall back to the existing full exchange envelope for control, error, and unexpected frames
- emit a trace event when the preferred decoder falls back
- keep the existing `IntoWsData` normalization and downstream event routing unchanged

The fast path avoids the intermediate work performed by nested or broad
`#[serde(untagged)]` envelopes for normal high-frequency data frames. The
legacy envelope remains the compatibility path for subscription responses,
pong/control messages, and exchange errors.

## Behavior validation

Fixtures cover:

- Binance aggregate trades, account positions, subscription responses, and errors
- Gate trades, BBO/snapshot/incremental books, spot order updates, controls, and errors
- Hyperliquid trades, clearinghouse positions, BBO/L2 books, pong/errors, and cross-book fallback
- OKX trades, BBO/books/heartbeat frames, subscription responses, and errors
- preferred decode success, full-envelope fallback, and final parse-error propagation

No `IntoWsData` implementation, symbol normalization, order-state mapping,
subscription behavior, or downstream event route is changed.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --offline --locked`
- `cargo test --offline --locked --features lob_clients --lib`
  - 147 passed
  - 0 failed
- `git diff --check`

## Focused performance evidence

An earlier release-mode Criterion A/B on base commit `0384457` validated the
same preferred-decoder design for selected Gate and Hyperliquid fixtures:

| Fixture | Legacy envelope | Preferred decoder | Decode time |
| --- | ---: | ---: | ---: |
| Gate BBO | 776.52 ns | 456.88 ns | -41.2% |
| Gate snapshot | 984.37 ns | 535.55 ns | -45.6% |
| Gate incremental | 870.11 ns | 476.71 ns | -45.2% |
| Hyperliquid BBO | 1.368 us | 0.539 us | -60.6% |
| Hyperliquid L2, 10 bids + 10 asks | 5.347 us | 2.289 us | -57.2% |

The timed boundary is raw JSON decode, production normalization, and output
construction. It excludes sockets/TLS, Tokio scheduling, strategy work, order
execution, and venue latency. These results validate the decoding approach;
they are not a benchmark of every channel in this exact final revision. Cold
fallback frames intentionally perform an additional failed typed decode.

## Cross-framework validation context

The following results are context, not an isolated before/after benchmark of
this PR and not an overall framework ranking. They are actual wall-clock
measurements on an Apple M5 Pro host with 15 logical CPUs, using prebuilt
production-shaped Binance JSON rather than live WebSocket captures.

Criterion measured `raw payload -> production DTO decode -> native normalize`
with a 1-second warm-up, 3-second measurement, 100 samples, and three repeats:

| Binance channel | NautilusTrader | Barter-rs | Extrema Infra |
| --- | ---: | ---: | ---: |
| Trade | **244.89 ns** | 260.87 ns | 297.42 ns |
| BBO / `bookTicker` | **278.16 ns** | 310.32 ns | 377.66 ns |
| Depth frame | 475.20 ns | **423.67 ns** | 524.30 ns |

BBO and depth use byte-identical payloads. Trade uses equivalent business
values, but Extrema/Nautilus consume `aggTrade` while Barter uses its production
`trade` schema. Native output models also differ.

A separate zero-network concurrent harness modeled 20 public producers x 5
symbols, 20 signal handlers, one AccountOrder ingress, an in-memory venue,
ACK/FILL decode, and 20 private observations per frame. Results are median
wall throughput after two warm-ups and seven measured runs:

| Workload | Compute | Extrema | Barter | Nautilus |
| --- | ---: | ---: | ---: | ---: |
| Stress: 6,400 ticks/orders | 0 ns/tick | **109,945** | 49,294 | 16,420 |
| Mixed: 25,600 ticks, 1,200 orders | 0 ns/tick | 552,959 | **1,158,111** | 354,068 |
| Stress: 6,400 ticks/orders | 100 us/tick | **81,322** | 9,424 | 6,194 |
| Mixed: 25,600 ticks, 1,200 orders | 100 us/tick | **96,313** | 9,930 | 9,674 |

Values are tick/s. The 100 us workload uses `Instant` plus `spin_loop()` in
each signal callback, so it consumes host CPU time. Extrema's 20 native
Strategy tasks can progress across Tokio workers; the benchmark topology
dispatches Barter's composite Strategy and Nautilus's LiveNode signal
callbacks serially. This demonstrates existing scheduling behavior and must
not be attributed to the decoder change.

All 84 formal concurrent measurements passed conservation checks with zero
drops, duplicates, missing routes, delivery loss, broadcast lag, or ending
in-flight work. The harness excludes physical sockets, TLS/kernel I/O, real
exchange latency, and reconnect behavior; its venue and correlation layers
are benchmark-local.
