### PR TITLE
feat(hyperliquid): expose raw perp metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.3.9"
+version = "0.3.10"
 edition = "2024"
 
 readme = "README.md"
@@ -37,7 +37,7 @@ tungstenite = "0.30.0"
 # Serialization / JSON / Binary encoding
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
-simd-json = "0.18.0"
+simd-json = "0.18.1"
 rmp-serde = "1.3.1"
 
 # Cryptography / Signing / Encoding

--- a/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
@@ -353,6 +353,18 @@ impl HyperliquidCli {
         Ok(data)
     }
 
+    pub async fn get_perp_meta_raw(&self) -> InfraResult<RestMetaHyperliquid> {
+        let body = json!({ "type": "meta", "dex": self._perp_dex() });
+        let res: RestResHyperliquid<RestMetaHyperliquid> = self._post_info_raw(&body).await?;
+
+        res.into_vec()?
+            .into_iter()
+            .next()
+            .ok_or(InfraError::ApiCliError(
+                "No Hyperliquid perpetual instrument info returned".into(),
+            ))
+    }
+
     pub async fn get_non_funding_ledger_updates(
         &self,
         start_time_us: u64,
@@ -539,21 +551,9 @@ impl HyperliquidCli {
     async fn _get_perp_instrument_info_with_quote(
         &self,
     ) -> InfraResult<(Vec<InstrumentInfo>, String)> {
-        let meta = self._get_perp_meta().await?;
+        let meta = self.get_perp_meta_raw().await?;
         let quote = self._perp_quote_from_meta(&meta).await?;
         Ok((meta.into_instrument_info(&quote), quote))
-    }
-
-    async fn _get_perp_meta(&self) -> InfraResult<RestMetaHyperliquid> {
-        let body = json!({ "type": "meta", "dex": self._perp_dex() });
-        let res: RestResHyperliquid<RestMetaHyperliquid> = self._post_info_raw(&body).await?;
-
-        res.into_vec()?
-            .into_iter()
-            .next()
-            .ok_or(InfraError::ApiCliError(
-                "No Hyperliquid perpetual instrument info returned".into(),
-            ))
     }
 
     async fn _get_spot_meta(&self) -> InfraResult<RestSpotMetaHyperliquid> {


### PR DESCRIPTION
## Summary

- expose the native Hyperliquid perpetual metadata response
- preserve the existing generic instrument-info conversion path by reusing the raw API
- bump `extrema_infra` to `0.3.10` and update `simd-json` to `0.18.1`
- add no additional API calls to the existing instrument-info flow

## Verification

- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `git diff --check`