### PR TITLE
feat(binance): expose UM ADL quantiles

### DIFF
--- a/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
+++ b/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
@@ -26,6 +26,7 @@ use super::{
         account_balance::RestAccountBalBinanceUM,
         account_config::RestAccountConfigBinanceUM,
         account_position_risk::RestAccountPosRiskBinanceUM,
+        adl_quantile::RestPositionAdlQuantileBinanceUM,
         candle::RestCandleBinanceUM,
         exchange_info::RestExchangeInfoBinanceUM,
         funding_rate::RestFundingRateBinanceUM,
@@ -380,6 +381,28 @@ impl BinanceUmCli {
                 query_string.as_deref(),
                 BINANCE_UM_FUTURES_BASE_URL,
                 BINANCE_UM_FUTURES_SYMBOL_CONFIG,
+            )
+            .await?;
+
+        res.into_vec()
+    }
+
+    pub async fn get_position_adl_quantiles(
+        &self,
+        inst: Option<&str>,
+    ) -> InfraResult<Vec<RestPositionAdlQuantileBinanceUM>> {
+        let query_string = inst.map(|s| format!("symbol={}", cli_perp_to_pure_uppercase(s)));
+
+        let res: RestResBinance<RestPositionAdlQuantileBinanceUM> = self
+            .api_key
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_signed_request(
+                &self.client,
+                RequestMethod::Get,
+                query_string.as_deref(),
+                BINANCE_UM_FUTURES_BASE_URL,
+                BINANCE_UM_FUTURES_POSITION_ADL_QUANTILE,
             )
             .await?;
 

--- a/src/arch/market_assets/exchange/binance/config_assets.rs
+++ b/src/arch/market_assets/exchange/binance/config_assets.rs
@@ -37,6 +37,7 @@ pub const BINANCE_UM_FUTURES_POSITION_MODE: &str = "/fapi/v1/positionSide/dual";
 pub const BINANCE_UM_FUTURES_ACCOUNT_CONFIG: &str = "/fapi/v1/accountConfig";
 pub const BINANCE_UM_FUTURES_SYMBOL_CONFIG: &str = "/fapi/v1/symbolConfig";
 pub const BINANCE_UM_FUTURES_POSITION_RISK_INFO: &str = "/fapi/v3/positionRisk";
+pub const BINANCE_UM_FUTURES_POSITION_ADL_QUANTILE: &str = "/fapi/v1/adlQuantile";
 pub const BINANCE_UM_FUTURES_TICKERS: &str = "/fapi/v2/ticker/price";
 pub const BINANCE_UM_FUTURES_KLINES: &str = "/fapi/v1/klines";
 pub const BINANCE_UM_FUTURES_DEPTH: &str = "/fapi/v1/depth";

--- a/src/arch/market_assets/exchange/binance/schemas/um_futures_rest.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/um_futures_rest.rs
@@ -1,6 +1,7 @@
 pub mod account_balance;
 pub mod account_config;
 pub mod account_position_risk;
+pub mod adl_quantile;
 pub mod candle;
 pub mod exchange_info;
 pub mod funding_rate;

--- a/src/arch/market_assets/exchange/binance/schemas/um_futures_rest/adl_quantile.rs
+++ b/src/arch/market_assets/exchange/binance/schemas/um_futures_rest/adl_quantile.rs
@@ -1,0 +1,41 @@
+use serde::Deserialize;
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+pub struct RestPositionAdlQuantileBinanceUM {
+    pub symbol: String,
+    pub adlQuantile: RestAdlQuantileBinanceUM,
+}
+
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+pub struct RestAdlQuantileBinanceUM {
+    pub LONG: u8,
+    pub SHORT: u8,
+    #[serde(default)]
+    pub BOTH: Option<u8>,
+    #[serde(default)]
+    pub HEDGE: Option<u8>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_one_way_and_cross_hedge_quantiles() {
+        let one_way: RestPositionAdlQuantileBinanceUM = serde_json::from_str(
+            r#"{"symbol":"BTCUSDT","adlQuantile":{"LONG":1,"SHORT":4,"BOTH":0}}"#,
+        )
+        .unwrap();
+        assert_eq!(one_way.adlQuantile.BOTH, Some(0));
+        assert_eq!(one_way.adlQuantile.HEDGE, None);
+
+        let cross_hedge: RestPositionAdlQuantileBinanceUM = serde_json::from_str(
+            r#"{"symbol":"ETHUSDT","adlQuantile":{"LONG":3,"SHORT":3,"HEDGE":2}}"#,
+        )
+        .unwrap();
+        assert_eq!(cross_hedge.adlQuantile.BOTH, None);
+        assert_eq!(cross_hedge.adlQuantile.HEDGE, Some(2));
+    }
+}


### PR DESCRIPTION
## Summary
- add the signed Binance UM ADL quantile endpoint
- decode one-way and hedge-mode quantile fields
- support optional symbol filtering without changing generic position APIs

## Validation
- cargo fmt --all -- --check
- cargo check --features lob_clients
- cargo test --features lob_clients decodes_one_way_and_cross_hedge_quantiles
- live read-only request returned account ADL quantiles successfully