### PR TITLE
feat: support raw websocket messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.3.10"
+version = "0.3.11"
 edition = "2024"
 
 readme = "README.md"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -326,6 +326,13 @@ Useful callbacks:
 - `on_acc_order`: private order updates.
 - `on_acc_bal_pos`: balance and position updates.
 - `on_acc_pos`: position-only updates.
+- `on_ws_other`: raw JSON frames from exchange-specific
+  `WsChannel::Other(...)` tasks.
+
+The relay preserves the complete top-level JSON frame and a local receive
+timestamp. Exchange-specific code can then decode fields such as Hyperliquid's
+`channel: "post"` and `data.id`; the relay-level `AckStatus::WsMessage` still
+means only that the text frame was written locally.
 
 Exchange clients normally need API-key initialization in `Strategy::initialize`
 before private websocket login messages are built. Credentials and login flows

--- a/src/arch/market_assets/exchange/hyperliquid/config_assets.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/config_assets.rs
@@ -7,3 +7,5 @@ pub const HYPERLIQUID_MAINNET_SOURCE: &str = "a";
 pub const HYPERLIQUID_MAINNET_CHAIN: &str = "Mainnet";
 pub const HYPERLIQUID_DEFAULT_SIGNATURE_CHAIN_ID: &str = "0x66eee";
 pub const HYPERLIQUID_GROUPING_NA: &str = "na";
+/// `WsChannel::Other` key for the Hyperliquid websocket action connection.
+pub const HYPERLIQUID_ORDER_ACTION_CHANNEL: &str = "hyperliquid_order_actions";

--- a/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
@@ -1063,6 +1063,9 @@ impl HyperliquidCli {
     fn _get_private_connect_msg(&self, channel: &WsChannel) -> InfraResult<String> {
         match channel {
             WsChannel::AccountOrders | WsChannel::AccountPositions => Ok(HYPERLIQUID_WS.into()),
+            WsChannel::Other(channel) if channel == HYPERLIQUID_ORDER_ACTION_CHANNEL => {
+                Ok(HYPERLIQUID_WS.into())
+            },
             _ => Err(InfraError::Unimplemented),
         }
     }
@@ -1082,26 +1085,35 @@ impl HyperliquidCli {
     }
 
     fn _get_private_sub_msg(&self, channel: &WsChannel) -> InfraResult<String> {
-        let user = self._owner_address()?;
-
         match channel {
-            WsChannel::AccountOrders => Ok(json!({
-                "method": "subscribe",
-                "subscription": {
-                    "type": "orderUpdates",
-                    "user": user,
-                }
-            })
-            .to_string()),
-            WsChannel::AccountPositions => Ok(json!({
-                "method": "subscribe",
-                "subscription": {
-                    "type": "clearinghouseState",
-                    "user": user,
-                    "dex": self._perp_dex(),
-                }
-            })
-            .to_string()),
+            WsChannel::AccountOrders => {
+                let user = self._owner_address()?;
+                Ok(json!({
+                    "method": "subscribe",
+                    "subscription": {
+                        "type": "orderUpdates",
+                        "user": user,
+                    }
+                })
+                .to_string())
+            },
+            WsChannel::AccountPositions => {
+                let user = self._owner_address()?;
+                Ok(json!({
+                    "method": "subscribe",
+                    "subscription": {
+                        "type": "clearinghouseState",
+                        "user": user,
+                        "dex": self._perp_dex(),
+                    }
+                })
+                .to_string())
+            },
+            WsChannel::Other(channel) if channel == HYPERLIQUID_ORDER_ACTION_CHANNEL => Err(
+                InfraError::ApiCliError(
+                    "Hyperliquid order-action websocket uses post messages and does not require a subscription".into(),
+                ),
+            ),
             _ => Err(InfraError::Unimplemented),
         }
     }

--- a/src/arch/market_assets/exchange/prelude.rs
+++ b/src/arch/market_assets/exchange/prelude.rs
@@ -3,7 +3,8 @@ pub use crate::arch::market_assets::exchange::lob_clients::LobClients;
 
 #[cfg(feature = "hyperliquid")]
 pub use crate::arch::market_assets::exchange::hyperliquid::{
-    api_utils::*, auth::*, hyperliquid_cli::HyperliquidCli,
+    api_utils::*, auth::*, config_assets::HYPERLIQUID_ORDER_ACTION_CHANNEL,
+    hyperliquid_cli::HyperliquidCli,
 };
 
 #[cfg(feature = "binance")]

--- a/src/arch/strategy_base/handler/events.rs
+++ b/src/arch/strategy_base/handler/events.rs
@@ -2,9 +2,11 @@ use std::sync::Arc;
 
 pub mod alt_events;
 pub mod lob_events;
+pub mod ws_events;
 
 pub use alt_events::*;
 pub use lob_events::*;
+pub use ws_events::*;
 
 /// Message envelope published by one runtime task.
 #[derive(Clone, Debug)]

--- a/src/arch/strategy_base/handler/events/ws_events.rs
+++ b/src/arch/strategy_base/handler/events/ws_events.rs
@@ -1,0 +1,10 @@
+/// A raw JSON message from an exchange-specific websocket task.
+///
+/// `timestamp` is the local runtime receive timestamp in Unix microseconds.
+/// `raw_json` contains the complete top-level websocket frame so that the
+/// exchange-specific protocol can be decoded by a checker or adapter.
+#[derive(Clone, Debug)]
+pub struct WsOtherMessage {
+    pub timestamp: u64,
+    pub raw_json: String,
+}

--- a/src/arch/strategy_base/handler/handler_core.rs
+++ b/src/arch/strategy_base/handler/handler_core.rs
@@ -50,6 +50,7 @@ where
         TaskEvent::AccOrder(msg) => strategy.on_acc_order(msg).await,
         TaskEvent::AccBalPos(msg) => strategy.on_acc_bal_pos(msg).await,
         TaskEvent::AccPos(msg) => strategy.on_acc_pos(msg).await,
+        TaskEvent::WsOther(msg) => strategy.on_ws_other(msg).await,
     }
 }
 

--- a/src/arch/strategy_base/handler/task_channel.rs
+++ b/src/arch/strategy_base/handler/task_channel.rs
@@ -9,6 +9,7 @@ use crate::arch::{
     strategy_base::handler::events::{
         alt_events::{AltIntent, AltOrder, AltScheduleEvent, AltTensor},
         lob_events::{WsAccBalPos, WsAccOrder, WsAccPosition, WsCandle, WsLob, WsLobMbo, WsTrade},
+        ws_events::WsOtherMessage,
     },
     task_execution::{
         TaskKey,
@@ -52,6 +53,7 @@ pub(crate) enum TaskEvent {
     AccOrder(InfraMsg<Vec<WsAccOrder>>),
     AccBalPos(InfraMsg<Vec<WsAccBalPos>>),
     AccPos(InfraMsg<Vec<WsAccPosition>>),
+    WsOther(InfraMsg<Vec<WsOtherMessage>>),
 }
 
 pub(crate) struct TaskReceiver {

--- a/src/arch/strategy_base/hlist_core.rs
+++ b/src/arch/strategy_base/hlist_core.rs
@@ -7,6 +7,7 @@ use crate::arch::{
             alt_events::*,
             lob_events::*,
             task_channel::{InfraMsg, TaskChannels},
+            ws_events::*,
         },
     },
     task_execution::{task_alt::AltTaskInfo, task_ws::WsTaskInfo},
@@ -147,6 +148,12 @@ where
     async fn on_acc_pos(&mut self, msg: InfraMsg<Vec<WsAccPosition>>) {
         let fut_head = self.head.on_acc_pos(msg.clone());
         let fut_tail = self.tail.on_acc_pos(msg);
+        tokio::join!(fut_head, fut_tail);
+    }
+
+    async fn on_ws_other(&mut self, msg: InfraMsg<Vec<WsOtherMessage>>) {
+        let fut_head = self.head.on_ws_other(msg.clone());
+        let fut_tail = self.tail.on_ws_other(msg);
         tokio::join!(fut_head, fut_tail);
     }
 }

--- a/src/arch/task_execution/task_ws.rs
+++ b/src/arch/task_execution/task_ws.rs
@@ -44,6 +44,11 @@ pub enum WsChannel {
     /// Public market-by-order order book stream.
     LobMbo,
     /// Exchange-specific or custom stream.
+    ///
+    /// The relay preserves complete JSON frames for this channel and emits
+    /// them through `EventHandler::on_ws_other`. For example, Hyperliquid
+    /// order actions use `Other("hyperliquid_order_actions")` and do not
+    /// require a subscription message.
     Other(String),
 }
 

--- a/src/arch/task_execution/ws_runner/binance.rs
+++ b/src/arch/task_execution/ws_runner/binance.rs
@@ -23,7 +23,7 @@ use crate::arch::{
     },
 };
 
-use super::{WsStream, WsTaskRunner};
+use super::{WsStream, WsTaskRunner, ws_decode::decode_raw_ws};
 
 impl WsTaskRunner {
     pub(super) async fn ws_channel_binance_um(&mut self, ws_stream: &mut WsStream) {
@@ -94,6 +94,10 @@ impl WsTaskRunner {
                     .await;
                 },
             },
+            WsChannel::Other(_) => {
+                self.ws_loop(TaskEvent::WsOther, ws_stream, decode_raw_ws)
+                    .await;
+            },
             c => {
                 self.log(
                     LogLevel::Warn,
@@ -112,6 +116,10 @@ impl WsTaskRunner {
                     BinanceWsData::<WsAccountOrderEnvelopeBinanceSpot>::decode_single,
                 )
                 .await;
+            },
+            WsChannel::Other(_) => {
+                self.ws_loop(TaskEvent::WsOther, ws_stream, decode_raw_ws)
+                    .await;
             },
             c => {
                 self.log(
@@ -149,6 +157,10 @@ impl WsTaskRunner {
                     )
                     .await;
                 },
+            },
+            WsChannel::Other(_) => {
+                self.ws_loop(TaskEvent::WsOther, ws_stream, decode_raw_ws)
+                    .await;
             },
             c => {
                 self.log(

--- a/src/arch/task_execution/ws_runner/gate.rs
+++ b/src/arch/task_execution/ws_runner/gate.rs
@@ -17,7 +17,7 @@ use crate::arch::{
     },
 };
 
-use super::{WsStream, WsTaskRunner};
+use super::{WsStream, WsTaskRunner, ws_decode::decode_raw_ws};
 
 impl WsTaskRunner {
     pub(super) async fn ws_channel_gate_futures(&mut self, ws_stream: &mut WsStream) {
@@ -80,6 +80,10 @@ impl WsTaskRunner {
                     .await;
                 },
             },
+            WsChannel::Other(_) => {
+                self.ws_loop(TaskEvent::WsOther, ws_stream, decode_raw_ws)
+                    .await;
+            },
             c => {
                 self.log(
                     LogLevel::Warn,
@@ -98,6 +102,10 @@ impl WsTaskRunner {
                     GateWsData::<WsAccountOrderGateSpot>::decode_batch,
                 )
                 .await;
+            },
+            WsChannel::Other(_) => {
+                self.ws_loop(TaskEvent::WsOther, ws_stream, decode_raw_ws)
+                    .await;
             },
             c => {
                 self.log(

--- a/src/arch/task_execution/ws_runner/hyperliquid.rs
+++ b/src/arch/task_execution/ws_runner/hyperliquid.rs
@@ -14,7 +14,7 @@ use crate::arch::{
     },
 };
 
-use super::{WsStream, WsTaskRunner};
+use super::{WsStream, WsTaskRunner, ws_decode::decode_raw_ws};
 
 impl WsTaskRunner {
     pub(super) async fn ws_channel_hyperliquid(&mut self, ws_stream: &mut WsStream) {
@@ -58,6 +58,10 @@ impl WsTaskRunner {
                     HyperliquidWsData::<WsLobHyperliquid>::decode_l2_book,
                 )
                 .await;
+            },
+            WsChannel::Other(_) => {
+                self.ws_loop(TaskEvent::WsOther, ws_stream, decode_raw_ws)
+                    .await;
             },
             c => {
                 self.log(

--- a/src/arch/task_execution/ws_runner/okx.rs
+++ b/src/arch/task_execution/ws_runner/okx.rs
@@ -11,7 +11,7 @@ use crate::arch::{
     task_execution::{task_general::LogLevel, task_ws::WsChannel},
 };
 
-use super::{WsStream, WsTaskRunner};
+use super::{WsStream, WsTaskRunner, ws_decode::decode_raw_ws};
 
 impl WsTaskRunner {
     pub(super) async fn ws_channel_okx(&mut self, ws_stream: &mut WsStream) {
@@ -63,6 +63,10 @@ impl WsTaskRunner {
                     OkxWsData::<OkxWsLobBook>::decode_batch,
                 )
                 .await;
+            },
+            WsChannel::Other(_) => {
+                self.ws_loop(TaskEvent::WsOther, ws_stream, decode_raw_ws)
+                    .await;
             },
             c => {
                 self.log(LogLevel::Warn, &format!("Unknown Okx channel: {:?}", c));

--- a/src/arch/task_execution/ws_runner/ws_decode.rs
+++ b/src/arch/task_execution/ws_runner/ws_decode.rs
@@ -1,4 +1,29 @@
+use crate::arch::{
+    market_assets::api_general::get_micros_timestamp,
+    strategy_base::handler::events::ws_events::WsOtherMessage, traits::conversion::IntoWsData,
+};
 use serde::de::DeserializeOwned;
+
+/// Decodes an exchange-specific JSON websocket frame without interpreting its
+/// exchange-specific fields.
+///
+pub(crate) fn decode_raw_ws(frame: &[u8]) -> serde_json::Result<WsOtherMessage> {
+    let timestamp = get_micros_timestamp();
+    serde_json::from_slice::<serde_json::Value>(frame)?;
+
+    Ok(WsOtherMessage {
+        timestamp,
+        raw_json: String::from_utf8_lossy(frame).into_owned(),
+    })
+}
+
+impl IntoWsData for WsOtherMessage {
+    type Output = Vec<WsOtherMessage>;
+
+    fn into_ws(self) -> Self::Output {
+        vec![self]
+    }
+}
 
 /// Tries the runner's expected data shape before falling back to the full frame.
 pub(crate) fn decode_preferred<Frame, Preferred, Wrap>(
@@ -25,9 +50,10 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::arch::traits::conversion::IntoWsData;
     use serde::Deserialize;
 
-    use super::decode_preferred;
+    use super::{decode_preferred, decode_raw_ws};
 
     #[derive(Debug, Deserialize)]
     #[serde(untagged)]
@@ -74,5 +100,21 @@ mod tests {
             .to_string();
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn raw_decoder_preserves_complete_json_frame_and_receive_time() {
+        let frame = br#"{ "channel": "post", "data": { "id": 256 } }"#;
+        let data = decode_raw_ws(frame).unwrap();
+        let message = data.into_ws().pop().expect("raw websocket message");
+
+        assert_eq!(message.raw_json, std::str::from_utf8(frame).unwrap());
+        assert!(message.raw_json.contains("\"channel\": \"post\""));
+        assert!(message.timestamp > 0);
+    }
+
+    #[test]
+    fn raw_decoder_rejects_invalid_json() {
+        assert!(decode_raw_ws(br#"not-json"#).is_err());
     }
 }

--- a/src/arch/traits/strategy.rs
+++ b/src/arch/traits/strategy.rs
@@ -4,7 +4,7 @@ use crate::arch::{
     strategy_base::{
         command::command_core::{CommandHandle, CommandRegistry},
         handler::{
-            events::{InfraMsg, alt_events::*, lob_events::*},
+            events::{InfraMsg, alt_events::*, lob_events::*, ws_events::*},
             task_channel::TaskChannels,
         },
     },
@@ -314,6 +314,18 @@ pub trait EventHandler {
     fn on_acc_pos(
         &mut self,
         _msg: InfraMsg<Vec<WsAccPosition>>,
+    ) -> impl Future<Output = ()> + Send {
+        ready(())
+    }
+
+    /// Receives raw JSON frames from an exchange-specific websocket task.
+    ///
+    /// This callback is emitted for [`WsChannel::Other`] tasks. The infra
+    /// layer preserves the complete frame and does not interpret exchange-
+    /// specific fields such as order ids or status values.
+    fn on_ws_other(
+        &mut self,
+        _msg: InfraMsg<Vec<WsOtherMessage>>,
     ) -> impl Future<Output = ()> + Send {
         ready(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,8 @@
 //!   strategy module or several independent modules in the same runtime.
 //! - [`EventHandler`] contains async callbacks for schedule ticks, model
 //!   predictions, order execution intents, trades, LOB updates, candles, and
-//!   private account updates. All callbacks default to no-op.
+//!   private account updates, and raw exchange-specific websocket frames. All
+//!   callbacks default to no-op.
 //! - [`CommandEmitter`] gives a strategy access to task command handles after
 //!   the runtime has prepared those tasks.
 //! - [`TaskInfo`] declares work that the runtime owns, such as [`AltTaskInfo`]
@@ -48,10 +49,10 @@
 //!
 //! [`EventHandler`] is the inbound event surface. Its methods are callbacks:
 //! `on_schedule`, `on_trade`, `on_candle`, `on_acc_pos`, `on_inst_intent`,
-//! `on_order_execution`, and so on. Every callback defaults to no-op, so modules
-//! stay narrow and only implement the events that matter to them. Modules
-//! receive every registered task by default; explicit task bindings avoid
-//! receiver creation and wakeups for unrelated tasks.
+//! `on_order_execution`, `on_ws_other`, and so on. Every callback defaults to
+//! no-op, so modules stay narrow and only implement the events that matter to
+//! them. Modules receive every registered task by default; explicit task
+//! bindings avoid receiver creation and wakeups for unrelated tasks.
 //!
 //! [`CommandEmitter`] is the outbound command surface. After tasks are prepared,
 //! the runtime supplies a [`CommandRegistry`]. Strategy modules store that

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -24,7 +24,7 @@ pub use crate::arch::{
             ack_handle::{AckHandle, AckStatus},
             command_core::*,
         },
-        handler::events::{InfraMsg, alt_events::*, lob_events::*},
+        handler::events::{InfraMsg, alt_events::*, lob_events::*, ws_events::*},
     },
     task_execution::{TaskInfo, TaskKey, task_alt::*, task_ws::*},
     traits::{conversion::*, market_lob::*, strategy::*},


### PR DESCRIPTION
## Summary

- add a generic raw JSON websocket event and `on_ws_other` callback
- route `WsChannel::Other` frames through Binance, OKX, Gate, and Hyperliquid runners
- support Hyperliquid websocket action connections without a subscription message
- expose the Hyperliquid action channel and document local receive timestamp semantics

## Verification

- `cargo fmt --check`
- `cargo test --all-features --lib`
- `cargo check --all-targets --all-features`
- `cargo check --all-targets --no-default-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --all-targets --no-default-features -- -D warnings`
- `cargo doc --all-features --no-deps`