### PR TITLE
feat(hyperliquid): support fast L2 subscriptions

### DIFF
--- a/src/arch/market_assets/exchange/hyperliquid/api_utils.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/api_utils.rs
@@ -68,28 +68,30 @@ pub fn hyperliquid_dex_from_scope_extra(extra: Option<&str>) -> Option<String> {
         .map(ToString::to_string)
 }
 
-pub(crate) fn hyperliquid_lob_subscription_type(
+pub(crate) fn hyperliquid_lob_subscription(
     lob_param: &Option<LobParam>,
-) -> InfraResult<&'static str> {
+) -> InfraResult<(&'static str, bool)> {
     match lob_param {
-        None => Ok("l2Book"),
+        None => Ok(("l2Book", false)),
         Some(LobParam::Bbo { frequency }) => match frequency {
-            None | Some(LobFrequency::Realtime) => Ok("bbo"),
+            None | Some(LobFrequency::Realtime) => Ok(("bbo", false)),
             Some(freq) => Err(InfraError::ApiCliError(format!(
                 "Hyperliquid bbo does not support requested frequency: {:?}",
                 freq
             ))),
         },
-        Some(LobParam::Snapshot { depth, frequency }) => {
-            if depth.is_none() && frequency.is_none() {
-                Ok("l2Book")
-            } else {
-                Err(InfraError::ApiCliError(format!(
-                    "Hyperliquid l2Book does not support depth/frequency: depth={:?}, frequency={:?}",
-                    depth, frequency
-                )))
-            }
-        },
+        Some(LobParam::Snapshot {
+            depth: None,
+            frequency: None,
+        }) => Ok(("l2Book", false)),
+        Some(LobParam::Snapshot {
+            depth: Some(5),
+            frequency: Some(LobFrequency::Ms500),
+        }) => Ok(("l2Book", true)),
+        Some(LobParam::Snapshot { depth, frequency }) => Err(InfraError::ApiCliError(format!(
+            "Hyperliquid l2Book does not support depth/frequency: depth={:?}, frequency={:?}",
+            depth, frequency
+        ))),
         Some(LobParam::Incremental { depth, frequency }) => Err(InfraError::ApiCliError(format!(
             "Hyperliquid does not support incremental LOB updates: depth={:?}, frequency={:?}",
             depth, frequency
@@ -221,6 +223,13 @@ pub fn hyperliquid_cli_inst_to_raw_perp_coin(inst: &str) -> InfraResult<String> 
 pub(crate) fn hyperliquid_cli_inst_to_raw_trade_coin(inst: &str) -> Option<String> {
     if let Ok(coin) = hyperliquid_cli_inst_to_raw_perp_coin(inst) {
         return Some(coin);
+    }
+
+    if inst
+        .split_once(':')
+        .is_some_and(|(dex, coin)| !dex.is_empty() && !coin.is_empty())
+    {
+        return Some(inst.to_string());
     }
 
     if inst == "PURR_USDC" {

--- a/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
@@ -1160,15 +1160,25 @@ impl HyperliquidCli {
             );
         }
 
-        let subscription_type = hyperliquid_lob_subscription_type(lob_param)?;
+        let (subscription_type, fast) = hyperliquid_lob_subscription(lob_param)?;
         let inst = insts.first().expect("checked non-empty insts");
         let coin = self._inst_to_trade_coin(inst)?;
+        let subscription = if fast {
+            json!({
+                "type": subscription_type,
+                "coin": coin,
+                "fast": true,
+            })
+        } else {
+            json!({
+                "type": subscription_type,
+                "coin": coin,
+            })
+        };
+
         Ok(json!({
             "method": "subscribe",
-            "subscription": {
-                "type": subscription_type,
-                "coin": coin.to_string(),
-            }
+            "subscription": subscription,
         })
         .to_string())
     }


### PR DESCRIPTION
## Summary
- map 5-level, 500ms snapshots to Hyperliquid fast l2Book subscriptions
- preserve existing default l2Book and BBO behavior
- accept raw HIP-3 coin identifiers for public market-data subscriptions

## Verification
- cargo test --features hyperliquid
- live XYZ100 feed returned 5 bid and 5 ask levels at roughly 500ms intervals