### PR TITLE
ci: add Markdown linting

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -14,6 +14,21 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  markdown:
+    name: Markdown
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint Markdown
+        uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff # v24.2.0
+        with:
+          config: .markdownlint.json
+          globs: |
+            **/*.md
+            !target/**
+
   fmt:
     name: Format
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- add a dedicated Markdown lint job to Rust CI
- reuse the existing `.markdownlint.json` rules
- pin `markdownlint-cli2-action` v24.2.0 to its commit SHA
- lint all repository Markdown while excluding generated `target` output

## Validation

- `npx --yes markdownlint-cli2@0.23.2 --config .markdownlint.json "**/*.md" "!target/**"`
- 3 files checked, 0 issues
- `git diff --check`