### PR TITLE
perf(ws): disable Nagle on websocket connections

### DIFF
--- a/src/arch/task_execution/ws_runner.rs
+++ b/src/arch/task_execution/ws_runner.rs
@@ -25,7 +25,7 @@ use tokio::{
     sync::{broadcast, mpsc},
     time::{Duration, error::Elapsed, sleep, timeout},
 };
-use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async_with_config};
 use tungstenite::{
     Bytes, Error,
     client::IntoClientRequest,
@@ -81,10 +81,12 @@ impl WsTaskRunner {
             request.headers_mut().insert(header_name, header_value);
         }
 
-        let (ws_stream, _) = connect_async(request).await.map_err(|e| {
-            error!("WebSocket connection failed: {:?}", e);
-            InfraError::WebSocket(Box::new(e))
-        })?;
+        let (ws_stream, _) = connect_async_with_config(request, None, true)
+            .await
+            .map_err(|e| {
+                error!("WebSocket connection failed: {:?}", e);
+                InfraError::WebSocket(Box::new(e))
+            })?;
         Ok(ws_stream)
     }
     async fn handle_ws_msg<WsData, Decode>(


### PR DESCRIPTION
## Summary
- open every websocket through `connect_async_with_config(request, None, true)` so `tokio-tungstenite` sets `TCP_NODELAY` on the stream before the TLS handshake
- `connect_async` is a thin wrapper that hard-codes `disable_nagle = false`; with Nagle on, the second and later frames of any back-to-back burst are held in the kernel until the first frame is ACKed
- `WsTaskRunner::connect_websocket` is the only connect site, so this covers public, private, and order-route connections; return type is unchanged

## Performance
- measured with a Linux 6.8 receiver (client and echo server in one process, netem for RTT), two live connections interleaved so both modes see the same conditions
- RTT 2 ms, server replies immediately, burst of 4: frame 2-4 p50 5.54 ms (Nagle) vs 2.80 ms (`TCP_NODELAY`), i.e. one extra RTT
- server replies after 10 ms: frame 2 p50 25.2 ms vs 13.3 ms, i.e. the hold equals the server's reply latency
- server replies after 50 ms: frame 2 p50 101.3 ms vs 56.3 ms, i.e. Linux `TCP_DELACK_MIN` (40 ms) plus RTT
- market data and account streams are unaffected (Nagle only delays what we send); REST is unaffected (`reqwest` already sets `TCP_NODELAY`)
- full method, tables, and reproducible harness will be posted in Discussions

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`: 169 unit + 7 integration + 9 doctests passed
