### PR TITLE
feat(hyperliquid): expose user fee and rate limit info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.3.11"
+version = "0.3.12"
 edition = "2024"
 
 readme = "README.md"

--- a/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
@@ -48,6 +48,8 @@ use super::{
         spot_clearinghouse_state::RestSpotClearinghouseStateHyperliquid,
         spot_meta::RestSpotMetaHyperliquid,
         trade_order::RestOrderAckHyperliquid,
+        user_fees::RestUserFeesHyperliquid,
+        user_rate_limit::RestUserRateLimitHyperliquid,
     },
 };
 
@@ -362,6 +364,37 @@ impl HyperliquidCli {
             .next()
             .ok_or(InfraError::ApiCliError(
                 "No Hyperliquid perpetual instrument info returned".into(),
+            ))
+    }
+
+    pub async fn get_user_rate_limit(&self) -> InfraResult<RestUserRateLimitHyperliquid> {
+        let body = json!({
+            "type": "userRateLimit",
+            "user": self._owner_address()?,
+        });
+        let res: RestResHyperliquid<RestUserRateLimitHyperliquid> =
+            self._post_info_raw(&body).await?;
+
+        res.into_vec()?
+            .into_iter()
+            .next()
+            .ok_or(InfraError::ApiCliError(
+                "No Hyperliquid user rate limit returned".into(),
+            ))
+    }
+
+    pub async fn get_user_fees(&self) -> InfraResult<RestUserFeesHyperliquid> {
+        let body = json!({
+            "type": "userFees",
+            "user": self._owner_address()?,
+        });
+        let res: RestResHyperliquid<RestUserFeesHyperliquid> = self._post_info_raw(&body).await?;
+
+        res.into_vec()?
+            .into_iter()
+            .next()
+            .ok_or(InfraError::ApiCliError(
+                "No Hyperliquid user fees returned".into(),
             ))
     }
 

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest.rs
@@ -13,3 +13,5 @@ pub mod perp_dexs;
 pub mod spot_clearinghouse_state;
 pub mod spot_meta;
 pub mod trade_order;
+pub mod user_fees;
+pub mod user_rate_limit;

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest/meta.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest/meta.rs
@@ -22,6 +22,12 @@ pub struct RestMetaUniverseHyperliquid {
     pub onlyIsolated: Option<bool>,
     pub isDelisted: Option<bool>,
     pub marginMode: Option<String>,
+    #[serde(default)]
+    pub growthMode: Option<String>,
+    #[serde(default)]
+    pub deployerFeeScale: Option<String>,
+    #[serde(default)]
+    pub lastFeeScaleChangeTime: Option<String>,
 }
 
 impl RestMetaHyperliquid {
@@ -62,5 +68,33 @@ impl RestMetaUniverseHyperliquid {
                 InstrumentStatus::Live
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_hip3_fee_metadata() {
+        let meta: RestMetaHyperliquid = serde_json::from_value(serde_json::json!({
+            "universe": [{
+                "name": "xyz:XYZ100",
+                "szDecimals": 3,
+                "maxLeverage": 20,
+                "growthMode": "enabled",
+                "deployerFeeScale": "1.0",
+                "lastFeeScaleChangeTime": "2025-11-23T17:37:10.033211662"
+            }]
+        }))
+        .unwrap();
+
+        let xyz100 = &meta.universe[0];
+        assert_eq!(xyz100.growthMode.as_deref(), Some("enabled"));
+        assert_eq!(xyz100.deployerFeeScale.as_deref(), Some("1.0"));
+        assert_eq!(
+            xyz100.lastFeeScaleChangeTime.as_deref(),
+            Some("2025-11-23T17:37:10.033211662")
+        );
     }
 }

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest/user_fees.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest/user_fees.rs
@@ -1,0 +1,169 @@
+use serde::Deserialize;
+use serde_json::Value;
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestUserFeesHyperliquid {
+    pub dailyUserVlm: Vec<RestDailyUserVolumeHyperliquid>,
+    pub feeSchedule: RestFeeScheduleHyperliquid,
+    pub userCrossRate: String,
+    pub userAddRate: String,
+    pub userSpotCrossRate: String,
+    pub userSpotAddRate: String,
+    pub activeReferralDiscount: String,
+    #[serde(default)]
+    pub trial: Option<Value>,
+    pub feeTrialEscrow: String,
+    #[serde(default)]
+    pub nextTrialAvailableTimestamp: Option<u64>,
+    #[serde(default)]
+    pub stakingLink: Option<Value>,
+    #[serde(default)]
+    pub activeStakingDiscount: Option<RestStakingDiscountHyperliquid>,
+}
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestDailyUserVolumeHyperliquid {
+    pub date: String,
+    pub userCross: String,
+    pub userAdd: String,
+    pub exchange: String,
+}
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestFeeScheduleHyperliquid {
+    pub cross: String,
+    pub add: String,
+    pub spotCross: String,
+    pub spotAdd: String,
+    pub tiers: RestFeeTiersHyperliquid,
+    pub referralDiscount: String,
+    pub stakingDiscountTiers: Vec<RestStakingDiscountHyperliquid>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestFeeTiersHyperliquid {
+    pub vip: Vec<RestVipFeeTierHyperliquid>,
+    pub mm: Vec<RestMarketMakerFeeTierHyperliquid>,
+}
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestVipFeeTierHyperliquid {
+    pub ntlCutoff: String,
+    pub cross: String,
+    pub add: String,
+    pub spotCross: String,
+    pub spotAdd: String,
+}
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestMarketMakerFeeTierHyperliquid {
+    pub makerFractionCutoff: String,
+    pub add: String,
+}
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestStakingDiscountHyperliquid {
+    pub bpsOfMaxSupply: String,
+    pub discount: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_user_fees() {
+        let fees: RestUserFeesHyperliquid = serde_json::from_value(serde_json::json!({
+            "dailyUserVlm": [{
+                "date": "2026-08-27",
+                "userCross": "12.34",
+                "userAdd": "56.78",
+                "exchange": "69.12"
+            }],
+            "feeSchedule": {
+                "cross": "0.00045",
+                "add": "0.00015",
+                "spotCross": "0.0007",
+                "spotAdd": "0.0004",
+                "tiers": {
+                    "vip": [{
+                        "ntlCutoff": "5000000.0",
+                        "cross": "0.0004",
+                        "add": "0.00012",
+                        "spotCross": "0.0006",
+                        "spotAdd": "0.0003"
+                    }],
+                    "mm": [{
+                        "makerFractionCutoff": "0.005",
+                        "add": "-0.00001"
+                    }]
+                },
+                "referralDiscount": "0.04",
+                "stakingDiscountTiers": [{
+                    "bpsOfMaxSupply": "0.0",
+                    "discount": "0.05"
+                }]
+            },
+            "userCrossRate": "0.0004275",
+            "userAddRate": "0.0001425",
+            "userSpotCrossRate": "0.000665",
+            "userSpotAddRate": "0.00038",
+            "activeReferralDiscount": "0.04",
+            "trial": null,
+            "feeTrialEscrow": "0.0",
+            "nextTrialAvailableTimestamp": null,
+            "stakingLink": null,
+            "activeStakingDiscount": {
+                "bpsOfMaxSupply": "0.0",
+                "discount": "0.05"
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(fees.dailyUserVlm.len(), 1);
+        assert_eq!(fees.dailyUserVlm[0].date, "2026-08-27");
+        assert_eq!(fees.dailyUserVlm[0].userCross, "12.34");
+        assert_eq!(fees.dailyUserVlm[0].userAdd, "56.78");
+        assert_eq!(fees.dailyUserVlm[0].exchange, "69.12");
+        assert_eq!(fees.userCrossRate, "0.0004275");
+        assert_eq!(fees.userAddRate, "0.0001425");
+        assert_eq!(fees.userSpotCrossRate, "0.000665");
+        assert_eq!(fees.userSpotAddRate, "0.00038");
+        assert_eq!(fees.activeReferralDiscount, "0.04");
+        assert!(fees.trial.is_none());
+        assert_eq!(fees.feeTrialEscrow, "0.0");
+        assert!(fees.nextTrialAvailableTimestamp.is_none());
+        assert!(fees.stakingLink.is_none());
+
+        assert_eq!(fees.feeSchedule.cross, "0.00045");
+        assert_eq!(fees.feeSchedule.add, "0.00015");
+        assert_eq!(fees.feeSchedule.spotCross, "0.0007");
+        assert_eq!(fees.feeSchedule.spotAdd, "0.0004");
+        assert_eq!(fees.feeSchedule.referralDiscount, "0.04");
+        assert_eq!(fees.feeSchedule.tiers.vip.len(), 1);
+        assert_eq!(fees.feeSchedule.tiers.vip[0].ntlCutoff, "5000000.0");
+        assert_eq!(fees.feeSchedule.tiers.vip[0].cross, "0.0004");
+        assert_eq!(fees.feeSchedule.tiers.vip[0].add, "0.00012");
+        assert_eq!(fees.feeSchedule.tiers.vip[0].spotCross, "0.0006");
+        assert_eq!(fees.feeSchedule.tiers.vip[0].spotAdd, "0.0003");
+        assert_eq!(fees.feeSchedule.tiers.mm.len(), 1);
+        assert_eq!(fees.feeSchedule.tiers.mm[0].makerFractionCutoff, "0.005");
+        assert_eq!(fees.feeSchedule.tiers.mm[0].add, "-0.00001");
+        assert_eq!(fees.feeSchedule.stakingDiscountTiers.len(), 1);
+        assert_eq!(
+            fees.feeSchedule.stakingDiscountTiers[0].bpsOfMaxSupply,
+            "0.0"
+        );
+        assert_eq!(fees.feeSchedule.stakingDiscountTiers[0].discount, "0.05");
+
+        let active_staking_discount = fees.activeStakingDiscount.unwrap();
+        assert_eq!(active_staking_discount.bpsOfMaxSupply, "0.0");
+        assert_eq!(active_staking_discount.discount, "0.05");
+    }
+}

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest/user_rate_limit.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest/user_rate_limit.rs
@@ -1,0 +1,31 @@
+use serde::Deserialize;
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestUserRateLimitHyperliquid {
+    pub cumVlm: String,
+    pub nRequestsUsed: u64,
+    pub nRequestsCap: u64,
+    pub nRequestsSurplus: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_user_rate_limit() {
+        let rate_limit: RestUserRateLimitHyperliquid = serde_json::from_value(serde_json::json!({
+            "cumVlm": "1807.76",
+            "nRequestsUsed": 1072,
+            "nRequestsCap": 11807,
+            "nRequestsSurplus": 0
+        }))
+        .unwrap();
+
+        assert_eq!(rate_limit.cumVlm, "1807.76");
+        assert_eq!(rate_limit.nRequestsUsed, 1072);
+        assert_eq!(rate_limit.nRequestsCap, 11807);
+        assert_eq!(rate_limit.nRequestsSurplus, 0);
+    }
+}


### PR DESCRIPTION
## Summary
- expose native Hyperliquid userRateLimit and userFees info methods
- add typed fee schedule, volume tier, market-maker tier, referral, and staking schemas
- preserve HIP-3 growth mode and deployer fee-scale metadata
- bump extrema_infra to 0.3.12

## Verification
- cargo fmt --all -- --check
- cargo test
- cargo test --all-features
- cargo clippy --all-targets -- -D warnings
- cargo clippy --all-targets --all-features -- -D warnings
- live A2 calls to userRateLimit and userFees returned result=pass