### PR TITLE
feat(hyperliquid): add non-funding ledger updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 
 readme = "README.md"

--- a/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
@@ -37,6 +37,7 @@ use super::{
         clearinghouse_state::RestClearinghouseStateHyperliquid,
         funding_history::RestFundingHistoryHyperliquid,
         meta::RestMetaHyperliquid,
+        non_funding_ledger::RestNonFundingLedgerUpdateHyperliquid,
         open_order::RestOpenOrderHyperliquid,
         order_status::{
             RestOrderStatusHyperliquid, finalize_hyperliquid_order_history,
@@ -339,6 +340,34 @@ impl HyperliquidCli {
             .collect();
 
         Ok(data)
+    }
+
+    pub async fn get_non_funding_ledger_updates(
+        &self,
+        start_time_us: u64,
+        end_time_us: Option<u64>,
+    ) -> InfraResult<Vec<RestNonFundingLedgerUpdateHyperliquid>> {
+        if let Some(end_time_us) = end_time_us
+            && end_time_us < start_time_us
+        {
+            return Err(InfraError::ApiCliError(format!(
+                "Hyperliquid non-funding ledger end_time_us {} is earlier than start_time_us {}",
+                end_time_us, start_time_us
+            )));
+        }
+
+        let mut body = json!({
+            "type": "userNonFundingLedgerUpdates",
+            "user": self._owner_address()?,
+            "startTime": start_time_us / 1_000,
+        });
+        if let Some(end_time_us) = end_time_us {
+            body["endTime"] = json!(end_time_us / 1_000);
+        }
+
+        let res: RestResHyperliquid<RestNonFundingLedgerUpdateHyperliquid> =
+            self._post_info_raw(&body).await?;
+        res.into_vec()
     }
 
     pub async fn withdraw3(&self, destination: &str, amount: &str) -> InfraResult<Value> {

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest.rs
@@ -5,6 +5,7 @@ pub mod candle;
 pub mod clearinghouse_state;
 pub mod funding_history;
 pub mod meta;
+pub mod non_funding_ledger;
 pub mod open_order;
 pub mod order_status;
 pub mod orderbook;

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest/non_funding_ledger.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest/non_funding_ledger.rs
@@ -1,0 +1,44 @@
+use serde::Deserialize;
+
+use crate::arch::market_assets::api_general::{de_micros_from_int, de_string_from_any};
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestNonFundingLedgerUpdateHyperliquid {
+    #[serde(rename = "time", deserialize_with = "de_micros_from_int")]
+    pub timestamp: u64,
+    #[serde(default, deserialize_with = "de_string_from_any")]
+    pub hash: String,
+    pub delta: RestNonFundingLedgerDeltaHyperliquid,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct RestNonFundingLedgerDeltaHyperliquid {
+    #[serde(rename = "type", default, deserialize_with = "de_string_from_any")]
+    pub kind: String,
+    #[serde(default, deserialize_with = "de_string_from_any")]
+    pub usdc: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_deposit_ledger_update() {
+        let update: RestNonFundingLedgerUpdateHyperliquid =
+            serde_json::from_value(serde_json::json!({
+                "time": 1_786_205_432_100_u64,
+                "hash": "0xabc123",
+                "delta": {
+                    "type": "deposit",
+                    "usdc": "79.89"
+                }
+            }))
+            .unwrap();
+
+        assert_eq!(update.timestamp, 1_786_205_432_100_000);
+        assert_eq!(update.hash, "0xabc123");
+        assert_eq!(update.delta.kind, "deposit");
+        assert_eq!(update.delta.usdc, "79.89");
+    }
+}


### PR DESCRIPTION
## Summary
- add typed Hyperliquid non-funding ledger update schemas
- expose a time-bounded `userNonFundingLedgerUpdates` client call using microsecond inputs
- prepare crate version 0.3.2

## Verification
- `cargo fmt -- --check`
- `cargo test --features hyperliquid`
- `cargo clippy --features hyperliquid --all-targets -- -D warnings`
- live read-only Large PO check returned the expected 104.932837 and 79.89 USDC deposits; exact tx-hash filtering matched the 79.89 USDC deposit once