### PR TITLE
perf: avoid copying REST response bodies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tungstenite = "0.30.0"
 # Serialization / JSON / Binary encoding
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
-simd-json = "0.17.3"
+simd-json = "0.18.0"
 rmp-serde = "1.3.1"
 
 # Cryptography / Signing / Encoding

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 
 readme = "README.md"

--- a/src/arch/market_assets/api_general.rs
+++ b/src/arch/market_assets/api_general.rs
@@ -258,13 +258,17 @@ where
     T: DeserializeOwned,
 {
     let status = response.status();
-    let mut bytes = response
+    let bytes = response
         .bytes()
         .await
-        .map_err(|e| InfraError::Msg(format!("[{label}] body read failed: {e}")))?
-        .to_vec();
+        .map_err(|e| InfraError::Msg(format!("[{label}] body read failed: {e}")))?;
 
-    simd_json::from_slice::<T>(&mut bytes).map_err(|e| {
+    let mut bytes = match bytes.try_into_mut() {
+        Ok(bytes) => bytes,
+        Err(bytes) => bytes.as_ref().into(),
+    };
+
+    simd_json::from_slice::<T>(bytes.as_mut()).map_err(|e| {
         let preview = String::from_utf8_lossy(&bytes[..bytes.len().min(500)]);
         InfraError::Msg(format!(
             "[{label}] JSON parse failed status={status} body={preview:?} err={e}"


### PR DESCRIPTION
## Summary

- upgrade `simd-json` from 0.17.3 to 0.18.0
- consume uniquely owned Reqwest response buffers in place
- retain a safe copy fallback when the response body is shared
- bump `extrema_infra` from 0.3.5 to 0.3.6

## Implementation

Previous REST input preparation always copied the complete response body:

```rust
let mut bytes = response.bytes().await?.to_vec();
simd_json::from_slice::<T>(&mut bytes)
```

The new path first tries to recover the uniquely owned Reqwest allocation:

```rust
let bytes = response.bytes().await?;
let mut bytes = match bytes.try_into_mut() {
    Ok(bytes) => bytes,
    Err(bytes) => bytes.as_ref().into(),
};
simd_json::from_slice::<T>(bytes.as_mut())
```

This does not change public APIs, schemas, WS decoding, or error behavior. It
also does not introduce shared/reused `simd_json::Buffers`; parser-buffer reuse
is a separate optimization with concurrency and retained-memory tradeoffs.

## Benchmark environment

- Apple M5 Pro, arm64, 15 CPU cores, 48 GB RAM
- Rust 1.97.1
- `serde_json` 1.0.151
- `simd-json` 0.18.0
- Reqwest 0.13.4 with gzip support, matching infra
- Release: `opt-level=3`, fat LTO, one codegen unit
- methods ran serially; comparison runs reversed method order
- generated fixtures repeat typed exchange-like records rather than arbitrary JSON values
- every fixture was decoded by both libraries and compared for equality before timing

## Benchmark 1: JSON parser and buffer strategy

This broader benchmark established why WS remains on `serde_json` while REST
continues to use `simd-json`.

Methods:

- `serde-borrowed`: decode immutable `&[u8]` directly, matching the current WS shape
- `simd-copy`: copy input to `Vec<u8>`, then decode with fresh SIMD parser buffers
- `simd-owned-reused`: consume uniquely owned `Bytes` as `BytesMut` without copying and reuse one parser buffer per worker

`parser-only` excludes input preparation. `real-buffer` starts with the owned
buffer form received from Tungstenite or Reqwest. Each result is a fixed batch
divided by message count, with p50/p95/p99 calculated across 15 normalized
batch samples. These are batch-average decode distributions, not production
per-message tail latency.

### Single-thread real-buffer results

Positive change means faster than `serde-borrowed`.

| Case | Bytes | serde p50 | simd-copy p50 | Change | simd-owned/reused p50 | Change |
|---|---:|---:|---:|---:|---:|---:|
| Binance Trade | 132 | 210.3 ns | 444.3 ns | -111.3% | 201.2 ns | +4.3% |
| Binance BBO | 136 | 243.5 ns | 457.9 ns | -88.0% | 224.7 ns | +7.7% |
| OKX Trade | 194 | 401.3 ns | 563.2 ns | -40.3% | 313.4 ns | +21.9% |
| OKX AccountOrder | 433 | 817.1 ns | 878.9 ns | -7.6% | 643.2 ns | +21.3% |
| Binance LOB, 20 levels | 1,004 | 2.522 us | 2.262 us | +10.3% | 2.105 us | +16.5% |
| Binance LOB, 200 levels | 8,924 | 20.866 us | 18.582 us | +10.9% | 18.176 us | +12.9% |
| REST order ack | 152 | 273.5 ns | 488.5 ns | -78.6% | 247.1 ns | +9.7% |
| REST instruments, 100 | 42,680 | 78.315 us | 60.625 us | +22.6% | 58.842 us | +24.9% |
| REST instruments, 1,000 | 431,480 | 745.800 us | 589.263 us | +21.0% | 582.813 us | +21.9% |
| REST instruments, 5,000 | 2,179,480 | 4.336 ms | 3.133 ms | +27.8% | 2.973 ms | +31.4% |
| REST orderbook, 20 levels | 1,293 | 4.651 us | 3.964 us | +14.8% | 3.647 us | +21.6% |
| REST orderbook, 200 levels | 12,291 | 41.335 us | 34.572 us | +16.4% | 33.741 us | +18.4% |
| REST orderbook, 2,000 levels | 122,271 | 396.043 us | 343.036 us | +13.4% | 338.255 us | +14.6% |

The reverse-order process reproduced the ranking. Differences around 4-8% on
tiny messages should be treated as approximately tied unless an end-to-end
profile shows that JSON decode is material.

### WS fallback and full-envelope cost

For a 73-byte OKX subscription/control frame:

| Method | p50 |
|---|---:|
| serde preferred decode followed by fallback | 520.2 ns |
| SIMD with two safe input copies | 441.2 ns |
| SIMD owned full-envelope decode once | 280.5 ns |

The full-envelope follow-up tested six hot WS frames with four methods. The
table reports the median p50 from three serial Release process runs, including
one reversed-order run; each process p50 comes from 15 normalized batch samples.

| Hot WS case | Current serde direct | Serde full envelope | SIMD owned direct | SIMD owned full envelope | Full SIMD vs current |
|---|---:|---:|---:|---:|---:|
| 132 B Binance Trade | 249.1 ns | 382.0 ns | 202.5 ns | 352.3 ns | 41.4% slower |
| 136 B Binance BBO | 239.7 ns | 392.7 ns | 221.1 ns | 361.6 ns | 50.9% slower |
| 194 B OKX Trade | 358.7 ns | 536.1 ns | 307.1 ns | 540.4 ns | 50.7% slower |
| 433 B OKX AccountOrder | 820.1 ns | 1.161 us | 659.4 ns | 1.044 us | 27.3% slower |
| 1,004 B Binance LOB | 2.524 us | 3.794 us | 2.052 us | 3.232 us | 28.0% slower |
| 8,924 B Binance LOB | 20.959 us | 31.999 us | 17.916 us | 28.653 us | 36.7% slower |

The untagged full-envelope decoder makes every hot WS case 27-51% slower even
though it helps the rare control frame. Therefore this PR does not change WS.

### Allocations per decoded message

Input buffers were prepared before counting and the reusable SIMD buffer was warmed first.

| Case | serde | simd-copy | simd-owned/reused |
|---|---:|---:|---:|
| 132 B Trade | 4 alloc / 28 B | 14 alloc / 3,348 B | 5 alloc / 1,012 B |
| 8,924 B LOB | 816 alloc / 54,386 B | 814 alloc / 167,902 B | 805 alloc / 83,306 B |
| 42,680 B instruments | 2,007 alloc / 157,603 B | 2,011 alloc / 531,619 B | 2,003 alloc / 305,563 B |

### CPU concurrency

This is CPU decode saturation using fixed, pre-created owned inputs, not Tokio
scheduling. It used 1, 4, and 8 decode threads. The first number is the normal
method-order p50 and the second is the reversed-order p50.

| Case | Threads | Messages | serde p50 normal/reverse | simd-copy p50 normal/reverse | simd-owned p50 normal/reverse |
|---|---:|---:|---:|---:|---:|
| 132 B Trade | 1 | 200,000 | 204.9 / 206.5 ns | 417.1 / 409.6 ns | 196.4 / 196.6 ns |
| 132 B Trade | 4 | 200,000 | 82.5 / 57.8 ns | 346.4 / 411.8 ns | 63.9 / 60.9 ns |
| 132 B Trade | 8 | 200,000 | 47.8 / 50.1 ns | 159.5 / 181.3 ns | 44.4 / 47.1 ns |
| 8,924 B LOB | 1 | 5,000 | 20.280 / 20.976 us | 17.961 / 18.429 us | 17.175 / 17.957 us |
| 8,924 B LOB | 4 | 5,000 | 6.509 / 6.981 us | 5.560 / 6.495 us | 5.333 / 5.509 us |
| 8,924 B LOB | 8 | 5,000 | 5.413 / 4.754 us | 3.707 / 4.680 us | 3.919 / 4.101 us |
| 42,680 B instruments | 1 | 1,000 | 75.195 / 75.659 us | 59.199 / 59.680 us | 57.278 / 58.541 us |
| 42,680 B instruments | 4 | 1,000 | 26.969 / 26.213 us | 21.075 / 21.912 us | 19.301 / 20.098 us |
| 42,680 B instruments | 8 | 1,000 | 25.579 / 24.141 us | 18.581 / 20.491 us | 16.142 / 19.588 us |

Stable observations:

- tiny Trade: serde and owned/reused SIMD remain in the same band; `simd-copy` is roughly 2x slower on one thread and scales poorly due to allocation
- 8.9 KiB LOB: SIMD is roughly 10-15% faster on one thread and remains ahead at 4/8 threads, although exact 8-thread ordering varies
- 42 KiB REST: SIMD remains roughly 20-30% faster; scaling flattens from 4 to 8 threads as allocation and memory bandwidth dominate

## Benchmark 2: exact PR path with real Reqwest responses

The broader benchmark above includes a reusable-buffer variant that this PR
does not implement. This second benchmark isolates the exact code change:

- current: `Response::bytes()` -> `.to_vec()` -> `simd_json::from_slice`
- proposed: `Response::bytes()` -> `.try_into_mut()` -> `simd_json::from_slice`
- both sides create fresh simd-json parser buffers
- the only timed difference is response input preparation

A local HTTP/1.1 server returned typed exchange-like JSON through a real Reqwest
client using persistent connections. HTTP transfer was outside the timed region.
Content-Length and 4 KiB chunked bodies were included. Methods alternated over
seven normalized batch samples and the complete Release process ran twice.

### Ownership result

| Transport/body | Owned attempts across two runs | `try_into_mut` success | Fallback copies |
|---|---:|---:|---:|
| Content-Length, 152 B | 28,000 | 28,000 | 0 |
| Content-Length, 42,680 B | 1,120 | 1,120 | 0 |
| Chunked 4 KiB, 42,680 B | 1,120 | 1,120 | 0 |
| Content-Length, 2,179,480 B | 56 | 56 | 0 |
| **Total** | **30,296** | **30,296 (100%)** | **0** |

### Release run 1

| Case | Current copy p50/p95 | Owned p50/p95 | p50 change |
|---|---:|---:|---:|
| 152 B order ack | 485.0 / 611.7 ns | 489.1 / 547.9 ns | 0.9% slower |
| 42,680 B instruments, Content-Length | 62.146 / 66.724 us | 59.047 / 59.886 us | 5.0% faster |
| 42,680 B instruments, chunked | 60.098 / 62.338 us | 59.524 / 59.879 us | 1.0% faster |
| 2,179,480 B instruments | 3.010 / 3.267 ms | 3.002 / 3.152 ms | 0.3% faster |

### Release run 2

| Case | Current copy p50/p95 | Owned p50/p95 | p50 change |
|---|---:|---:|---:|
| 152 B order ack | 461.9 / 492.8 ns | 466.0 / 480.3 ns | 0.9% slower |
| 42,680 B instruments, Content-Length | 61.720 / 63.345 us | 59.610 / 60.668 us | 3.4% faster |
| 42,680 B instruments, chunked | 60.368 / 61.622 us | 58.634 / 59.792 us | 2.9% faster |
| 2,179,480 B instruments | 2.994 / 3.107 ms | 2.961 / 3.001 ms | 1.1% faster |

Interpretation:

- all 30,296 real Reqwest bodies were uniquely owned and avoided the copy
- 152 B is too small to benefit; the ownership check costs about 4 ns at p50
- 42 KiB improves roughly 1-5% at p50 and 3-10% at p95
- 2.18 MiB improves roughly 0.3-1.1% at p50 because typed deserialization dominates
- peak live input memory drops by one response-body copy; the 2.18 MiB case avoids about 2.18 MiB of duplicate input per concurrent response
- the fallback remains required because uniqueness is not guaranteed for every transport or middleware

## Verification

Infra:

- `cargo fmt --all -- --check`
- `cargo clippy --all-features -- -D warnings`
- `cargo test --all-features`
- 158 unit tests passed
- 7 runtime integration tests passed
- 9 doc tests passed
- `git diff --check`

API Checker uses the local infra path:

```toml
extrema_infra = { path = "../extrema_infra", features = ["lob_clients"] }
```

Checks and real public REST calls:

- `cargo check --all-targets`
- Binance UM instrument info parsed successfully
- Gate Futures instrument info parsed successfully
- OKX instrument info parsed successfully
- Hyperliquid returned and parsed 232 perpetual instruments and 324 spot instruments
- API Checker's existing uncommitted files and lockfile were not modified

## Scope and limitations

The parser benchmark excludes network latency, TLS, WebSocket framing, Tokio
scheduling, broadcast delivery, strategy work, and production end-to-end tail
latency. The exact Reqwest benchmark verifies local persistent HTTP/1.1 with
Content-Length and chunked responses, but does not separately exercise TLS,
HTTP/2, gzip decompression, proxies, or middleware that clones the body. Shared
bodies remain correct through the copy fallback.

Results are specific to this Apple ARM machine. Linux x86 deployment should be
remeasured on the target 4-core host because AVX2 availability, allocator,
clock rate, and memory bandwidth can change the crossover.

## Decision

- keep WS on `serde_json`; copying tiny frames for SIMD is a regression and full-envelope decoding makes hot frames 27-51% slower
- keep REST on `simd-json`; typed medium/large responses improve materially over serde
- apply only the minimal ownership-aware REST input change in this PR
- do not add shared parser-buffer state or alter WS decoding in this PR
