### PR TITLE
chore: prepare extrema infra 0.3.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.3.14"
+version = "0.3.15"
 edition = "2024"
 
 readme = "README.md"
@@ -52,7 +52,7 @@ rustls = { version = "0.23.43", features = ["aws-lc-rs"] }
 
 # IPC / Model inference / Data processing
 zeromq = { version = "0.6.0", optional = true }
-tract-onnx = { version = "0.23.5", optional = true }
+tract-onnx = { version = "0.23.6", optional = true }
 polars = { version = "0.55.2", default-features = false, optional = true }
 
 # Logging & Tracing


### PR DESCRIPTION
## Summary
- bump extrema_infra from 0.3.14 to 0.3.15
- upgrade optional tract-onnx from 0.23.5 to 0.23.6

## Validation
- not run (manifest-only version updates)