### PR TITLE
feat: support Hyperliquid cloids and OKX all-trades stream

### DIFF
--- a/src/arch/market_assets/exchange/hyperliquid/api_utils.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/api_utils.rs
@@ -500,6 +500,8 @@ pub struct HyperliquidOrderRequest {
     reduce_only: bool,
     #[serde(rename = "t")]
     order_type: HyperliquidOrderTypeRequest,
+    #[serde(rename = "c", skip_serializing_if = "Option::is_none")]
+    cloid: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -556,6 +558,11 @@ pub fn hyperliquid_order_from_params(
 
     let reduce_only = order_params.reduce_only.unwrap_or(false);
     let size = normalize_hyperliquid_num_str(&order_params.size);
+    let cloid = order_params
+        .client_order_id
+        .as_deref()
+        .map(normalize_hyperliquid_cloid)
+        .transpose()?;
 
     let (price, tif) = match order_params.order_type {
         OrderType::Market => {
@@ -595,6 +602,7 @@ pub fn hyperliquid_order_from_params(
         order_type: HyperliquidOrderTypeRequest::Limit {
             limit: HyperliquidLimitOrderRequest { tif },
         },
+        cloid,
     })
 }
 
@@ -757,5 +765,58 @@ mod tests {
                 }]
             })
         );
+    }
+
+    #[test]
+    fn serializes_order_cloid_from_client_order_id() {
+        let request = hyperliquid_order_from_params(OrderParams {
+            inst: "120007".into(),
+            side: OrderSide::BUY,
+            size: "0.0004000".into(),
+            order_type: OrderType::PostOnly,
+            price: Some("29570.00".into()),
+            client_order_id: Some("0xABCDEF0123456789ABCDEF0123456789".into()),
+            ..Default::default()
+        })
+        .unwrap();
+
+        assert_eq!(
+            serde_json::to_value(request).unwrap(),
+            json!({
+                "a": 120007,
+                "b": true,
+                "p": "29570",
+                "s": "0.0004",
+                "r": false,
+                "t": {"limit": {"tif": "Alo"}},
+                "c": "0xabcdef0123456789abcdef0123456789"
+            })
+        );
+    }
+
+    #[test]
+    fn omits_absent_order_cloid_and_rejects_invalid_cloid() {
+        let request = hyperliquid_order_from_params(OrderParams {
+            inst: "120007".into(),
+            side: OrderSide::SELL,
+            size: "0.0004".into(),
+            order_type: OrderType::Limit,
+            price: Some("29570".into()),
+            ..Default::default()
+        })
+        .unwrap();
+        let value = serde_json::to_value(request).unwrap();
+        assert!(value.get("c").is_none());
+
+        let invalid = hyperliquid_order_from_params(OrderParams {
+            inst: "120007".into(),
+            side: OrderSide::BUY,
+            size: "0.0004".into(),
+            order_type: OrderType::PostOnly,
+            price: Some("29570".into()),
+            client_order_id: Some("probe-1".into()),
+            ..Default::default()
+        });
+        assert!(invalid.is_err());
     }
 }

--- a/src/arch/market_assets/exchange/okx/okx_cli.rs
+++ b/src/arch/market_assets/exchange/okx/okx_cli.rs
@@ -1530,7 +1530,7 @@ impl OkxCli {
     ) -> InfraResult<String> {
         let channel = match trades_param {
             Some(TradesParam::AggTrades) | None => "trades",
-            Some(TradesParam::AllTrades) => "tradesAll",
+            Some(TradesParam::AllTrades) => "trades-all",
         };
 
         Ok(ws_subscribe_msg_okx(channel, insts))
@@ -1620,6 +1620,28 @@ mod tests {
 
             assert_eq!(value["op"], "subscribe");
             assert_eq!(value["args"][0]["channel"], expected);
+            assert_eq!(value["args"][0]["instId"], "BTC-USDT-SWAP");
+        }
+    }
+
+    #[test]
+    fn builds_okx_trade_connect_and_subscribe_messages() {
+        let cli = OkxCli::default();
+        let insts = vec!["BTC_USDT_PERP".to_string()];
+        let cases = [
+            (TradesParam::AggTrades, OKX_WS_PUB, "trades"),
+            (TradesParam::AllTrades, OKX_WS_BUS, "trades-all"),
+        ];
+
+        for (param, expected_url, expected_channel) in cases {
+            let channel = WsChannel::Trades(Some(param));
+            assert_eq!(cli._get_public_connect_msg(&channel).unwrap(), expected_url);
+
+            let msg = cli._get_public_sub_msg(&channel, Some(&insts)).unwrap();
+            let value: Value = serde_json::from_str(&msg).unwrap();
+
+            assert_eq!(value["op"], "subscribe");
+            assert_eq!(value["args"][0]["channel"], expected_channel);
             assert_eq!(value["args"][0]["instId"], "BTC-USDT-SWAP");
         }
     }


### PR DESCRIPTION
## Summary
- serialize optional OrderParams.client_order_id as Hyperliquid native c after validating and normalizing the required 128-bit hex cloid
- omit c when no client order ID is provided and reject invalid cloids before signing
- map OKX TradesParam::AllTrades to the official trades-all business WebSocket channel
- cover both OKX aggregate and all-trades connection/subscription routing

## Validation
- cargo test --features okx,hyperliquid
- cargo clippy --all-targets --features okx,hyperliquid -- -D warnings
- live OKX trades-all probe received and decoded a BTC perpetual trade
- guarded Hyperliquid A2 probe placed a far-from-market post-only XYZ100 order, observed the same cloid in the exchange response and REST open orders, canceled it over WebSocket, and confirmed no residual open order or position