### PR TITLE
feat(okx): add websocket candle decoding

### DIFF
--- a/src/arch/market_assets/exchange/okx/okx_cli.rs
+++ b/src/arch/market_assets/exchange/okx/okx_cli.rs
@@ -1337,7 +1337,8 @@ impl OkxCli {
                 TradesParam::AggTrades => OKX_WS_PUB,
                 TradesParam::AllTrades => OKX_WS_BUS,
             },
-            WsChannel::Candles(_) | WsChannel::Lob(_) | WsChannel::Trades(None) => OKX_WS_PUB,
+            WsChannel::Candles(_) => OKX_WS_BUS,
+            WsChannel::Lob(_) | WsChannel::Trades(None) => OKX_WS_PUB,
             WsChannel::Other(s) if s == "instruments" || s == "funding-rate" => OKX_WS_BUS,
             _ => return Err(InfraError::Unimplemented),
         };
@@ -1363,7 +1364,10 @@ impl OkxCli {
         candle_param: &Option<CandleParam>,
         insts: Option<&[String]>,
     ) -> InfraResult<String> {
-        let interval = candle_param.as_ref().map(|p| p.as_str()).unwrap_or("1m");
+        let interval = candle_param
+            .as_ref()
+            .map(okx_candle_interval)
+            .unwrap_or("1m");
 
         let channel = format!("candle{}", interval);
 
@@ -1512,6 +1516,34 @@ mod tests {
 
             assert_eq!(value["op"], "subscribe");
             assert_eq!(value["args"][0]["channel"], expected);
+            assert_eq!(value["args"][0]["instId"], "BTC-USDT-SWAP");
+        }
+    }
+
+    #[test]
+    fn builds_okx_candle_connect_and_subscribe_messages() {
+        let cli = OkxCli::default();
+        let insts = vec!["BTC_USDT_PERP".to_string()];
+
+        assert_eq!(
+            cli._get_public_connect_msg(&WsChannel::Candles(Some(CandleParam::OneHour)))
+                .unwrap(),
+            OKX_WS_BUS
+        );
+
+        let cases = [
+            (None, "candle1m"),
+            (Some(CandleParam::OneHour), "candle1H"),
+            (Some(CandleParam::OneDay), "candle1Dutc"),
+        ];
+
+        for (interval, expected_channel) in cases {
+            let msg = cli
+                ._get_public_sub_msg(&WsChannel::Candles(interval), Some(&insts))
+                .unwrap();
+            let value: Value = serde_json::from_str(&msg).unwrap();
+
+            assert_eq!(value["args"][0]["channel"], expected_channel);
             assert_eq!(value["args"][0]["instId"], "BTC-USDT-SWAP");
         }
     }

--- a/src/arch/market_assets/exchange/okx/schemas/ws.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/ws.rs
@@ -1,5 +1,6 @@
 pub(crate) mod account_bal_and_pos;
 pub(crate) mod account_order;
 pub(crate) mod account_position;
+pub(crate) mod candles;
 pub(crate) mod lob;
 pub(crate) mod trades;

--- a/src/arch/market_assets/exchange/okx/schemas/ws/candles.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/ws/candles.rs
@@ -1,0 +1,105 @@
+use serde::Deserialize;
+
+use crate::arch::{
+    market_assets::{
+        api_general::ts_to_micros,
+        exchange::okx::{
+            api_utils::okx_inst_to_cli,
+            okx_ws_msg::{IntoOkxWsData, WsArg},
+        },
+        market_core::Market,
+    },
+    strategy_base::handler::lob_events::WsCandle,
+    task_execution::task_ws::CandleParam,
+};
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct WsCandleOkx([String; 9]);
+
+impl IntoOkxWsData for WsCandleOkx {
+    type Output = WsCandle;
+
+    fn into_ws_with_okx_context(self, arg: &WsArg, _action: Option<&str>) -> Self::Output {
+        let [
+            timestamp,
+            open,
+            high,
+            low,
+            close,
+            volume,
+            _volume_ccy,
+            _volume_quote,
+            confirm,
+        ] = self.0;
+        let interval = arg
+            .channel
+            .as_deref()
+            .and_then(|channel| channel.strip_prefix("candle"))
+            .map(candle_param_from_okx_interval)
+            .unwrap_or(CandleParam::OneMinute);
+
+        WsCandle {
+            timestamp: ts_to_micros(timestamp.parse().unwrap_or_default()),
+            market: Market::Okx,
+            inst: okx_inst_to_cli(arg.instId.as_deref().unwrap_or_default()),
+            interval,
+            open: open.parse().unwrap_or_default(),
+            high: high.parse().unwrap_or_default(),
+            low: low.parse().unwrap_or_default(),
+            close: close.parse().unwrap_or_default(),
+            volume: volume.parse().unwrap_or_default(),
+            confirm: confirm == "1",
+        }
+    }
+}
+
+fn candle_param_from_okx_interval(interval: &str) -> CandleParam {
+    match interval {
+        "1s" => CandleParam::OneSecond,
+        "1m" => CandleParam::OneMinute,
+        "5m" => CandleParam::FiveMinutes,
+        "15m" => CandleParam::FifteenMinutes,
+        "1H" => CandleParam::OneHour,
+        "4H" => CandleParam::FourHours,
+        "1D" | "1Dutc" => CandleParam::OneDay,
+        "1W" | "1Wutc" => CandleParam::OneWeek,
+        custom => CandleParam::Custom(custom.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::arch::{
+        market_assets::exchange::okx::okx_ws_msg::OkxWsData, traits::conversion::IntoWsData,
+    };
+
+    use super::*;
+
+    #[test]
+    fn decodes_okx_candle_batch_with_outer_context() {
+        let frame = br#"{
+            "arg":{"channel":"candle1Dutc","instId":"BTC-USDT-SWAP"},
+            "data":[[
+                "1597026383085","8533.02","8553.74","8527.17","8548.26",
+                "45247","529.5858061","5529.5858061","1"
+            ]]
+        }"#;
+
+        let candles = OkxWsData::<WsCandleOkx>::decode_batch(frame)
+            .unwrap()
+            .into_ws();
+
+        assert_eq!(candles.len(), 1);
+        let candle = &candles[0];
+        assert_eq!(candle.timestamp, 1_597_026_383_085_000);
+        assert_eq!(candle.market, Market::Okx);
+        assert_eq!(candle.inst, "BTC_USDT_PERP");
+        assert_eq!(candle.interval, CandleParam::OneDay);
+        assert_eq!(candle.open, 8533.02);
+        assert_eq!(candle.high, 8553.74);
+        assert_eq!(candle.low, 8527.17);
+        assert_eq!(candle.close, 8548.26);
+        assert_eq!(candle.volume, 45247.0);
+        assert!(candle.confirm);
+    }
+}

--- a/src/arch/task_execution/ws_runner/okx.rs
+++ b/src/arch/task_execution/ws_runner/okx.rs
@@ -3,7 +3,8 @@ use crate::arch::{
         okx_ws_msg::OkxWsData,
         schemas::ws::{
             account_bal_and_pos::WsBalAndPosOkx, account_order::WsAccountOrderOkx,
-            account_position::WsAccountPositionOkx, lob::OkxWsLobBook, trades::WsTradesOkx,
+            account_position::WsAccountPositionOkx, candles::WsCandleOkx, lob::OkxWsLobBook,
+            trades::WsTradesOkx,
         },
     },
     strategy_base::handler::task_channel::TaskEvent,
@@ -36,6 +37,14 @@ impl WsTaskRunner {
                     TaskEvent::AccPos,
                     ws_stream,
                     OkxWsData::<WsAccountPositionOkx>::decode_batch,
+                )
+                .await;
+            },
+            WsChannel::Candles(..) => {
+                self.ws_loop(
+                    TaskEvent::Candle,
+                    ws_stream,
+                    OkxWsData::<WsCandleOkx>::decode_batch,
                 )
                 .await;
             },


### PR DESCRIPTION
## Summary
- connect OKX candle tasks to the business websocket endpoint
- generate OKX-specific candle channel intervals such as 1H and 1Dutc
- decode the nine-field OKX candle array with instrument and interval context from the websocket envelope
- dispatch normalized candle batches through TaskEvent::Candle

## Runtime design
- reuse the existing OkxWsData batch envelope and IntoOkxWsData context path
- deserialize each candle into a fixed [String; 9] payload
- no new runtime abstraction or dynamic dispatch

## Validation
- cargo fmt --all -- --check
- cargo check --all-features --all-targets
- cargo clippy --all-features --all-targets -- -D warnings
- cargo test --all-features --all-targets
- 149 unit tests and 7 runtime tests passed; all examples compiled
- live OKX business websocket test received BTC_USDT_PERP OneMinute candle data through WsTaskRunner -> TaskEvent::Candle -> Strategy::on_candle