### PR TITLE
fix(hyperliquid): validate set leverage response

### DIFF
--- a/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
@@ -489,12 +489,14 @@ impl HyperliquidCli {
             leverage,
         };
 
-        self.auth
+        let res: RestResHyperliquid<Value> = self
+            .auth
             .as_ref()
             .ok_or(InfraError::ApiCliNotInitialized)?
-            .send_signed_exchange_action_raw::<Value, _>(&self.client, &action)
+            .send_signed_exchange_action_raw(&self.client, &action)
             .await?;
 
+        res.into_vec()?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- deserialize the Hyperliquid update-leverage response through RestResHyperliquid
- validate the exchange-level status before returning success
- preserve the existing InfraResult<()> API for downstream callers

## Testing
- cargo test --features hyperliquid
- 96 passed, 0 failed