### PR TITLE
refactor(okx): simplify REST response APIs

### DIFF
--- a/src/arch/infra_core/env_builder.rs
+++ b/src/arch/infra_core/env_builder.rs
@@ -1,20 +1,18 @@
 use std::sync::Arc;
 use tracing::info;
 
-use crate::{
-    arch::{
-        infra_core::{env_core::EnvCore, env_mediator::EnvMediator},
-        strategy_base::{
-            handler::task_channel::TaskChannels,
-            hlist_core::{HCons, HNil},
-            strategy_group::InnerStrategyGroup,
-            strategy_module::InnerStrategyModule,
-        },
-        task_execution::{TaskInfo, TaskKey},
-        traits::strategy::Strategy,
+use crate::arch::{
+    infra_core::{env_core::EnvCore, env_mediator::EnvMediator},
+    strategy_base::{
+        handler::task_channel::TaskChannels,
+        hlist_core::{HCons, HNil},
+        strategy_group::InnerStrategyGroup,
+        strategy_module::InnerStrategyModule,
     },
-    errors::{InfraError, InfraResult},
+    task_execution::{TaskInfo, TaskKey},
+    traits::strategy::Strategy,
 };
+use crate::errors::{InfraError, InfraResult};
 
 /// Builder for an `extrema_infra` runtime.
 ///

--- a/src/arch/market_assets/api_general.rs
+++ b/src/arch/market_assets/api_general.rs
@@ -7,10 +7,10 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use crate::arch::market_assets::base_data::{
-    MarginMode, OrderSide, OrderType, PositionSide, TimeInForce,
+use crate::arch::{
+    market_assets::base_data::{MarginMode, OrderSide, OrderType, PositionSide, TimeInForce},
+    task_execution::task_ws::CandleParam,
 };
-use crate::arch::task_execution::task_ws::CandleParam;
 use crate::errors::{InfraError, InfraResult};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
+++ b/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
@@ -419,84 +419,6 @@ impl BinanceUmCli {
         Ok(candles)
     }
 
-    async fn _get_candles(
-        &self,
-        inst: &str,
-        interval: CandleParam,
-        limit: Option<u32>,
-        start_time_us: Option<u64>,
-        end_time_us: Option<u64>,
-    ) -> InfraResult<Vec<CandleData>> {
-        let mut params = vec![
-            format!("symbol={}", cli_perp_to_pure_uppercase(inst)),
-            format!("interval={}", interval.as_str()),
-        ];
-        if let Some(limit) = limit {
-            params.push(format!("limit={limit}"));
-        }
-        if let Some(start_time_us) = start_time_us {
-            params.push(format!("startTime={}", start_time_us / 1_000));
-        }
-        if let Some(end_time_us) = end_time_us {
-            params.push(format!("endTime={}", end_time_us / 1_000));
-        }
-
-        let url = format!(
-            "{}{}?{}",
-            BINANCE_UM_FUTURES_BASE_URL,
-            BINANCE_UM_FUTURES_KLINES,
-            params.join("&")
-        );
-
-        let response = self.client.get(url).send().await?;
-        let res: RestResBinance<RestCandleBinanceUM> =
-            parse_json_response("BinanceUmFutures candles", response).await?;
-
-        let mut data: Vec<CandleData> = res
-            .into_vec()?
-            .into_iter()
-            .map(|entry| entry.into_candle_data(inst))
-            .collect();
-        data.sort_by_key(|candle| candle.timestamp);
-
-        Ok(data)
-    }
-
-    async fn _get_orderbook(
-        &self,
-        inst: &str,
-        inst_type: InstrumentType,
-        depth: usize,
-    ) -> InfraResult<OrderBookData> {
-        if inst_type != InstrumentType::Perpetual {
-            return Err(InfraError::ApiCliError(format!(
-                "Binance UM orderbook supports perpetual instruments only, got {:?}",
-                inst_type
-            )));
-        }
-
-        let mut params = vec![format!("symbol={}", cli_perp_to_pure_uppercase(inst))];
-        if depth > 0 {
-            params.push(format!("limit={}", binance_um_orderbook_limit(depth)?));
-        }
-
-        let url = format!(
-            "{}{}?{}",
-            BINANCE_UM_FUTURES_BASE_URL,
-            BINANCE_UM_FUTURES_DEPTH,
-            params.join("&")
-        );
-        let response = self.client.get(url).send().await?;
-        let res: RestResBinance<RestOrderBookBinanceUM> =
-            parse_json_response("BinanceUmFutures orderbook", response).await?;
-
-        res.into_vec()?
-            .into_iter()
-            .next()
-            .map(|entry| entry.into_orderbook_data(inst))
-            .ok_or_else(|| InfraError::ApiCliError("No Binance UM orderbook data returned".into()))
-    }
-
     pub async fn get_premium_index(
         &self,
         inst: Option<&str>,
@@ -634,6 +556,84 @@ impl BinanceUmCli {
             .collect();
 
         Ok(data)
+    }
+
+    async fn _get_candles(
+        &self,
+        inst: &str,
+        interval: CandleParam,
+        limit: Option<u32>,
+        start_time_us: Option<u64>,
+        end_time_us: Option<u64>,
+    ) -> InfraResult<Vec<CandleData>> {
+        let mut params = vec![
+            format!("symbol={}", cli_perp_to_pure_uppercase(inst)),
+            format!("interval={}", interval.as_str()),
+        ];
+        if let Some(limit) = limit {
+            params.push(format!("limit={limit}"));
+        }
+        if let Some(start_time_us) = start_time_us {
+            params.push(format!("startTime={}", start_time_us / 1_000));
+        }
+        if let Some(end_time_us) = end_time_us {
+            params.push(format!("endTime={}", end_time_us / 1_000));
+        }
+
+        let url = format!(
+            "{}{}?{}",
+            BINANCE_UM_FUTURES_BASE_URL,
+            BINANCE_UM_FUTURES_KLINES,
+            params.join("&")
+        );
+
+        let response = self.client.get(url).send().await?;
+        let res: RestResBinance<RestCandleBinanceUM> =
+            parse_json_response("BinanceUmFutures candles", response).await?;
+
+        let mut data: Vec<CandleData> = res
+            .into_vec()?
+            .into_iter()
+            .map(|entry| entry.into_candle_data(inst))
+            .collect();
+        data.sort_by_key(|candle| candle.timestamp);
+
+        Ok(data)
+    }
+
+    async fn _get_orderbook(
+        &self,
+        inst: &str,
+        inst_type: InstrumentType,
+        depth: usize,
+    ) -> InfraResult<OrderBookData> {
+        if inst_type != InstrumentType::Perpetual {
+            return Err(InfraError::ApiCliError(format!(
+                "Binance UM orderbook supports perpetual instruments only, got {:?}",
+                inst_type
+            )));
+        }
+
+        let mut params = vec![format!("symbol={}", cli_perp_to_pure_uppercase(inst))];
+        if depth > 0 {
+            params.push(format!("limit={}", binance_um_orderbook_limit(depth)?));
+        }
+
+        let url = format!(
+            "{}{}?{}",
+            BINANCE_UM_FUTURES_BASE_URL,
+            BINANCE_UM_FUTURES_DEPTH,
+            params.join("&")
+        );
+        let response = self.client.get(url).send().await?;
+        let res: RestResBinance<RestOrderBookBinanceUM> =
+            parse_json_response("BinanceUmFutures orderbook", response).await?;
+
+        res.into_vec()?
+            .into_iter()
+            .next()
+            .map(|entry| entry.into_orderbook_data(inst))
+            .ok_or_else(|| InfraError::ApiCliError("No Binance UM orderbook data returned".into()))
     }
 
     async fn _get_tickers(

--- a/src/arch/market_assets/exchange/gate/api_utils.rs
+++ b/src/arch/market_assets/exchange/gate/api_utils.rs
@@ -4,8 +4,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tracing::{error, warn};
 
-use crate::arch::market_assets::{api_general::get_seconds_timestamp, base_data::SUBSCRIBE_LOWER};
-use crate::arch::task_execution::task_ws::LobFrequency;
+use crate::arch::{
+    market_assets::{api_general::get_seconds_timestamp, base_data::SUBSCRIBE_LOWER},
+    task_execution::task_ws::LobFrequency,
+};
 use crate::errors::{InfraError, InfraResult};
 
 pub const GATE_CHANNEL_ID_EXTRA_KEY: &str = "gate_channel_id";

--- a/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
@@ -378,6 +378,59 @@ impl HyperliquidCli {
             .await
     }
 
+    pub async fn get_perps_at_open_interest_cap(&self) -> InfraResult<Vec<String>> {
+        let body = json!({
+            "type": "perpsAtOpenInterestCap",
+            "dex": self._perp_dex(),
+        });
+        let res: RestResHyperliquid<String> = self._post_info_raw(&body).await?;
+        res.into_vec()
+    }
+
+    pub async fn set_leverage(
+        &self,
+        inst: &str,
+        leverage: u32,
+        margin_mode: MarginMode,
+    ) -> InfraResult<()> {
+        if leverage == 0 {
+            return Err(InfraError::ApiCliError(
+                "Hyperliquid leverage must be greater than 0".into(),
+            ));
+        }
+
+        let normalized_inst = normalize_hyperliquid_cli_inst(inst);
+        if !is_hyperliquid_cli_perp_inst(&normalized_inst) {
+            return Err(InfraError::ApiCliError(
+                "Hyperliquid set_leverage supports perpetual instruments only".into(),
+            ));
+        }
+        self._ensure_perp_quote_matches(&normalized_inst)?;
+
+        let action = HyperliquidUpdateLeverageAction {
+            kind: "updateLeverage",
+            asset: self._inst_to_asset_id(&normalized_inst)?,
+            is_cross: match margin_mode {
+                MarginMode::Cross => true,
+                MarginMode::Isolated => false,
+                MarginMode::Unknown => {
+                    return Err(InfraError::ApiCliError(
+                        "Unknown margin mode for Hyperliquid set_leverage".into(),
+                    ));
+                },
+            },
+            leverage,
+        };
+
+        self.auth
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_signed_exchange_action_raw::<Value, _>(&self.client, &action)
+            .await?;
+
+        Ok(())
+    }
+
     async fn _get_candles(
         &self,
         inst: &str,
@@ -443,59 +496,6 @@ impl HyperliquidCli {
             ))?;
 
         Ok(book.into_orderbook_data(inst, depth))
-    }
-
-    pub async fn get_perps_at_open_interest_cap(&self) -> InfraResult<Vec<String>> {
-        let body = json!({
-            "type": "perpsAtOpenInterestCap",
-            "dex": self._perp_dex(),
-        });
-        let res: RestResHyperliquid<String> = self._post_info_raw(&body).await?;
-        res.into_vec()
-    }
-
-    pub async fn set_leverage(
-        &self,
-        inst: &str,
-        leverage: u32,
-        margin_mode: MarginMode,
-    ) -> InfraResult<()> {
-        if leverage == 0 {
-            return Err(InfraError::ApiCliError(
-                "Hyperliquid leverage must be greater than 0".into(),
-            ));
-        }
-
-        let normalized_inst = normalize_hyperliquid_cli_inst(inst);
-        if !is_hyperliquid_cli_perp_inst(&normalized_inst) {
-            return Err(InfraError::ApiCliError(
-                "Hyperliquid set_leverage supports perpetual instruments only".into(),
-            ));
-        }
-        self._ensure_perp_quote_matches(&normalized_inst)?;
-
-        let action = HyperliquidUpdateLeverageAction {
-            kind: "updateLeverage",
-            asset: self._inst_to_asset_id(&normalized_inst)?,
-            is_cross: match margin_mode {
-                MarginMode::Cross => true,
-                MarginMode::Isolated => false,
-                MarginMode::Unknown => {
-                    return Err(InfraError::ApiCliError(
-                        "Unknown margin mode for Hyperliquid set_leverage".into(),
-                    ));
-                },
-            },
-            leverage,
-        };
-
-        self.auth
-            .as_ref()
-            .ok_or(InfraError::ApiCliNotInitialized)?
-            .send_signed_exchange_action_raw::<Value, _>(&self.client, &action)
-            .await?;
-
-        Ok(())
     }
 
     async fn _get_instrument_info(

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest/cancel_order.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest/cancel_order.rs
@@ -1,12 +1,9 @@
 use serde::Deserialize;
 
-use crate::{
-    arch::market_assets::{
-        api_data::account_data::OrderAckData, api_general::get_micros_timestamp,
-        base_data::OrderStatus,
-    },
-    errors::{InfraError, InfraResult},
+use crate::arch::market_assets::{
+    api_data::account_data::OrderAckData, api_general::get_micros_timestamp, base_data::OrderStatus,
 };
+use crate::errors::{InfraError, InfraResult};
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct RestCancelAckHyperliquid {

--- a/src/arch/market_assets/exchange/okx/api_utils.rs
+++ b/src/arch/market_assets/exchange/okx/api_utils.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::json;
 use tracing::error;
 
@@ -92,6 +92,64 @@ pub fn okx_inst_to_cli(symbol: &str) -> String {
     }
 }
 
+pub(crate) fn de_okx_inst<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    String::deserialize(deserializer).map(|inst| okx_inst_to_cli(&inst))
+}
+
+pub(crate) fn de_okx_instrument_type<'de, D>(deserializer: D) -> Result<InstrumentType, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(
+        match String::deserialize(deserializer)?
+            .to_ascii_uppercase()
+            .as_str()
+        {
+            "SPOT" => InstrumentType::Spot,
+            "SWAP" => InstrumentType::Perpetual,
+            "FUTURES" => InstrumentType::Futures,
+            "OPTION" | "OPTIONS" => InstrumentType::Options,
+            _ => InstrumentType::Unknown,
+        },
+    )
+}
+
+pub(crate) fn de_okx_margin_mode<'de, D>(deserializer: D) -> Result<MarginMode, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(
+        match String::deserialize(deserializer)?
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "cross" => MarginMode::Cross,
+            "isolated" => MarginMode::Isolated,
+            _ => MarginMode::Unknown,
+        },
+    )
+}
+
+pub(crate) fn de_okx_position_side<'de, D>(deserializer: D) -> Result<PositionSide, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(
+        match String::deserialize(deserializer)?
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "long" => PositionSide::Long,
+            "short" => PositionSide::Short,
+            "net" => PositionSide::Both,
+            _ => PositionSide::Unknown,
+        },
+    )
+}
+
 pub fn okx_preopen_inst(symbol: &str) -> Option<(InstrumentType, String)> {
     let (inst_type, inst) = symbol.strip_prefix("LISTING-")?.split_once('-')?;
     if !inst.contains('-') {
@@ -124,7 +182,7 @@ pub fn okx_candle_interval(interval: &CandleParam) -> &str {
 /// Query parameters for retrieving public lead traders from OKX.
 /// All fields are optional and can be used to filter or paginate results.
 #[derive(Clone, Debug, Default)]
-pub struct PubLeadTraderQuery {
+pub struct OkxPublicLeadTradersReq {
     /// Instrument type: Spot / Perpetual / Option
     pub inst_type: Option<InstrumentType>,
     /// Sorting type: "overview" / "pnl" / "aum" / "win_ratio" / "pnl_ratio" / "current_copy_trader_pnl".
@@ -147,85 +205,6 @@ pub struct PubLeadTraderQuery {
     pub page: Option<u64>,
     /// Number of records per page
     pub limit: Option<u64>,
-}
-
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-pub struct LeadtraderSubposition {
-    pub timestamp: u64,
-    pub unique_code: String,
-    pub inst: String,
-    pub subpos_id: String,
-    pub pos_side: PositionSide,
-    pub margin_mode: MarginMode,
-    pub leverage: f64,
-    pub open_ts: u64,
-    pub open_avg_price: f64,
-    pub size: f64,
-    pub ins_type: InstrumentType,
-    pub margin: f64,
-}
-
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-pub struct LeadtraderSubpositionHistory {
-    pub timestamp: u64,
-    pub unique_code: String,
-    pub inst: String,
-    pub subpos_id: String,
-    pub pos_side: PositionSide,
-    pub margin_mode: MarginMode,
-    pub ins_type: InstrumentType,
-    pub leverage: f64,
-    pub size: f64,
-    pub margin: f64,
-    pub open_ts: u64,
-    pub open_avg_price: f64,
-    pub close_ts: u64,
-    pub close_avg_price: f64,
-    pub pnl: f64,
-    pub pnl_ratio: f64,
-}
-
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-pub struct CurrentLeadtrader {
-    pub timestamp: u64,
-    pub unique_code: String,
-    pub nick_name: String,
-    pub margin: f64,
-    pub copy_pnl: f64,
-    pub copy_amount: f64,
-}
-
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-pub struct PubLeadtraderInfo {
-    pub data_version: u64,
-    pub total_page: u64,
-    pub pub_leadtraders: Vec<PubLeadtrader>,
-}
-
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-pub struct PubLeadtrader {
-    pub unique_code: String,
-    pub nick_name: String,
-    pub aum: f64,
-    pub copy_state: u64,
-    pub copy_trader_num: u64,
-    pub max_copy_trader_num: u64,
-    pub accum_copy_trader_num: u64,
-    pub lead_days: u64,
-    pub win_ratio: f64,
-    pub pnl_ratio: f64,
-    pub pnl: f64,
-}
-
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-pub struct PubLeadtraderStats {
-    pub timestamp: u64,
-    pub win_ratio: f64,
-    pub profit_days: u64,
-    pub loss_days: f64,
-    pub invest_amount: f64,
-    pub avg_sub_pos_national: f64,
-    pub current_copy_trader_pnl: f64,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/arch/market_assets/exchange/okx/okx_cli.rs
+++ b/src/arch/market_assets/exchange/okx/okx_cli.rs
@@ -549,7 +549,7 @@ impl OkxCli {
     pub async fn get_current_lead_traders(
         &self,
         inst_type: Option<InstrumentType>,
-    ) -> InfraResult<Vec<CurrentLeadtrader>> {
+    ) -> InfraResult<Vec<RestLeadtraderOkx>> {
         let inst_type_str = match inst_type.unwrap_or(InstrumentType::Perpetual) {
             InstrumentType::Spot => "SPOT",
             InstrumentType::Futures => "FUTURES",
@@ -578,19 +578,13 @@ impl OkxCli {
             )
             .await?;
 
-        let data: Vec<CurrentLeadtrader> = res
-            .into_vec()?
-            .into_iter()
-            .map(CurrentLeadtrader::from)
-            .collect();
-
-        Ok(data)
+        res.into_vec()
     }
 
     pub async fn get_public_lead_traders(
         &self,
-        query: PubLeadTraderQuery,
-    ) -> InfraResult<PubLeadtraderInfo> {
+        query: OkxPublicLeadTradersReq,
+    ) -> InfraResult<RestPubLeadTradersOkx> {
         let inst_type_str = match query.inst_type.unwrap_or(InstrumentType::Perpetual) {
             InstrumentType::Spot => "SPOT",
             InstrumentType::Futures => "FUTURES",
@@ -649,7 +643,7 @@ impl OkxCli {
                 "No public lead traders data returned".into(),
             ))?;
 
-        Ok(PubLeadtraderInfo::from(data))
+        Ok(data)
     }
 
     pub async fn get_public_lead_trader_stats(
@@ -657,7 +651,7 @@ impl OkxCli {
         unique_code: &str,
         last_days: u64,
         inst_type: Option<InstrumentType>,
-    ) -> InfraResult<Vec<PubLeadtraderStats>> {
+    ) -> InfraResult<Vec<RestPubLeadTraderStatsOkx>> {
         let inst_type_str = match inst_type.unwrap_or(InstrumentType::Perpetual) {
             InstrumentType::Spot => "SPOT",
             InstrumentType::Futures => "FUTURES",
@@ -677,13 +671,7 @@ impl OkxCli {
         let res: RestResOkx<RestPubLeadTraderStatsOkx> =
             parse_json_response("Okx public_lead_trader_stats", response).await?;
 
-        let data = res
-            .into_vec()?
-            .into_iter()
-            .map(PubLeadtraderStats::from)
-            .collect();
-
-        Ok(data)
+        res.into_vec()
     }
 
     pub async fn get_lead_trader_subpositions(
@@ -691,7 +679,7 @@ impl OkxCli {
         unique_code: &str,
         inst_type: Option<InstrumentType>,
         limit: Option<u32>,
-    ) -> InfraResult<Vec<LeadtraderSubposition>> {
+    ) -> InfraResult<Vec<RestSubPositionOkx>> {
         let inst_type_str = match inst_type.unwrap_or(InstrumentType::Perpetual) {
             InstrumentType::Spot => "SPOT",
             InstrumentType::Futures => "FUTURES",
@@ -715,13 +703,7 @@ impl OkxCli {
         let res: RestResOkx<RestSubPositionOkx> =
             parse_json_response("Okx lead_trader_subpositions", response).await?;
 
-        let data = res
-            .into_vec()?
-            .into_iter()
-            .map(LeadtraderSubposition::from)
-            .collect();
-
-        Ok(data)
+        res.into_vec()
     }
 
     pub async fn get_lead_trader_subpositions_history(
@@ -731,7 +713,7 @@ impl OkxCli {
         limit: Option<u32>,
         before: Option<&str>,
         after: Option<&str>,
-    ) -> InfraResult<Vec<LeadtraderSubpositionHistory>> {
+    ) -> InfraResult<Vec<RestSubPositionHistoryOkx>> {
         let inst_type_str = match inst_type.unwrap_or(InstrumentType::Perpetual) {
             InstrumentType::Spot => "SPOT",
             InstrumentType::Futures => "FUTURES",
@@ -761,13 +743,7 @@ impl OkxCli {
         let res: RestResOkx<RestSubPositionHistoryOkx> =
             parse_json_response("Okx lead_trader_subpositions_history", response).await?;
 
-        let data: Vec<LeadtraderSubpositionHistory> = res
-            .into_vec()?
-            .into_iter()
-            .map(LeadtraderSubpositionHistory::from)
-            .collect();
-
-        Ok(data)
+        res.into_vec()
     }
 
     pub async fn get_funding_rate_info(

--- a/src/arch/market_assets/exchange/okx/schemas/rest/asset_deposit_history.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/rest/asset_deposit_history.rs
@@ -1,5 +1,7 @@
 use serde::Deserialize;
 
+use crate::arch::market_assets::api_general::de_micros_from_int;
+
 #[allow(non_snake_case)]
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct RestAssetDepositHistoryOkx {
@@ -19,8 +21,8 @@ pub struct RestAssetDepositHistoryOkx {
     pub areaCodeTo: String,
     #[serde(default)]
     pub txId: String,
-    #[serde(default)]
-    pub ts: String,
+    #[serde(default, deserialize_with = "de_micros_from_int")]
+    pub ts: u64,
     #[serde(default)]
     pub state: String,
     #[serde(default)]

--- a/src/arch/market_assets/exchange/okx/schemas/rest/asset_withdrawal_history.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/rest/asset_withdrawal_history.rs
@@ -1,5 +1,8 @@
-use serde::Deserialize;
 use std::collections::HashMap;
+
+use serde::Deserialize;
+
+use crate::arch::market_assets::api_general::de_micros_from_int;
 
 #[allow(non_snake_case)]
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -32,8 +35,8 @@ pub struct RestAssetWithdrawalHistoryOkx {
     pub addrEx: HashMap<String, String>,
     #[serde(default)]
     pub txId: String,
-    #[serde(default)]
-    pub ts: String,
+    #[serde(default, deserialize_with = "de_micros_from_int")]
+    pub ts: u64,
     #[serde(default)]
     pub state: String,
     #[serde(default)]

--- a/src/arch/market_assets/exchange/okx/schemas/rest/ct_current_lead_traders.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/rest/ct_current_lead_traders.rs
@@ -1,9 +1,5 @@
 use serde::Deserialize;
 
-use crate::arch::market_assets::{
-    api_general::get_micros_timestamp, exchange::okx::api_utils::CurrentLeadtrader,
-};
-
 #[allow(non_snake_case)]
 #[derive(Clone, Debug, Deserialize)]
 pub struct RestLeadtraderOkx {
@@ -19,16 +15,4 @@ pub struct RestLeadtraderOkx {
     pub todayPnl: String,
     pub uniqueCode: String,
     pub upl: String,
-}
-impl From<RestLeadtraderOkx> for CurrentLeadtrader {
-    fn from(d: RestLeadtraderOkx) -> Self {
-        CurrentLeadtrader {
-            timestamp: get_micros_timestamp(),
-            unique_code: d.uniqueCode,
-            nick_name: d.nickName,
-            margin: d.margin.parse().unwrap_or_default(),
-            copy_pnl: d.copyTotalPnl.parse().unwrap_or_default(),
-            copy_amount: d.copyTotalAmt.parse().unwrap_or_default(),
-        }
-    }
 }

--- a/src/arch/market_assets/exchange/okx/schemas/rest/ct_public_current_subpositions.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/rest/ct_public_current_subpositions.rs
@@ -1,66 +1,32 @@
 use serde::Deserialize;
 
 use crate::arch::market_assets::{
-    api_general::{get_micros_timestamp, ts_to_micros},
     base_data::{InstrumentType, MarginMode, PositionSide},
-    exchange::okx::api_utils::{LeadtraderSubposition, okx_inst_to_cli},
+    exchange::okx::api_utils::{
+        de_okx_inst, de_okx_instrument_type, de_okx_margin_mode, de_okx_position_side,
+    },
 };
 
 #[allow(non_snake_case)]
 #[derive(Clone, Debug, Deserialize)]
 pub struct RestSubPositionOkx {
+    #[serde(deserialize_with = "de_okx_inst")]
     pub instId: String,
     pub subPosId: String,
-    pub posSide: String,
-    pub mgnMode: String,
+    #[serde(deserialize_with = "de_okx_position_side")]
+    pub posSide: PositionSide,
+    #[serde(deserialize_with = "de_okx_margin_mode")]
+    pub mgnMode: MarginMode,
     pub lever: String,
     pub openAvgPx: String,
     pub openTime: String,
     pub subPos: String,
-    pub instType: String,
+    #[serde(deserialize_with = "de_okx_instrument_type")]
+    pub instType: InstrumentType,
     pub margin: String,
     pub upl: String,
     pub uplRatio: String,
     pub markPx: Option<String>,
     pub uniqueCode: String,
     pub ccy: String,
-}
-
-impl From<RestSubPositionOkx> for LeadtraderSubposition {
-    fn from(d: RestSubPositionOkx) -> Self {
-        let size_val = d.subPos.parse::<f64>().unwrap_or_default();
-
-        LeadtraderSubposition {
-            timestamp: get_micros_timestamp(),
-            unique_code: d.uniqueCode,
-            inst: okx_inst_to_cli(&d.instId),
-            subpos_id: d.subPosId,
-            pos_side: match d.posSide.to_lowercase().as_str() {
-                "long" => PositionSide::Long,
-                "short" => PositionSide::Short,
-                _ => {
-                    if size_val >= 0.0 {
-                        PositionSide::Long
-                    } else {
-                        PositionSide::Short
-                    }
-                },
-            },
-            margin_mode: match d.mgnMode.to_lowercase().as_str() {
-                "cross" => MarginMode::Cross,
-                "isolated" => MarginMode::Isolated,
-                _ => MarginMode::Cross,
-            },
-            leverage: d.lever.parse().unwrap_or_default(),
-            open_ts: ts_to_micros(d.openTime.parse().unwrap_or_default()),
-            open_avg_price: d.openAvgPx.parse().unwrap_or_default(),
-            size: size_val,
-            ins_type: match d.instType.to_uppercase().as_str() {
-                "SWAP" => InstrumentType::Perpetual,
-                "SPOT" => InstrumentType::Spot,
-                _ => InstrumentType::Spot,
-            },
-            margin: d.margin.parse().unwrap_or_default(),
-        }
-    }
 }

--- a/src/arch/market_assets/exchange/okx/schemas/rest/ct_public_lead_trader_stats.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/rest/ct_public_lead_trader_stats.rs
@@ -1,9 +1,5 @@
 use serde::Deserialize;
 
-use crate::arch::market_assets::{
-    api_general::get_micros_timestamp, exchange::okx::api_utils::PubLeadtraderStats,
-};
-
 #[allow(non_snake_case)]
 #[derive(Clone, Debug, Deserialize)]
 pub struct RestPubLeadTraderStatsOkx {
@@ -14,18 +10,4 @@ pub struct RestPubLeadTraderStatsOkx {
     pub avgSubPosNotional: String,
     pub investAmt: String,
     pub ccy: String,
-}
-
-impl From<RestPubLeadTraderStatsOkx> for PubLeadtraderStats {
-    fn from(d: RestPubLeadTraderStatsOkx) -> Self {
-        PubLeadtraderStats {
-            timestamp: get_micros_timestamp(),
-            win_ratio: d.winRatio.parse().unwrap_or_default(),
-            profit_days: d.profitDays.parse().unwrap_or_default(),
-            loss_days: d.lossDays.parse().unwrap_or_default(),
-            invest_amount: d.investAmt.parse().unwrap_or_default(),
-            avg_sub_pos_national: d.avgSubPosNotional.parse().unwrap_or_default(),
-            current_copy_trader_pnl: d.curCopyTraderPnl.parse().unwrap_or_default(),
-        }
-    }
 }

--- a/src/arch/market_assets/exchange/okx/schemas/rest/ct_public_lead_traders.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/rest/ct_public_lead_traders.rs
@@ -1,7 +1,5 @@
 use serde::Deserialize;
 
-use crate::arch::market_assets::exchange::okx::api_utils::{PubLeadtrader, PubLeadtraderInfo};
-
 #[allow(non_snake_case)]
 #[derive(Clone, Debug, Deserialize)]
 pub struct RestPubLeadTradersOkx {
@@ -26,32 +24,4 @@ pub struct RankInfo {
     pub leadDays: String,         // Number of lead-trading days
     pub pnl: String,              // Profit and loss in the past 90 days (unit: USDT)
     pub pnlRatio: String,         // Profit and loss ratio in the past 90 days
-}
-
-impl From<RestPubLeadTradersOkx> for PubLeadtraderInfo {
-    fn from(d: RestPubLeadTradersOkx) -> Self {
-        let traders = d
-            .ranks
-            .into_iter()
-            .map(|r| PubLeadtrader {
-                unique_code: r.uniqueCode,
-                nick_name: r.nickName,
-                aum: r.aum.parse().unwrap_or_default(),
-                copy_state: r.copyState.parse().unwrap_or_default(),
-                copy_trader_num: r.copyTraderNum.parse().unwrap_or_default(),
-                max_copy_trader_num: r.maxCopyTraderNum.parse().unwrap_or_default(),
-                accum_copy_trader_num: r.accCopyTraderNum.parse().unwrap_or_default(),
-                lead_days: r.leadDays.parse().unwrap_or_default(),
-                win_ratio: r.winRatio.parse().unwrap_or_default(),
-                pnl_ratio: r.pnlRatio.parse().unwrap_or_default(),
-                pnl: r.pnl.parse().unwrap_or_default(),
-            })
-            .collect();
-
-        PubLeadtraderInfo {
-            data_version: d.dataVer.parse().unwrap_or_default(),
-            total_page: d.totalPage.parse().unwrap_or_default(),
-            pub_leadtraders: traders,
-        }
-    }
 }

--- a/src/arch/market_assets/exchange/okx/schemas/rest/ct_public_subpositions_history.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/rest/ct_public_subpositions_history.rs
@@ -1,18 +1,22 @@
 use serde::Deserialize;
 
 use crate::arch::market_assets::{
-    api_general::{get_micros_timestamp, ts_to_micros},
     base_data::{InstrumentType, MarginMode, PositionSide},
-    exchange::okx::api_utils::{LeadtraderSubpositionHistory, okx_inst_to_cli},
+    exchange::okx::api_utils::{
+        de_okx_inst, de_okx_instrument_type, de_okx_margin_mode, de_okx_position_side,
+    },
 };
 
 #[allow(non_snake_case)]
 #[derive(Clone, Debug, Deserialize)]
 pub struct RestSubPositionHistoryOkx {
+    #[serde(deserialize_with = "de_okx_inst")]
     pub instId: String,
     pub subPosId: String,
-    pub posSide: String,
-    pub mgnMode: String,
+    #[serde(deserialize_with = "de_okx_position_side")]
+    pub posSide: PositionSide,
+    #[serde(deserialize_with = "de_okx_margin_mode")]
+    pub mgnMode: MarginMode,
     pub lever: String,
     pub openAvgPx: String,
     pub openTime: String,
@@ -21,60 +25,9 @@ pub struct RestSubPositionHistoryOkx {
     pub closeAvgPx: Option<String>,
     pub pnl: Option<String>,
     pub pnlRatio: Option<String>,
-    pub instType: String,
+    #[serde(deserialize_with = "de_okx_instrument_type")]
+    pub instType: InstrumentType,
     pub margin: String,
     pub ccy: String,
     pub uniqueCode: String,
-}
-
-impl From<RestSubPositionHistoryOkx> for LeadtraderSubpositionHistory {
-    fn from(d: RestSubPositionHistoryOkx) -> Self {
-        let size_val = d.subPos.parse::<f64>().unwrap_or_default();
-
-        LeadtraderSubpositionHistory {
-            timestamp: get_micros_timestamp(),
-            unique_code: d.uniqueCode,
-            inst: okx_inst_to_cli(&d.instId),
-            subpos_id: d.subPosId,
-            pos_side: match d.posSide.to_lowercase().as_str() {
-                "long" => PositionSide::Long,
-                "short" => PositionSide::Short,
-                _ => {
-                    if size_val >= 0.0 {
-                        PositionSide::Long
-                    } else {
-                        PositionSide::Short
-                    }
-                },
-            },
-            margin_mode: match d.mgnMode.to_lowercase().as_str() {
-                "cross" => MarginMode::Cross,
-                "isolated" => MarginMode::Isolated,
-                _ => MarginMode::Cross,
-            },
-            ins_type: match d.instType.to_uppercase().as_str() {
-                "SWAP" => InstrumentType::Perpetual,
-                "SPOT" => InstrumentType::Spot,
-                _ => InstrumentType::Spot,
-            },
-            leverage: d.lever.parse().unwrap_or_default(),
-            size: size_val,
-            margin: d.margin.parse().unwrap_or_default(),
-            open_ts: ts_to_micros(d.openTime.parse().unwrap_or_default()),
-            open_avg_price: d.openAvgPx.parse().unwrap_or_default(),
-            close_ts: d
-                .closeTime
-                .map(|t| ts_to_micros(t.parse().unwrap_or_default()))
-                .unwrap_or_default(),
-            close_avg_price: d
-                .closeAvgPx
-                .and_then(|p| p.parse().ok())
-                .unwrap_or_default(),
-            pnl: d.pnl.and_then(|p| p.parse().ok()).unwrap_or_default(),
-            pnl_ratio: d
-                .pnlRatio
-                .map(|r| r.parse().unwrap_or_default())
-                .unwrap_or_default(),
-        }
-    }
 }

--- a/src/arch/strategy_base/handler/task_channel.rs
+++ b/src/arch/strategy_base/handler/task_channel.rs
@@ -5,22 +5,18 @@ use std::{
 
 use tokio::sync::broadcast;
 
-use crate::{
-    arch::{
-        strategy_base::handler::events::{
-            alt_events::{AltIntent, AltOrder, AltScheduleEvent, AltTensor},
-            lob_events::{
-                WsAccBalPos, WsAccOrder, WsAccPosition, WsCandle, WsLob, WsLobMbo, WsTrade,
-            },
-        },
-        task_execution::{
-            TaskKey,
-            task_alt::{AltTaskInfo, AltTaskType},
-            task_ws::{WsChannel, WsTaskInfo},
-        },
+use crate::arch::{
+    strategy_base::handler::events::{
+        alt_events::{AltIntent, AltOrder, AltScheduleEvent, AltTensor},
+        lob_events::{WsAccBalPos, WsAccOrder, WsAccPosition, WsCandle, WsLob, WsLobMbo, WsTrade},
     },
-    errors::{InfraError, InfraResult},
+    task_execution::{
+        TaskKey,
+        task_alt::{AltTaskInfo, AltTaskType},
+        task_ws::{WsChannel, WsTaskInfo},
+    },
 };
+use crate::errors::{InfraError, InfraResult};
 
 pub use super::events::InfraMsg;
 

--- a/src/arch/task_execution/alt_runner/model_onnx.rs
+++ b/src/arch/task_execution/alt_runner/model_onnx.rs
@@ -12,10 +12,10 @@ use tract_onnx::prelude::{
     tvec,
 };
 
-use crate::{
-    arch::{strategy_base::handler::alt_events::AltTensor, task_execution::task_general::LogLevel},
-    errors::{InfraError, InfraResult},
+use crate::arch::{
+    strategy_base::handler::alt_events::AltTensor, task_execution::task_general::LogLevel,
 };
+use crate::errors::{InfraError, InfraResult};
 
 use super::AltTaskRunner;
 


### PR DESCRIPTION
## Summary

- organize imports and exchange API methods without changing runtime behavior
- return raw OKX REST response models from the copy-trading endpoints instead of lossy intermediate models
- normalize subposition `instId`, `instType`, `mgnMode`, and `posSide` while preserving other exchange response fields
- expose deposit and withdrawal history timestamps as infra microseconds
- rename `PubLeadTraderQuery` to `OkxPublicLeadTradersReq`

## Breaking API changes

- five OKX copy-trading methods now return their `Rest*Okx` response models
- removed the converted copy-trading model types from `okx::api_utils`
- `RestAssetDepositHistoryOkx::ts` and `RestAssetWithdrawalHistoryOkx::ts` changed from `String` milliseconds to `u64` microseconds
- subposition `posSide`, `mgnMode`, and `instType` fields now use infra enums; unknown values map to `Unknown`
- `PubLeadTraderQuery` was renamed to `OkxPublicLeadTradersReq`

## Validation

- `cargo fmt --all -- --check`
- `cargo check --all-features --all-targets`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test --all-features --all-targets` (150 unit tests and 7 integration tests)