### PR TITLE
docs: correct runtime behavior contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ flowchart TB
         PM["Portfolio mediator<br/>risk / constraints / OMS"]
         PLAN["Order planner<br/>slice / net / reduce-only / route"]
 
-        subgraph ORDERS["N order tasks"]
-            O1["Account A"]
-            O2["Account B"]
-            O3["Account N"]
+        subgraph ORDERS["N application order-execution modules"]
+            O1["Account A execution"]
+            O2["Account B execution"]
+            O3["Account N execution"]
         end
 
         CMD["Strategy Cmd Path<br/>optional WS order route"]
@@ -132,13 +132,13 @@ flowchart TB
     ALLOC -->|allocator intent| PM
     PM --> PLAN
 
-    PLAN -->|order instruction| O1
-    PLAN -->|order instruction| O2
-    PLAN -->|order instruction| O3
+    PLAN -->|OrderExecute via relay| O1
+    PLAN -->|OrderExecute via relay| O2
+    PLAN -->|OrderExecute via relay| O3
 
-    O1 -->|async REST order| EXS
-    O2 -->|async REST order| EXS
-    O3 -->|async REST order| EXS
+    O1 -->|application REST submission| EXS
+    O2 -->|application REST submission| EXS
+    O3 -->|application REST submission| EXS
 
     O1 -.->|WS order via command handle| CMD
     O2 -.->|WS order via command handle| CMD
@@ -148,9 +148,12 @@ flowchart TB
     ACC -.->|state feedback| PM
 ```
 
-Signal, model, allocator, and portfolio-mediator components can all be Strategy
-Modules. The runtime composes them with websocket tasks, scheduler tasks,
-model-prediction tasks, command handles, and account-bound order tasks.
+Signal, model, allocator, portfolio-mediator, and execution components can all
+be Strategy Modules. The runtime composes them with websocket tasks, scheduler
+tasks, model-prediction tasks, command handles, and order-execution relays. The
+built-in `OrderExecution` task only republishes `OrderExecute` batches to
+`on_order_execution`; an application module performs actual REST or websocket
+submission.
 
 ---
 
@@ -216,7 +219,9 @@ Enable the `model_onnx` feature, or `model_runner` / `all`, to make this backend
 - The ONNX model is loaded once during task initialization.
 - Inference requests are routed through a dedicated worker thread owned by the ONNX task.
 - Callers send an `AltTensor` feature payload and receive an `AltTensor` prediction payload.
-- For multi-output models, select a specific output with `output_index`; otherwise the runner picks the first decodable tensor output.
+- For multi-output models, select a specific output with `output_index`.
+  Otherwise, the runner prefers the first `f32` or `f64` output; if neither is
+  present, it selects the first output that can be converted to `f32`.
 
 You can initialize the runner in two ways:
 
@@ -281,18 +286,14 @@ selected client does not support return `InfraError::Unimplemented`.
 
 ---
 
-## TLS / rustls Initialization (Important)
+## TLS / rustls Initialization
 
 This framework relies on `rustls` for secure REST and WebSocket connections
 (e.g. via `reqwest` and `tokio-tungstenite`).
 
-Starting with **rustls v0.23**, the TLS crypto backend (e.g. `aws-lc-rs` or `ring`)
-**must be explicitly selected by the final binary**.
-
-### ⚠️ Required for binaries that use TLS-enabled REST/WebSocket functionality
-
-Before using any TLS-enabled functionality (REST / WebSocket),
-the executable **must install a default CryptoProvider**:
+When exactly one built-in provider feature is enabled, `rustls` 0.23 can select
+it automatically. A final binary can still install a provider explicitly before
+creating REST or websocket clients to pin the process-wide choice:
 
 ```rust
 #[tokio::main]
@@ -304,6 +305,11 @@ async fn main() {
   // start tokio runtime, env builder, etc.
 }
 ```
+
+Explicit selection is necessary when the dependency graph enables zero or
+multiple built-in providers, or when the application uses a custom provider.
+Provider installation belongs in the final binary because `rustls` allows only
+one process-wide default provider.
 
 ---
 
@@ -401,14 +407,17 @@ async fn main() -> InfraResult<()> {
 
 For a practical implementation, see the [complex strategy example](examples/complex_strategy_example.rs).
 
-- **Latency-sensitive task**  
-  - Handles order placement, cancel/replace, LOB reaction, etc.
+- **Latency-sensitive module**
+  - Receives execution requests and can implement placement, cancel/replace,
+    LOB reaction, and other application logic.
+  - The example logs relayed execution requests; exchange submission is omitted.
   - Minimal logic, no blocking, no heavy computation.
   - Samples only the data needed by the fast path.
 
 - **Supporting tasks**
-  - Order execution, feature generation, risk checks, position management, and evaluation.
-  - These tasks communicate with the latency-sensitive task through channels (**CommandEmitter** -> **OrderExecution**) and task-local state.
+  - Feature generation, risk checks, position management, and evaluation.
+  - These tasks communicate with the latency-sensitive module through channels
+    (`CommandEmitter` -> `OrderExecution` relay) and task-local state.
   - Use **AltTask** for feature extraction, sending data to a ZMQ or ONNX model runner via command handle, then generating signals to execute orders.
 
 Latency-sensitive logic can be decomposed into multiple tasks, with each task

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -178,10 +178,13 @@ let env = EnvBuilder::new()
 
 Common `AltTaskType` values:
 
-- `TimeScheduler(Duration)`: periodic ticks delivered to `on_schedule`.
+- `TimeScheduler(Duration)`: the duration must be greater than zero. After the
+  task's approximately five-second startup delay, the first `on_schedule`
+  callback is immediate; later callbacks use the configured duration.
 - `InstIntent`: instrument or portfolio target intents delivered to
   `on_inst_intent`.
-- `OrderExecution`: order batches delivered to `on_order_execution`.
+- `OrderExecution`: relays order batches to `on_order_execution`; the receiving
+  application module implements actual exchange submission.
 - `ModelPreds(ModelRunner::Zmq(..))`: external model process integration.
   Enable `model_zmq`, `model_runner`, or `all`, to make this variant available.
 - `ModelPreds(ModelRunner::Onnx(..))`: in-process ONNX inference. Enable
@@ -193,10 +196,12 @@ to `on_preds`.
 
 ## Public Websocket Task
 
-A public market-data strategy typically receives a `WsTaskInfo` startup event,
-uses the command handle to connect and subscribe, then consumes normalized
-events such as trades or candles. LOB updates are available only for exchange
-relays that implement `WsChannel::Lob` routing.
+A public market-data strategy receives a `WsTaskInfo` event before each
+connection or reconnection cycle, uses the command handle to connect and
+subscribe, then consumes normalized events such as trades or candles. The
+handler must be safe to call repeatedly and must repeat the full initialization
+sequence each time. LOB updates are available only for exchange relays that
+implement `WsChannel::Lob` routing.
 
 ```rust,ignore
 use extrema_infra::prelude::*;
@@ -236,9 +241,9 @@ impl EventHandler for MyPublicWsModule {
 }
 ```
 
-The strategy owns the connect and subscribe sequence. In practice, the
-`on_ws_event` handler finds the websocket handle, sends `TaskCommand::WsConnect`,
-then sends exchange login/subscription messages as needed:
+The strategy owns the connect and subscribe sequence. The Binance UM example
+below uses its URL-only target with `TaskCommand::WsConnect`, then sends exchange
+login/subscription messages as needed:
 
 ```rust,ignore
 async fn on_ws_event(&mut self, msg: InfraMsg<WsTaskInfo>) {
@@ -290,6 +295,11 @@ async fn on_ws_event(&mut self, msg: InfraMsg<WsTaskInfo>) {
         .await;
 }
 ```
+
+URL-only clients use `get_*_connect_msg` with `TaskCommand::WsConnect`. Clients
+that require HTTP upgrade metadata, currently including Gate Futures, use
+`get_*_connect_target` with `TaskCommand::WsConnectWithTarget`; the string form
+cannot carry headers.
 
 ## Private Account Websocket Task
 
@@ -444,8 +454,9 @@ reduce receivers and wakeups, but do not reduce publisher ring capacity.
 
 ## TLS Setup
 
-If the binary uses REST or websocket clients, install a `rustls` crypto provider
-before creating those clients:
+When exactly one built-in provider feature is enabled, `rustls` 0.23 can select
+it automatically. A final binary can still install a provider explicitly before
+creating REST or websocket clients to pin the process-wide choice:
 
 ```rust,no_run
 rustls::crypto::aws_lc_rs::default_provider()
@@ -453,8 +464,10 @@ rustls::crypto::aws_lc_rs::default_provider()
     .expect("failed to install rustls crypto provider");
 ```
 
-This belongs in the final binary, not inside library code, because `rustls`
-allows only one process-wide default provider.
+Explicit selection is necessary when the dependency graph enables zero or
+multiple built-in providers, or when the application uses a custom provider.
+It belongs in the final binary, not library code, because `rustls` allows only
+one process-wide default provider.
 
 ## Reference Patterns
 

--- a/examples/complex_strategy_example.rs
+++ b/examples/complex_strategy_example.rs
@@ -311,7 +311,7 @@ async fn main() -> InfraResult<()> {
 
     // Strategy logic (signal generation, sends orders to account module)
     let strategy_logic = HFTStrategy::new();
-    // Account/order execution module (handles exchange connection + order placement)
+    // Receives execution requests and owns exchange connectivity; submission is omitted.
     let strategy_account_module = AccountModule::new();
 
     // WebSocket tasks: account order updates & market trades

--- a/examples/multi_strategy_example.rs
+++ b/examples/multi_strategy_example.rs
@@ -162,7 +162,7 @@ async fn main() -> InfraResult<()> {
     let binance_ws_candle = WsTaskInfo {
         market: Market::BinanceUmFutures,
         ws_channel: WsChannel::Candles(Some(CandleParam::OneMinute)),
-        filter_channels: false, // false for debug msg
+        filter_channels: false, // Log websocket decode failures.
         chunk: 1,               // number of websocket connections for this task
         task_base_id: None,
     };

--- a/src/arch/market_assets/exchange/lob_clients.rs
+++ b/src/arch/market_assets/exchange/lob_clients.rs
@@ -15,9 +15,9 @@ use crate::errors::{InfraError, InfraResult};
 
 /// Unified dispatcher for the built-in limit-order-book exchange clients.
 ///
-/// Each trait call delegates to the selected concrete client. Exchange
-/// capabilities are not uniform, so unsupported operation and market
-/// combinations return [`InfraError::Unimplemented`].
+/// Dispatcher methods delegate supported client/operation combinations to the
+/// selected concrete client. Combinations not exposed by this aggregate return
+/// [`InfraError::Unimplemented`].
 #[derive(Clone, Debug)]
 #[cfg(feature = "lob_clients")]
 pub enum LobClients {

--- a/src/arch/strategy_base/command/ack_handle.rs
+++ b/src/arch/strategy_base/command/ack_handle.rs
@@ -2,19 +2,25 @@ use tokio::sync::oneshot::Sender;
 
 /// Acknowledgement status returned by runtime tasks.
 ///
-/// Strategies can pass an expected status to
-/// `CommandHandle::send_command`. This is useful for ordered websocket control
-/// flows where the next message should only be sent after the previous command
-/// was accepted, such as connect -> login -> subscribe.
+/// Strategies can pass an expected status to [`CommandHandle::send_command`]
+/// to sequence relay commands such as connect -> login -> subscribe. An
+/// acknowledgement reports progress inside the local relay; it does not imply
+/// exchange-level authentication, subscription, or order acceptance.
+///
+/// [`CommandHandle::send_command`]: crate::arch::strategy_base::command::command_core::CommandHandle::send_command
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AckStatus {
-    /// Websocket connection command was accepted.
+    /// The websocket relay completed the connection handshake.
     WsConnect,
-    /// Websocket message command was accepted.
+    /// The relay consumed a websocket message command and attempted the write.
+    ///
+    /// The relay currently returns this status even when the socket write fails.
     WsMessage,
-    /// Websocket shutdown command was accepted.
+    /// The relay consumed a shutdown command and attempted its payload write.
+    ///
+    /// The relay currently returns this status even when the socket write fails.
     WsShutdown,
-    /// Alt task command was accepted or auto-acknowledged.
+    /// An alt task auto-acknowledged an unexpected ack-bearing command.
     AltTask,
     /// Unknown or placeholder acknowledgement.
     Unknown,

--- a/src/arch/task_execution/task_alt.rs
+++ b/src/arch/task_execution/task_alt.rs
@@ -26,6 +26,10 @@ pub enum AltTaskType {
     #[cfg(any(feature = "model_onnx", feature = "model_zmq"))]
     ModelPreds(ModelRunner),
     /// Periodic scheduler task.
+    ///
+    /// The duration must be greater than zero. After the task's approximately
+    /// five-second startup delay, the first tick is immediate; later ticks use
+    /// the configured duration.
     TimeScheduler(Duration),
 }
 

--- a/src/arch/task_execution/task_ws.rs
+++ b/src/arch/task_execution/task_ws.rs
@@ -3,17 +3,19 @@ use crate::arch::market_assets::market_core::Market;
 /// Descriptor for a websocket relay task.
 ///
 /// The relay owns websocket IO for a market/channel pair and publishes
-/// normalized events into its task-local broadcast stream. Strategies usually react
-/// to the initial `on_ws_event` event by sending connect/login/subscribe
-/// commands through the task handle.
+/// normalized events into its task-local broadcast ring. Before every connection
+/// or reconnection cycle, it emits `on_ws_event`; the handler must repeat the
+/// required connect/login/subscribe sequence and be safe to call again.
 #[derive(Clone, Debug)]
 pub struct WsTaskInfo {
     /// Exchange or venue for this websocket task.
     pub market: Market,
     /// Stream category handled by this task.
     pub ws_channel: WsChannel,
-    /// Whether parse failures from expected non-target websocket payloads should
-    /// be ignored quietly instead of logged as parse errors.
+    /// Whether to suppress logs for all text and binary decode failures.
+    ///
+    /// When `true`, malformed target payloads are silent as well as expected
+    /// non-target messages. Failed payloads are dropped in either mode.
     pub filter_channels: bool,
     /// Number of task instances to spawn.
     pub chunk: u64,

--- a/src/arch/traits/market_lob.rs
+++ b/src/arch/traits/market_lob.rs
@@ -168,7 +168,11 @@ pub trait LobWebsocket: Send + Sync {
         ready(Err(InfraError::Unimplemented))
     }
 
-    /// Builds or returns a public websocket connection target.
+    /// Returns a public websocket endpoint using the URL-only string form.
+    ///
+    /// This form cannot carry HTTP upgrade headers. Use
+    /// [`LobWebsocket::get_public_connect_target`] when the venue requires
+    /// connection metadata.
     fn get_public_connect_msg(
         &self,
         _channel: &WsChannel,
@@ -186,7 +190,11 @@ pub trait LobWebsocket: Send + Sync {
         ready(Err(InfraError::Unimplemented))
     }
 
-    /// Returns the private websocket endpoint using the legacy string form.
+    /// Returns a private websocket endpoint using the URL-only string form.
+    ///
+    /// This form cannot carry HTTP upgrade headers. Use
+    /// [`LobWebsocket::get_private_connect_target`] when the venue requires
+    /// connection metadata.
     fn get_private_connect_msg(
         &self,
         _channel: &WsChannel,

--- a/src/arch/traits/strategy.rs
+++ b/src/arch/traits/strategy.rs
@@ -228,59 +228,59 @@ pub trait EventHandler {
     /// Receives model prediction tensors from a model task.
     ///
     /// Model tasks emit this after receiving `TaskCommand::FeatInput` and
-    /// finishing inference. Registering the model task makes `EnvBuilder`
-    /// provide its default prediction channel.
+    /// finishing inference. The concrete model task publishes the result into
+    /// its task-local broadcast ring.
     fn on_preds(&mut self, _msg: InfraMsg<AltTensor>) -> impl Future<Output = ()> + Send {
         ready(())
     }
 
     /// Receives periodic scheduler ticks.
     ///
-    /// Scheduler tasks emit [`AltScheduleEvent`] at their configured
-    /// `Duration`. Use `msg.task_id` to distinguish multiple timers.
+    /// Scheduler tasks emit [`AltScheduleEvent`]. After task startup, their first
+    /// tick is immediate and later ticks use the configured `Duration`. Use
+    /// `msg.task_id` to distinguish multiple timers.
     fn on_schedule(&mut self, _msg: InfraMsg<AltScheduleEvent>) -> impl Future<Output = ()> + Send {
         ready(())
     }
 
     /// Receives generic websocket-task lifecycle/control events.
     ///
-    /// Websocket tasks emit this before waiting for the initial
-    /// `TaskCommand::WsConnect`. Strategies commonly implement this callback to
-    /// connect, authenticate, and subscribe the relay.
+    /// Websocket tasks emit this before every connection or reconnection cycle
+    /// while waiting for `TaskCommand::WsConnect`. Implementations should be
+    /// safe to call repeatedly and must reconnect, authenticate, and subscribe
+    /// the relay for each cycle.
     fn on_ws_event(&mut self, _msg: InfraMsg<WsTaskInfo>) -> impl Future<Output = ()> + Send {
         ready(())
     }
 
     /// Receives normalized public trade batches.
     ///
-    /// Emitted by websocket relays configured with [`WsChannel::Trades`].
-    /// Registering the task makes `EnvBuilder` provide its default trade
-    /// channel.
+    /// A concrete websocket task configured with [`WsChannel::Trades`] publishes
+    /// each batch into its task-local broadcast ring.
     fn on_trade(&mut self, _msg: InfraMsg<Vec<WsTrade>>) -> impl Future<Output = ()> + Send {
         ready(())
     }
 
     /// Receives normalized order book updates.
     ///
-    /// Emitted by exchange relays that implement [`WsChannel::Lob`] routing and
-    /// publish into the inferred default LOB channel.
+    /// A concrete exchange task that implements [`WsChannel::Lob`] routing
+    /// publishes each update into its task-local broadcast ring.
     fn on_lob(&mut self, _msg: InfraMsg<Vec<WsLob>>) -> impl Future<Output = ()> + Send {
         ready(())
     }
 
     /// Receives normalized market-by-order order book updates.
     ///
-    /// Emitted by exchange relays that implement [`WsChannel::LobMbo`] routing
-    /// and publish into the inferred default MBO channel.
+    /// A concrete exchange task that implements [`WsChannel::LobMbo`] routing
+    /// publishes each update into its task-local broadcast ring.
     fn on_lob_mbo(&mut self, _msg: InfraMsg<Vec<WsLobMbo>>) -> impl Future<Output = ()> + Send {
         ready(())
     }
 
     /// Receives normalized candle batches.
     ///
-    /// Emitted by websocket relays configured with [`WsChannel::Candles`].
-    /// Registering the task makes `EnvBuilder` provide its default candle
-    /// channel.
+    /// A concrete websocket task configured with [`WsChannel::Candles`]
+    /// publishes each batch into its task-local broadcast ring.
     fn on_candle(&mut self, _msg: InfraMsg<Vec<WsCandle>>) -> impl Future<Output = ()> + Send {
         ready(())
     }


### PR DESCRIPTION
## Summary

- clarify relay acknowledgement and websocket reconnect semantics
- document decode filtering and structured websocket connection targets accurately
- distinguish the built-in order-execution relay from application exchange submission
- correct scheduler, ONNX output-selection, rustls provider, task-local ring, and aggregate-client descriptions

## Scope

Documentation, Rustdoc, and example comments only. No runtime behavior changes.

## Verification

- `cargo fmt --check`
- `cargo check --examples --all-features`
- `cargo test --doc --all-features` (9 passed, 6 ignored)
- `npx markdownlint-cli2 README.md docs/usage.md`
- `git diff --check`
