### PR TITLE
fix(okx): zero-pad timestamp milliseconds

### DIFF
--- a/src/arch/market_assets/exchange/okx/api_utils.rs
+++ b/src/arch/market_assets/exchange/okx/api_utils.rs
@@ -38,7 +38,7 @@ pub fn get_okx_timestamp() -> String {
     let seconds = now.as_secs();
     let millis = now.subsec_millis();
 
-    format!("{}.{}", seconds, millis)
+    format!("{}.{:03}", seconds, millis)
 }
 
 pub fn cli_perp_to_okx_inst(symbol: &str) -> String {


### PR DESCRIPTION
## Summary

- format OKX authentication timestamps with exactly three millisecond digits
- avoid interpreting values such as 5 ms as `.5` (500 ms)

## Validation

- `cargo fmt --all -- --check`
- `cargo check --all-features --all-targets`
- `cargo clippy --all-features --all-targets -- -D warnings`
- Linux x86_64 release build of `api_checker` against the local infra path
- Large PO read-only `okx_settings show`: authentication succeeded and returned account configuration (`posMode=net_mode`)

No order, transfer, withdrawal, or account setting mutation was performed.