### PR TITLE
feat(okx): add raw order query APIs

### DIFF
--- a/src/arch/market_assets/exchange/okx/api_utils.rs
+++ b/src/arch/market_assets/exchange/okx/api_utils.rs
@@ -179,6 +179,127 @@ pub fn okx_candle_interval(interval: &CandleParam) -> &str {
     }
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OkxOpenOrdersReq {
+    pub inst_type: Option<String>,
+    pub inst_family: Option<String>,
+    pub inst_id: Option<String>,
+    pub ord_type: Option<String>,
+    pub state: Option<String>,
+    pub after: Option<String>,
+    pub before: Option<String>,
+    pub limit: Option<u32>,
+}
+
+impl OkxOpenOrdersReq {
+    pub(crate) fn to_query_body(&self) -> String {
+        let mut parts = Vec::new();
+
+        if let Some(value) = self.inst_type.as_deref() {
+            parts.push(format!("instType={value}"));
+        }
+        if let Some(value) = self.inst_family.as_deref() {
+            parts.push(format!("instFamily={value}"));
+        }
+        if let Some(value) = self.inst_id.as_deref() {
+            parts.push(format!("instId={value}"));
+        }
+        if let Some(value) = self.ord_type.as_deref() {
+            parts.push(format!("ordType={value}"));
+        }
+        if let Some(value) = self.state.as_deref() {
+            parts.push(format!("state={value}"));
+        }
+        if let Some(value) = self.after.as_deref() {
+            parts.push(format!("after={value}"));
+        }
+        if let Some(value) = self.before.as_deref() {
+            parts.push(format!("before={value}"));
+        }
+        if let Some(value) = self.limit {
+            parts.push(format!("limit={value}"));
+        }
+
+        parts.join("&")
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OkxOrderHistoryReq {
+    pub inst_type: String,
+    pub inst_family: Option<String>,
+    pub inst_id: Option<String>,
+    pub ord_type: Option<String>,
+    pub state: Option<String>,
+    pub category: Option<String>,
+    pub after: Option<String>,
+    pub before: Option<String>,
+    pub begin: Option<u64>,
+    pub end: Option<u64>,
+    pub limit: Option<u32>,
+}
+
+impl OkxOrderHistoryReq {
+    pub(crate) fn to_query_body(&self) -> String {
+        let mut parts = vec![format!("instType={}", self.inst_type)];
+
+        if let Some(value) = self.inst_family.as_deref() {
+            parts.push(format!("instFamily={value}"));
+        }
+        if let Some(value) = self.inst_id.as_deref() {
+            parts.push(format!("instId={value}"));
+        }
+        if let Some(value) = self.ord_type.as_deref() {
+            parts.push(format!("ordType={value}"));
+        }
+        if let Some(value) = self.state.as_deref() {
+            parts.push(format!("state={value}"));
+        }
+        if let Some(value) = self.category.as_deref() {
+            parts.push(format!("category={value}"));
+        }
+        if let Some(value) = self.after.as_deref() {
+            parts.push(format!("after={value}"));
+        }
+        if let Some(value) = self.before.as_deref() {
+            parts.push(format!("before={value}"));
+        }
+        if let Some(value) = self.begin {
+            parts.push(format!("begin={value}"));
+        }
+        if let Some(value) = self.end {
+            parts.push(format!("end={value}"));
+        }
+        if let Some(value) = self.limit {
+            parts.push(format!("limit={value}"));
+        }
+
+        parts.join("&")
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OkxOrderReq {
+    pub inst_id: String,
+    pub ord_id: Option<String>,
+    pub cl_ord_id: Option<String>,
+}
+
+impl OkxOrderReq {
+    pub(crate) fn to_query_body(&self) -> String {
+        let mut parts = vec![format!("instId={}", self.inst_id)];
+
+        if let Some(value) = self.ord_id.as_deref() {
+            parts.push(format!("ordId={value}"));
+        }
+        if let Some(value) = self.cl_ord_id.as_deref() {
+            parts.push(format!("clOrdId={value}"));
+        }
+
+        parts.join("&")
+    }
+}
+
 /// Query parameters for retrieving public lead traders from OKX.
 /// All fields are optional and can be used to filter or paginate results.
 #[derive(Clone, Debug, Default)]
@@ -430,5 +551,60 @@ mod tests {
             Some((InstrumentType::Perpetual, "SLX-USDT-SWAP".into()))
         );
         assert_eq!(okx_preopen_inst("SLX-USDT"), None);
+    }
+
+    #[test]
+    fn builds_open_orders_native_query() {
+        let req = OkxOpenOrdersReq {
+            inst_type: Some("SWAP".into()),
+            inst_family: Some("BTC-USDT".into()),
+            inst_id: Some("BTC-USDT-SWAP".into()),
+            ord_type: Some("limit,post_only".into()),
+            state: Some("live".into()),
+            after: Some("100".into()),
+            before: Some("200".into()),
+            limit: Some(50),
+        };
+
+        assert_eq!(
+            req.to_query_body(),
+            "instType=SWAP&instFamily=BTC-USDT&instId=BTC-USDT-SWAP&ordType=limit,post_only&state=live&after=100&before=200&limit=50"
+        );
+    }
+
+    #[test]
+    fn builds_order_history_native_query() {
+        let req = OkxOrderHistoryReq {
+            inst_type: "SWAP".into(),
+            inst_family: Some("BTC-USDT".into()),
+            inst_id: Some("BTC-USDT-SWAP".into()),
+            ord_type: Some("limit".into()),
+            state: Some("filled".into()),
+            category: Some("twap".into()),
+            after: Some("100".into()),
+            before: Some("200".into()),
+            begin: Some(1_720_000_000_000),
+            end: Some(1_720_000_060_000),
+            limit: Some(25),
+        };
+
+        assert_eq!(
+            req.to_query_body(),
+            "instType=SWAP&instFamily=BTC-USDT&instId=BTC-USDT-SWAP&ordType=limit&state=filled&category=twap&after=100&before=200&begin=1720000000000&end=1720000060000&limit=25"
+        );
+    }
+
+    #[test]
+    fn builds_order_detail_native_query() {
+        let req = OkxOrderReq {
+            inst_id: "BTC-USDT-SWAP".into(),
+            ord_id: Some("12345".into()),
+            cl_ord_id: Some("entry-1".into()),
+        };
+
+        assert_eq!(
+            req.to_query_body(),
+            "instId=BTC-USDT-SWAP&ordId=12345&clOrdId=entry-1"
+        );
     }
 }

--- a/src/arch/market_assets/exchange/okx/okx_cli.rs
+++ b/src/arch/market_assets/exchange/okx/okx_cli.rs
@@ -220,6 +220,91 @@ impl OkxCli {
         Ok(msg.to_string())
     }
 
+    pub async fn get_open_orders_raw(
+        &self,
+        req: OkxOpenOrdersReq,
+    ) -> InfraResult<Vec<RestOrderHistoryOkx>> {
+        let body = req.to_query_body();
+        let res: RestResOkx<RestOrderHistoryOkx> = self
+            .api_key
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_signed_request(
+                &self.client,
+                RequestMethod::Get,
+                body,
+                OKX_BASE_URL,
+                OKX_TRADE_ORDERS_PENDING,
+            )
+            .await?;
+
+        res.into_vec()
+    }
+
+    pub async fn get_order_history_raw(
+        &self,
+        req: OkxOrderHistoryReq,
+    ) -> InfraResult<Vec<RestOrderHistoryOkx>> {
+        if req.inst_type.trim().is_empty() {
+            return Err(InfraError::ApiCliError(
+                "OKX order history requires instType".into(),
+            ));
+        }
+
+        let body = req.to_query_body();
+        let res: RestResOkx<RestOrderHistoryOkx> = self
+            .api_key
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_signed_request(
+                &self.client,
+                RequestMethod::Get,
+                body,
+                OKX_BASE_URL,
+                OKX_TRADE_ORDERS_HISTORY,
+            )
+            .await?;
+
+        res.into_vec()
+    }
+
+    pub async fn get_order_raw(&self, req: OkxOrderReq) -> InfraResult<Vec<RestOrderHistoryOkx>> {
+        if req.inst_id.trim().is_empty() {
+            return Err(InfraError::ApiCliError(
+                "OKX order detail requires instId".into(),
+            ));
+        }
+        let has_ord_id = req
+            .ord_id
+            .as_deref()
+            .is_some_and(|id| !id.trim().is_empty());
+        let has_cl_ord_id = req
+            .cl_ord_id
+            .as_deref()
+            .is_some_and(|id| !id.trim().is_empty());
+        if !has_ord_id && !has_cl_ord_id {
+            return Err(InfraError::ApiCliError(
+                "OKX order detail requires ordId or clOrdId".into(),
+            ));
+        }
+
+        let body = req.to_query_body();
+        let res: RestResOkx<RestOrderHistoryOkx> = self
+            .api_key
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_signed_request(
+                &self.client,
+                RequestMethod::Get,
+                body,
+                OKX_BASE_URL,
+                OKX_TRADE_ORDER,
+            )
+            .await?;
+
+        res.into_vec()
+    }
+
     pub async fn get_account_config(&self) -> InfraResult<Vec<RestAccountConfigOkx>> {
         let res: RestResOkx<RestAccountConfigOkx> = self
             .api_key
@@ -1197,12 +1282,16 @@ impl OkxCli {
         let mut after = None;
 
         loop {
-            let page_data = self
-                ._get_open_orders_page(inst, page_limit, after.as_deref())
-                .await?;
-            let page_len = page_data.len();
-            let next_after = page_data.last().map(|order| order.order_id.clone());
-            data.extend(page_data);
+            let req = OkxOpenOrdersReq {
+                inst_id: Some(cli_perp_to_okx_inst(inst)),
+                after: after.clone(),
+                limit: Some(page_limit),
+                ..Default::default()
+            };
+            let page = self.get_open_orders_raw(req).await?;
+            let page_len = page.len();
+            let next_after = page.last().map(|order| order.ordId.clone());
+            data.extend(page.into_iter().map(OrderDetailData::from));
 
             if let Some(limit) = limit
                 && data.len() >= limit as usize
@@ -1225,39 +1314,6 @@ impl OkxCli {
         Ok(data)
     }
 
-    async fn _get_open_orders_page(
-        &self,
-        inst: &str,
-        limit: u32,
-        after: Option<&str>,
-    ) -> InfraResult<Vec<OrderDetailData>> {
-        let mut query = format!("instId={}&limit={limit}", cli_perp_to_okx_inst(inst));
-        if let Some(after) = after {
-            query.push_str(&format!("&after={after}"));
-        }
-
-        let res: RestResOkx<RestOrderHistoryOkx> = self
-            .api_key
-            .as_ref()
-            .ok_or(InfraError::ApiCliNotInitialized)?
-            .send_signed_request(
-                &self.client,
-                RequestMethod::Get,
-                query,
-                OKX_BASE_URL,
-                OKX_TRADE_ORDERS_PENDING,
-            )
-            .await?;
-
-        let data = res
-            .into_vec()?
-            .into_iter()
-            .map(OrderDetailData::from)
-            .collect();
-
-        Ok(data)
-    }
-
     async fn _get_order_history(
         &self,
         inst: &str,
@@ -1267,42 +1323,26 @@ impl OkxCli {
         order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
         let okx_inst = cli_perp_to_okx_inst(inst);
-        let mut query = format!("instId={}", okx_inst);
-        let endpoint = if let Some(order_id) = order_id {
-            query.push_str(&format!("&ordId={}", order_id));
-            OKX_TRADE_ORDER
+        let raw = if let Some(order_id) = order_id {
+            self.get_order_raw(OkxOrderReq {
+                inst_id: okx_inst,
+                ord_id: Some(order_id.into()),
+                cl_ord_id: None,
+            })
+            .await?
         } else {
-            query.push_str("&instType=SWAP");
-            if let Some(start_time_us) = start_time_us {
-                query.push_str(&format!("&begin={}", micros_to_millis(start_time_us)));
-            }
-            if let Some(end_time_us) = end_time_us {
-                query.push_str(&format!("&end={}", micros_to_millis(end_time_us)));
-            }
-            if let Some(limit) = limit {
-                query.push_str(&format!("&limit={}", limit));
-            }
-            OKX_TRADE_ORDERS_HISTORY
+            self.get_order_history_raw(OkxOrderHistoryReq {
+                inst_type: "SWAP".into(),
+                inst_id: Some(okx_inst),
+                begin: start_time_us.map(micros_to_millis),
+                end: end_time_us.map(micros_to_millis),
+                limit,
+                ..Default::default()
+            })
+            .await?
         };
 
-        let res: RestResOkx<RestOrderHistoryOkx> = self
-            .api_key
-            .as_ref()
-            .ok_or(InfraError::ApiCliNotInitialized)?
-            .send_signed_request(
-                &self.client,
-                RequestMethod::Get,
-                query,
-                OKX_BASE_URL,
-                endpoint,
-            )
-            .await?;
-
-        let data: Vec<OrderDetailData> = res
-            .into_vec()?
-            .into_iter()
-            .map(OrderDetailData::from)
-            .collect();
+        let data = raw.into_iter().map(OrderDetailData::from).collect();
 
         Ok(data)
     }

--- a/src/arch/market_assets/exchange/okx/schemas/rest/order_history.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/rest/order_history.rs
@@ -10,15 +10,53 @@ use crate::arch::market_assets::{
 };
 
 #[allow(non_snake_case)]
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct RestAttachedAlgoOrderOkx {
+    pub activePx: Option<String>,
+    pub amendPxOnTriggerType: Option<String>,
+    pub attachAlgoClOrdId: Option<String>,
+    pub attachAlgoId: Option<String>,
+    pub callbackRatio: Option<String>,
+    pub callbackSpread: Option<String>,
+    pub failCode: Option<String>,
+    pub failReason: Option<String>,
+    pub percent: Option<String>,
+    pub slOrdPx: Option<String>,
+    pub slTriggerPx: Option<String>,
+    pub slTriggerPxType: Option<String>,
+    pub slTriggerRatio: Option<String>,
+    pub sz: Option<String>,
+    pub tpOrdKind: Option<String>,
+    pub tpOrdPx: Option<String>,
+    pub tpTriggerPx: Option<String>,
+    pub tpTriggerPxType: Option<String>,
+    pub tpTriggerRatio: Option<String>,
+}
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct RestLinkedAlgoOrderOkx {
+    pub algoId: Option<String>,
+}
+
+#[allow(non_snake_case)]
 #[derive(Clone, Debug, Deserialize)]
 pub struct RestOrderHistoryOkx {
+    pub instType: Option<String>,
     pub instId: String,
     pub ordId: String,
     pub clOrdId: Option<String>,
+    pub algoClOrdId: Option<String>,
+    pub algoId: Option<String>,
+    pub attachAlgoClOrdId: Option<String>,
     pub side: String,
     pub posSide: Option<String>,
+    pub tdMode: Option<String>,
     pub ordType: String,
     pub state: String,
+    pub category: Option<String>,
+    pub source: Option<String>,
+    pub isTpLimit: Option<String>,
     pub px: Option<String>,
     pub sz: String,
     pub accFillSz: Option<String>,
@@ -30,6 +68,15 @@ pub struct RestOrderHistoryOkx {
     pub cTime: Option<String>,
     pub uTime: Option<String>,
     pub fillTime: Option<String>,
+    #[serde(default)]
+    pub attachAlgoOrds: Vec<RestAttachedAlgoOrderOkx>,
+    pub linkedAlgoOrd: Option<RestLinkedAlgoOrderOkx>,
+    pub tpOrdPx: Option<String>,
+    pub tpTriggerPx: Option<String>,
+    pub tpTriggerPxType: Option<String>,
+    pub slOrdPx: Option<String>,
+    pub slTriggerPx: Option<String>,
+    pub slTriggerPxType: Option<String>,
 }
 
 impl From<RestOrderHistoryOkx> for OrderDetailData {
@@ -119,5 +166,145 @@ fn parse_order_kind(ord_type: &str) -> (OrderType, Option<TimeInForce>) {
             warn!("Unknown OKX order type: {}", other);
             (OrderType::Unknown, None)
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn order_fixture() -> serde_json::Value {
+        serde_json::from_str(
+            r#"{
+                "instId": "BTC-USDT-SWAP",
+                "instType": "SWAP",
+                "ordId": "12345",
+                "clOrdId": "entry-1",
+                "algoClOrdId": "",
+                "algoId": "",
+                "attachAlgoClOrdId": "bracket-1",
+                "side": "buy",
+                "posSide": "long",
+                "tdMode": "cross",
+                "ordType": "limit",
+                "state": "filled",
+                "category": "normal",
+                "source": "",
+                "isTpLimit": "false",
+                "px": "100",
+                "sz": "3",
+                "accFillSz": "3",
+                "fillSz": "1",
+                "avgPx": "100.1",
+                "fee": "-0.01",
+                "feeCcy": "USDT",
+                "reduceOnly": "false",
+                "cTime": "1720000000000",
+                "uTime": "1720000001000",
+                "fillTime": "1720000000900",
+                "tpOrdPx": "103.1",
+                "tpTriggerPx": "103",
+                "tpTriggerPxType": "last",
+                "slOrdPx": "-1",
+                "slTriggerPx": "95",
+                "slTriggerPxType": "mark",
+                "linkedAlgoOrd": {"algoId": "linked-1"},
+                "attachAlgoOrds": [
+                    {
+                        "activePx": "",
+                        "amendPxOnTriggerType": "1",
+                        "attachAlgoClOrdId": "tp-1",
+                        "attachAlgoId": "algo-1",
+                        "callbackRatio": "",
+                        "callbackSpread": "",
+                        "failCode": "",
+                        "failReason": "",
+                        "percent": "",
+                        "slOrdPx": "-1",
+                        "slTriggerPx": "95",
+                        "slTriggerPxType": "mark",
+                        "slTriggerRatio": "",
+                        "sz": "1",
+                        "tpOrdKind": "condition",
+                        "tpOrdPx": "101.1",
+                        "tpTriggerPx": "101",
+                        "tpTriggerPxType": "last",
+                        "tpTriggerRatio": ""
+                    },
+                    {
+                        "attachAlgoClOrdId": "tp-2",
+                        "attachAlgoId": "algo-2",
+                        "sz": "2",
+                        "tpOrdKind": "condition",
+                        "tpOrdPx": "102.1",
+                        "tpTriggerPx": "102",
+                        "tpTriggerPxType": "mark"
+                    }
+                ]
+            }"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn deserializes_attached_and_top_level_tp_sl_fields() {
+        let order: RestOrderHistoryOkx = serde_json::from_value(order_fixture()).unwrap();
+
+        assert_eq!(order.attachAlgoOrds.len(), 2);
+        assert_eq!(order.instType.as_deref(), Some("SWAP"));
+        assert_eq!(order.category.as_deref(), Some("normal"));
+        assert_eq!(order.source.as_deref(), Some(""));
+        assert_eq!(order.isTpLimit.as_deref(), Some("false"));
+        assert_eq!(order.tdMode.as_deref(), Some("cross"));
+        assert_eq!(order.attachAlgoClOrdId.as_deref(), Some("bracket-1"));
+        assert_eq!(
+            order
+                .linkedAlgoOrd
+                .as_ref()
+                .and_then(|linked| linked.algoId.as_deref()),
+            Some("linked-1")
+        );
+        assert_eq!(order.attachAlgoOrds[0].tpTriggerPx.as_deref(), Some("101"));
+        assert_eq!(
+            order.attachAlgoOrds[0].slTriggerPxType.as_deref(),
+            Some("mark")
+        );
+        assert_eq!(order.attachAlgoOrds[1].sz.as_deref(), Some("2"));
+        assert_eq!(order.tpTriggerPx.as_deref(), Some("103"));
+        assert_eq!(order.slTriggerPx.as_deref(), Some("95"));
+    }
+
+    #[test]
+    fn defaults_missing_attached_orders_to_empty() {
+        let mut fixture = order_fixture();
+        fixture.as_object_mut().unwrap().remove("attachAlgoOrds");
+
+        let order: RestOrderHistoryOkx = serde_json::from_value(fixture).unwrap();
+
+        assert!(order.attachAlgoOrds.is_empty());
+    }
+
+    #[test]
+    fn preserves_normalized_order_conversion() {
+        let raw: RestOrderHistoryOkx = serde_json::from_value(order_fixture()).unwrap();
+        let normalized = OrderDetailData::from(raw);
+
+        assert_eq!(normalized.timestamp, 1_720_000_000_000_000);
+        assert_eq!(normalized.inst, "BTC_USDT_PERP");
+        assert_eq!(normalized.order_id, "12345");
+        assert_eq!(normalized.cli_order_id.as_deref(), Some("entry-1"));
+        assert_eq!(normalized.side, OrderSide::BUY);
+        assert_eq!(normalized.position_side, Some(PositionSide::Long));
+        assert_eq!(normalized.order_type, OrderType::Limit);
+        assert_eq!(normalized.order_status, OrderStatus::Filled);
+        assert_eq!(normalized.price, 100.0);
+        assert_eq!(normalized.avg_price, 100.1);
+        assert_eq!(normalized.size, 3.0);
+        assert_eq!(normalized.executed_size, 3.0);
+        assert_eq!(normalized.fee, Some(-0.01));
+        assert_eq!(normalized.fee_currency.as_deref(), Some("USDT"));
+        assert_eq!(normalized.reduce_only, Some(false));
+        assert_eq!(normalized.time_in_force, Some(TimeInForce::GTC));
+        assert_eq!(normalized.update_time, 1_720_000_001_000_000);
     }
 }


### PR DESCRIPTION
## Summary

- add OKX-native request models for pending orders, order history, and order detail
- add single-request raw OkxCli methods while preserving the existing normalized LobPrivateRest signatures and open-order pagination behavior
- retain attached and top-level TP/SL fields plus guard metadata and Algo parent-child identifiers in the OKX order response model
- cover native query serialization, bracket response decoding, and raw-to-normalized conversion with offline tests

## Validation

- `cargo fmt --all -- --check`
- `cargo test --features okx` (72 unit tests, 7 integration tests, and 9 doctests passed)
- `cargo clippy --features okx --all-targets -- -D warnings`
- `cargo test --all-features` (156 unit tests, 7 integration tests, and 9 doctests passed)
- `git diff --check`