### PR TITLE
fix(ws): avoid logging sensitive payloads

### DIFF
--- a/src/arch/market_assets/exchange.rs
+++ b/src/arch/market_assets/exchange.rs
@@ -1,6 +1,5 @@
 #![allow(dead_code)]
 pub mod prelude;
-pub(crate) mod secret;
 
 #[cfg(feature = "hyperliquid")]
 pub mod hyperliquid;

--- a/src/arch/market_assets/exchange/binance/api_key.rs
+++ b/src/arch/market_assets/exchange/binance/api_key.rs
@@ -4,9 +4,9 @@ use hmac::{KeyInit, Mac};
 use reqwest::{Client, Response};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
-use crate::arch::market_assets::{
-    api_general::*,
-    exchange::secret::{redact_identifier, redact_secret},
+use crate::arch::{
+    market_assets::api_general::*,
+    redaction::{redact_identifier, redact_secret},
 };
 use crate::errors::{InfraError, InfraResult};
 

--- a/src/arch/market_assets/exchange/gate/api_key.rs
+++ b/src/arch/market_assets/exchange/gate/api_key.rs
@@ -6,9 +6,9 @@ use reqwest::{Client, Response};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::{Value, json};
 
-use crate::arch::market_assets::{
-    api_general::*,
-    exchange::secret::{redact_identifier, redact_secret},
+use crate::arch::{
+    market_assets::api_general::*,
+    redaction::{redact_identifier, redact_secret},
 };
 use crate::errors::{InfraError, InfraResult};
 

--- a/src/arch/market_assets/exchange/hyperliquid/auth.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/auth.rs
@@ -5,9 +5,9 @@ use secp256k1::{Message, Secp256k1, SecretKey};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use sha3::{Digest, Keccak256};
 
-use crate::arch::market_assets::{
-    api_general::{get_mills_timestamp, parse_json_response},
-    exchange::secret::{redact_identifier, redact_secret},
+use crate::arch::{
+    market_assets::api_general::{get_mills_timestamp, parse_json_response},
+    redaction::{redact_identifier, redact_secret},
 };
 use crate::errors::{InfraError, InfraResult};
 

--- a/src/arch/market_assets/exchange/okx/api_key.rs
+++ b/src/arch/market_assets/exchange/okx/api_key.rs
@@ -5,9 +5,9 @@ use reqwest::{Client, Response};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::Value;
 
-use crate::arch::market_assets::{
-    api_general::*,
-    exchange::secret::{redact_identifier, redact_secret},
+use crate::arch::{
+    market_assets::api_general::*,
+    redaction::{redact_identifier, redact_secret},
 };
 use crate::errors::{InfraError, InfraResult};
 

--- a/src/arch/redaction.rs
+++ b/src/arch/redaction.rs
@@ -1,5 +1,35 @@
 pub(crate) const REDACTED_SECRET: &str = "[REDACTED]";
 
+const SENSITIVE_FIELDS: [&[u8]; 11] = [
+    b"api_key",
+    b"apikey",
+    b"access_token",
+    b"accesstoken",
+    b"secret",
+    b"signature",
+    b"passphrase",
+    b"\"auth\"",
+    b"\"key\"",
+    b"\"sign\"",
+    b"listenkey",
+];
+
+pub(crate) fn contains_sensitive_content(message: &str) -> bool {
+    SENSITIVE_FIELDS.iter().any(|field| {
+        message
+            .as_bytes()
+            .windows(field.len())
+            .any(|window| window.eq_ignore_ascii_case(field))
+    })
+}
+
+#[cfg(any(
+    test,
+    feature = "hyperliquid",
+    feature = "binance",
+    feature = "gate",
+    feature = "okx"
+))]
 pub(crate) fn redact_identifier(value: &str) -> String {
     let chars: Vec<char> = value.chars().collect();
 

--- a/src/arch/task_execution/ws_runner.rs
+++ b/src/arch/task_execution/ws_runner.rs
@@ -37,6 +37,7 @@ use tracing::{error, info, warn};
 
 use crate::arch::{
     market_assets::market_core::Market,
+    redaction::{contains_sensitive_content, redact_secret},
     strategy_base::{
         command::{
             ack_handle::{AckHandle, AckStatus},
@@ -207,12 +208,22 @@ impl WsTaskRunner {
         ack_status: AckStatus,
     ) {
         if ws_stream.send(Message::text(msg.clone())).await.is_err() {
-            self.log(
-                LogLevel::Error,
-                &format!("Failed to send {:?}: {}", ack_status, msg),
-            );
-        } else {
-            self.log(LogLevel::Info, &format!("{:?}: {}", ack_status, msg));
+            if contains_sensitive_content(&msg) {
+                self.log(
+                    LogLevel::Error,
+                    &format!(
+                        "Failed to send {:?}: {}, {} bytes",
+                        ack_status,
+                        redact_secret(),
+                        msg.len()
+                    ),
+                );
+            } else {
+                self.log(
+                    LogLevel::Error,
+                    &format!("Failed to send {:?}: {}", ack_status, msg),
+                );
+            }
         }
 
         ack_handle.respond(ack_status);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,6 +180,7 @@ pub mod prelude;
 pub mod arch {
     pub mod infra_core;
     pub mod market_assets;
+    pub(crate) mod redaction;
     pub mod strategy_base;
     pub mod task_execution;
     pub mod traits;


### PR DESCRIPTION
## Summary
- stop logging successful outbound websocket payloads
- redact failed outbound payloads when they contain credential markers while retaining command type and byte length
- move exchange credential redaction into a shared internal arch::redaction module used by websocket and exchange clients
- preserve full failure payload logs for messages that do not match sensitive markers

## Sensitive markers
- api_key / apiKey
- access_token / accessToken
- secret, signature, passphrase
- auth, key, sign, listenKey

## Runtime impact
- no scanning or logging on successful sends
- case-insensitive byte scanning runs only after a websocket send failure
- no public API changes or runtime abstractions

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo clippy --all-features --all-targets -- -D warnings
- cargo test --all-features --all-targets
- 147 unit tests and 7 runtime tests passed; all examples compiled