### PR TITLE
chore: prepare v0.3.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.3.13"
+version = "0.3.14"
 edition = "2024"
 
 readme = "README.md"


### PR DESCRIPTION
## Summary

- bump `extrema_infra` from 0.3.13 to 0.3.14

## Included in v0.3.14

- #122: open every websocket with `TCP_NODELAY` (`connect_async_with_config(request, None, true)`), so back-to-back frames are no longer held by Nagle until the previous frame is ACKed; measurements in Discussion #123

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (169 unit, 7 integration, 9 doc tests passed; 6 doc tests ignored)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- `cargo publish --dry-run --all-features --allow-dirty` (256 files, 2.4 MiB uncompressed / 1.5 MiB compressed)
- `git diff --check`
