### PR TITLE
feat: expose Gate and OKX raw positions

### DIFF
--- a/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
@@ -243,6 +243,37 @@ impl GateFuturesCli {
         Ok(msg.to_string())
     }
 
+    pub async fn get_positions_raw(
+        &self,
+        settle: &str,
+    ) -> InfraResult<Vec<RestAccountPosGateFutures>> {
+        let endpoint = GATE_FUTURES_POSITIONS.replace("{settle}", settle);
+        let res: RestResGate<RestAccountPosGateFutures> = self
+            .api_key
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_signed_request(
+                &self.client,
+                RequestMethod::Get,
+                None,
+                None,
+                GATE_BASE_URL,
+                &endpoint,
+            )
+            .await?;
+
+        match res {
+            RestResGate::Error { label, message }
+                if label == "USER_NOT_FOUND"
+                    || message
+                        .contains("please transfer funds first to create futures account") =>
+            {
+                Ok(Vec::new())
+            },
+            other => other.into_vec(),
+        }
+    }
+
     pub async fn get_funding_rate_history(
         &self,
         settle: &str,
@@ -889,35 +920,9 @@ impl GateFuturesCli {
 
         let mut data: Vec<PositionData> = Vec::new();
         for settle in settles {
-            let endpoint = GATE_FUTURES_POSITIONS.replace("{settle}", &settle);
-            let res: RestResGate<RestAccountPosGateFutures> = self
-                .api_key
-                .as_ref()
-                .ok_or(InfraError::ApiCliNotInitialized)?
-                .send_signed_request(
-                    &self.client,
-                    RequestMethod::Get,
-                    None,
-                    None,
-                    GATE_BASE_URL,
-                    &endpoint,
-                )
-                .await?;
-
-            let pos_raw = match res {
-                RestResGate::Error { label, message }
-                    if label == "USER_NOT_FOUND"
-                        || message
-                            .contains("please transfer funds first to create futures account") =>
-                {
-                    continue;
-                },
-                other => other,
-            };
-
             data.extend(
-                pos_raw
-                    .into_vec()?
+                self.get_positions_raw(&settle)
+                    .await?
                     .into_iter()
                     .filter(|p| value_to_f64(&p.size) != 0.0)
                     .filter(|t| match insts {

--- a/src/arch/market_assets/exchange/gate/schemas/futures_rest/account_position.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/futures_rest/account_position.rs
@@ -17,6 +17,8 @@ pub struct RestAccountPosGateFutures {
     pub mark_price: Option<Value>,
     pub initial_margin: Option<Value>,
     pub lever: Option<Value>,
+    /// ADL rank: 1 is highest, 5 is lowest, and 6 means no position or liquidation.
+    pub adl_ranking: Option<u8>,
     pub update_time: Option<Value>,
 }
 

--- a/src/arch/market_assets/exchange/okx/okx_cli.rs
+++ b/src/arch/market_assets/exchange/okx/okx_cli.rs
@@ -302,6 +302,34 @@ impl OkxCli {
         res.into_vec()
     }
 
+    pub async fn get_positions_raw(
+        &self,
+        insts: Option<&[String]>,
+    ) -> InfraResult<Vec<RestAccountPosOkx>> {
+        let body = match insts {
+            Some(ids) if !ids.is_empty() => {
+                let okx_ids: Vec<String> = ids.iter().map(|s| cli_perp_to_okx_inst(s)).collect();
+                json!({ "instId": okx_ids.join(",") }).to_string()
+            },
+            _ => "{}".into(),
+        };
+
+        let res: RestResOkx<RestAccountPosOkx> = self
+            .api_key
+            .as_ref()
+            .ok_or(InfraError::ApiCliNotInitialized)?
+            .send_signed_request(
+                &self.client,
+                RequestMethod::Get,
+                body,
+                OKX_BASE_URL,
+                OKX_ACCOUNT_POSITIONS,
+            )
+            .await?;
+
+        res.into_vec()
+    }
+
     pub async fn get_account_config(&self) -> InfraResult<Vec<RestAccountConfigOkx>> {
         let res: RestResOkx<RestAccountConfigOkx> = self
             .api_key
@@ -1324,29 +1352,9 @@ impl OkxCli {
     }
 
     async fn _get_positions(&self, insts: Option<&[String]>) -> InfraResult<Vec<PositionData>> {
-        let body = match insts {
-            Some(ids) if !ids.is_empty() => {
-                let okx_ids: Vec<String> = ids.iter().map(|s| cli_perp_to_okx_inst(s)).collect();
-                json!({ "instId": okx_ids.join(",") }).to_string()
-            },
-            _ => "{}".into(),
-        };
-
-        let res: RestResOkx<RestAccountPosOkx> = self
-            .api_key
-            .as_ref()
-            .ok_or(InfraError::ApiCliNotInitialized)?
-            .send_signed_request(
-                &self.client,
-                RequestMethod::Get,
-                body,
-                OKX_BASE_URL,
-                OKX_ACCOUNT_POSITIONS,
-            )
-            .await?;
-
-        let data: Vec<PositionData> = res
-            .into_vec()?
+        let data: Vec<PositionData> = self
+            .get_positions_raw(insts)
+            .await?
             .into_iter()
             .map(PositionData::from)
             .collect();

--- a/src/arch/market_assets/exchange/okx/schemas/rest/account_positions.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/rest/account_positions.rs
@@ -18,6 +18,8 @@ pub struct RestAccountPosOkx {
     pub markPx: String,
     pub margin: Option<String>,
     pub lever: String,
+    /// ADL level from 0 (lowest priority) to 5 (highest priority).
+    pub adl: Option<String>,
     pub uTime: String,
 }
 


### PR DESCRIPTION
## Summary
- expose typed Gate futures raw positions, including `adl_ranking`
- expose typed OKX raw positions, including `adl`
- keep normalized `get_positions()` behavior by converting from the new raw methods
- document the opposite Gate and OKX ADL ranking directions

## Validation
- `cargo fmt`
- Linux release build through `api_checkers`
- largepo live read-only Gate query: 974 raw rows, 84 open positions, ADL ranks decoded
- largepo live read-only OKX query: 35 positions, ADL levels decoded
- OKX single-instrument raw query returned the requested position

No orders, transfers, or strategy restarts were performed.