### PR TITLE
chore(release): prepare v0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -71,16 +71,13 @@ flowchart TB
     EXS["N Exchanges<br/>Binance / OKX / Gate / Hyperliquid"]
 
     subgraph RT["Extrema Infra runtime"]
-        direction TB
 
         subgraph INGEST["WS ingestion tasks"]
-            direction LR
             PUB["Public market WS<br/>trade / book / price"]
             ACC["Account WS<br/>position / order / fill"]
         end
 
         subgraph SIGS["N strategy signal modules"]
-            direction TB
             S1["Signal A"]
             S2["Signal B"]
             S3["Signal N"]
@@ -89,8 +86,7 @@ flowchart TB
         FEAT["Feature stream<br/>AltTensor"]
 
         subgraph MODELS["N model strategy modules"]
-            direction TB
-            M1["LightGBM<br/>Python / ZMQ"]
+            M1["PyTorch<br/>Python / ZMQ"]
             M2["ONNX<br/>Rust"]
             M3["Model N"]
         end
@@ -101,7 +97,6 @@ flowchart TB
         PLAN["Order planner<br/>slice / net / reduce-only / route"]
 
         subgraph ORDERS["N order tasks"]
-            direction TB
             O1["Account A"]
             O2["Account B"]
             O3["Account N"]

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ With **HList**:
 - **Heterogeneous strategies** (different struct types) can be stored in one container.  
 - **Compile-time guarantees**: only strategies implementing the `Strategy` trait can be registered.  
 - **Static strategy registration**: no `Box<dyn Strategy>` at the module-list boundary.
+
 ---
 
 ## Strategy Execution Model


### PR DESCRIPTION
## Summary

- bump `extrema_infra` from `0.3.0` to `0.3.1`
- prepare the channel-aware WebSocket decoder improvements from #92 for release
- restore the README architecture diagram's pre-Mermaid-11.16 layout
- label the Python model path as PyTorch and fix surrounding README spacing

## Included in v0.3.1

- select typed WebSocket decoders from the configured channel for Binance,
  Gate, Hyperliquid, and OKX
- retain the existing full-envelope decoder as the compatibility path for
  control, error, and unexpected frames
- trace preferred-decoder fallbacks without changing downstream normalization
  or event routing
- cover data, control, error, and fallback behavior across the four exchanges

## Verification

- `cargo fmt --all -- --check`
- `cargo check --offline --locked`
- `cargo test --offline --locked --features lob_clients --lib`
  - 147 passed
  - 0 failed
- `cargo package --list --allow-dirty`
- `cargo publish --dry-run --all-features --allow-dirty`
  - packaged and verified `extrema_infra v0.3.1`
  - 250 files, 2.3 MiB uncompressed / 1.5 MiB compressed
- Mermaid 11.16.1 render check
  - `N Exchanges` remains above the runtime graph
  - nodes, edges, and subgraph boundaries retain the Mermaid 11.15 layout
- `git diff --check`

`Cargo.lock` remains untracked as configured for this library crate.
