### PR TITLE
chore: prepare v0.3.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 
 readme = "README.md"


### PR DESCRIPTION
## Summary

- bump `extrema_infra` from 0.3.3 to 0.3.4

## Verification

- `cargo fmt --all -- --check`
- `cargo check --all-features --all-targets`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test --all-features` (150 unit, 7 integration, 9 doc tests passed; 6 doc tests ignored)
- `cargo publish --dry-run --all-features --allow-dirty`
- `git diff --check`