### PR TITLE
ci: add Gitleaks secret scanning

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,27 @@
+name: Secret Scan
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+
+      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_VERSION: 8.30.1
+          GITLEAKS_ENABLE_COMMENTS: false
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false


### PR DESCRIPTION
## Summary
- scan pushes and pull requests for committed secrets
- pin `actions/checkout` and `gitleaks-action` to immutable commit SHAs
- pin the Gitleaks engine to `8.30.1`
- use read-only permissions and disable comments/artifact uploads

## Validation
- workflow YAML parses successfully
- local Gitleaks scan reports no leaks