### PR TITLE
feat: add Gate and OKX market-level ADL warning signals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.3.15"
+version = "0.3.16"
 edition = "2024"
 
 readme = "README.md"

--- a/src/arch/market_assets/exchange/gate/api_utils.rs
+++ b/src/arch/market_assets/exchange/gate/api_utils.rs
@@ -8,6 +8,10 @@ use crate::arch::{
     market_assets::{
         api_general::{CancelOrderParams, OrderParams, get_seconds_timestamp},
         base_data::{OrderSide, OrderType, SUBSCRIBE_LOWER},
+        exchange::gate::{
+            config_assets::GATE_WS_FUTURES_ADL_WARNING, gate_ws_msg::GateWsData,
+            schemas::futures_ws::adl_warning::WsAdlWarningGateFutures,
+        },
     },
     task_execution::task_ws::LobFrequency,
 };
@@ -154,6 +158,30 @@ pub fn ws_subscribe_msg_gate_futures(channel: &str, payload: Vec<String>) -> Str
     });
 
     msg.to_string()
+}
+
+pub fn ws_subscribe_adl_warning_msg_gate_futures(insts: Option<&[String]>) -> InfraResult<String> {
+    let payload = match insts {
+        Some(list) if !list.is_empty() => gate_contracts_from_insts(insts)?,
+        _ => vec!["!all".into()],
+    };
+
+    Ok(ws_subscribe_msg_gate_futures(
+        GATE_WS_FUTURES_ADL_WARNING,
+        payload,
+    ))
+}
+
+/// Decodes one raw `futures.adl_warning` frame delivered through `on_ws_other`.
+///
+/// Subscription acknowledgements and other event frames decode to an empty
+/// vector. The `all` snapshot and `update` frames both decode to their entries.
+pub fn parse_ws_adl_warning_gate(raw_json: &str) -> InfraResult<Vec<WsAdlWarningGateFutures>> {
+    match GateWsData::<WsAdlWarningGateFutures>::decode_batch(raw_json.as_bytes())? {
+        GateWsData::Channel(batch) => Ok(batch.result),
+        GateWsData::Single(single) => Ok(vec![single.result]),
+        GateWsData::Event(_) => Ok(Vec::new()),
+    }
 }
 
 pub fn gate_fut_inst_to_cli(symbol: &str) -> String {

--- a/src/arch/market_assets/exchange/gate/config_assets.rs
+++ b/src/arch/market_assets/exchange/gate/config_assets.rs
@@ -34,6 +34,7 @@ pub const GATE_UNI_SUB_ACCOUNTS: &str = "/api/v4/sub_accounts";
 pub const GATE_FUTURES_CONTRACTS: &str = "/api/v4/futures/{settle}/contracts";
 pub const GATE_FUTURES_CONTRACT: &str = "/api/v4/futures/{settle}/contracts/{contract}";
 pub const GATE_FUTURES_TICKERS: &str = "/api/v4/futures/{settle}/tickers";
+pub const GATE_FUTURES_ADL_RISK_STATES: &str = "/api/v4/futures/{settle}/adl_risk_states";
 pub const GATE_FUTURES_CANDLESTICKS: &str = "/api/v4/futures/{settle}/candlesticks";
 pub const GATE_FUTURES_ORDER_BOOK: &str = "/api/v4/futures/{settle}/order_book";
 pub const GATE_FUTURES_PREMIUM_INDEX: &str = "/api/v4/futures/{settle}/premium_index";
@@ -54,6 +55,7 @@ pub const GATE_WS_FUTURES_CANDLES: &str = "futures.candlesticks";
 pub const GATE_WS_FUTURES_BOOK_TICKER: &str = "futures.book_ticker";
 pub const GATE_WS_FUTURES_ORDER_BOOK: &str = "futures.order_book";
 pub const GATE_WS_FUTURES_ORDER_BOOK_UPDATE: &str = "futures.order_book_update";
+pub const GATE_WS_FUTURES_ADL_WARNING: &str = "futures.adl_warning";
 
 /// Delivery REST endpoints
 pub const GATE_DELIVERY_CONTRACTS: &str = "/api/v4/delivery/{settle}/contracts";

--- a/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
@@ -32,6 +32,7 @@ use super::{
     gate_rest_msg::RestResGate,
     schemas::futures_rest::{
         account_position::RestAccountPosGateFutures,
+        adl_risk_state::RestAdlRiskStatesGateFutures,
         candle::RestCandleGateFutures,
         contract_futures::RestContractGateFutures,
         funding_rate::RestFundingRateGateFutures,
@@ -511,6 +512,25 @@ impl GateFuturesCli {
             parse_json_response("GateFutures tickers", response).await?;
 
         res.into_vec()
+    }
+
+    pub async fn get_adl_risk_states(
+        &self,
+        settle: &str,
+    ) -> InfraResult<RestAdlRiskStatesGateFutures> {
+        let endpoint = GATE_FUTURES_ADL_RISK_STATES.replace("{settle}", settle);
+        let url = [GATE_BASE_URL, &endpoint].concat();
+
+        let response = self.client.get(url).send().await?;
+        let res: RestResGate<RestAdlRiskStatesGateFutures> =
+            parse_json_response("GateFutures adl_risk_states", response).await?;
+
+        res.into_vec()?
+            .into_iter()
+            .next()
+            .ok_or(InfraError::ApiCliError(
+                "No Gate ADL risk states returned".into(),
+            ))
     }
 
     async fn _get_tickers(
@@ -1122,6 +1142,9 @@ impl GateFuturesCli {
             WsChannel::Candles(channel) => self._ws_subscribe_candle(channel, insts),
             WsChannel::Trades(_) => self._ws_subscribe_trades(insts),
             WsChannel::Lob(lob_param) => self._ws_subscribe_lob(lob_param, insts),
+            WsChannel::Other(channel) if channel == GATE_WS_FUTURES_ADL_WARNING => {
+                ws_subscribe_adl_warning_msg_gate_futures(insts)
+            },
             _ => Err(InfraError::Unimplemented),
         }
     }
@@ -1202,14 +1225,35 @@ impl GateFuturesCli {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::Value;
+
     use crate::arch::{
         market_assets::exchange::gate::{
             api_utils::{GATE_SIZE_DECIMAL_HEADER, GATE_SIZE_DECIMAL_HEADER_VALUE},
+            config_assets::GATE_WS_FUTURES_ADL_WARNING,
             gate_futures_cli::GateFuturesCli,
         },
         task_execution::task_ws::{LobFrequency, LobParam, WsChannel},
         traits::market_lob::LobWebsocket,
     };
+
+    #[test]
+    fn builds_gate_adl_warning_subscribe_messages() {
+        let cli = GateFuturesCli::default();
+        let channel = WsChannel::Other(GATE_WS_FUTURES_ADL_WARNING.to_string());
+        let insts = vec!["BTC_USDT_PERP".to_string()];
+
+        let all: Value =
+            serde_json::from_str(&cli._get_public_sub_msg(&channel, None).unwrap()).unwrap();
+        assert_eq!(all["channel"], "futures.adl_warning");
+        assert_eq!(all["event"], "subscribe");
+        assert_eq!(all["payload"], serde_json::json!(["!all"]));
+
+        let one: Value =
+            serde_json::from_str(&cli._get_public_sub_msg(&channel, Some(&insts)).unwrap())
+                .unwrap();
+        assert_eq!(one["payload"], serde_json::json!(["BTC_USDT"]));
+    }
 
     #[tokio::test]
     async fn gate_futures_connect_target_requests_decimal_sizes() {

--- a/src/arch/market_assets/exchange/gate/schemas/futures_rest.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/futures_rest.rs
@@ -1,4 +1,5 @@
 pub mod account_position;
+pub mod adl_risk_state;
 pub mod candle;
 pub mod contract_futures;
 pub mod funding_rate;

--- a/src/arch/market_assets/exchange/gate/schemas/futures_rest/adl_risk_state.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/futures_rest/adl_risk_state.rs
@@ -1,0 +1,42 @@
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestAdlRiskStatesGateFutures {
+    pub settle: String,
+    pub states: HashMap<String, RestAdlRiskStateGateFutures>,
+}
+
+/// Market-level ADL risk state of one contract: `normal`, `warning` or `adl_risk`.
+#[derive(Clone, Debug, Deserialize)]
+pub struct RestAdlRiskStateGateFutures {
+    pub state: String,
+    pub calculated_at_ms: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn parses_market_adl_risk_states() {
+        let raw: RestAdlRiskStatesGateFutures = serde_json::from_value(json!({
+            "settle": "usdt",
+            "states": {
+                "BTC_USDT": { "state": "normal", "calculated_at_ms": 1788433195394u64 },
+                "AKE_USDT": { "state": "warning", "calculated_at_ms": 1788433195394u64 },
+                "BTW_USDT": { "state": "adl_risk", "calculated_at_ms": 1788433195394u64 }
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(raw.settle, "usdt");
+        assert_eq!(raw.states.len(), 3);
+        assert_eq!(raw.states["AKE_USDT"].state, "warning");
+        assert_eq!(raw.states["BTW_USDT"].state, "adl_risk");
+        assert_eq!(raw.states["BTC_USDT"].calculated_at_ms, 1788433195394);
+    }
+}

--- a/src/arch/market_assets/exchange/gate/schemas/futures_ws.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/futures_ws.rs
@@ -1,5 +1,6 @@
 pub(crate) mod account_order;
 pub(crate) mod account_position;
+pub(crate) mod adl_warning;
 pub(crate) mod candles;
 pub(crate) mod lob;
 pub(crate) mod trades;

--- a/src/arch/market_assets/exchange/gate/schemas/futures_ws/adl_warning.rs
+++ b/src/arch/market_assets/exchange/gate/schemas/futures_ws/adl_warning.rs
@@ -1,0 +1,77 @@
+use serde::Deserialize;
+use serde_json::Value;
+
+/// Market-level ADL risk state of one contract: `normal`, `warning` or `adl_risk`.
+///
+/// Gate pushes a full snapshot with `event: "all"` right after subscribing and
+/// `event: "update"` frames afterwards.
+#[derive(Clone, Debug, Deserialize)]
+pub struct WsAdlWarningGateFutures {
+    pub contract: String,
+    pub settle: String,
+    pub state: String,
+    #[serde(default)]
+    pub update_time: Option<Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::arch::market_assets::exchange::gate::api_utils::parse_ws_adl_warning_gate;
+
+    #[test]
+    fn parses_update_frame() {
+        let frame = json!({
+            "time": 1788433195,
+            "time_ms": 1788433195394u64,
+            "channel": "futures.adl_warning",
+            "event": "update",
+            "result": [
+                { "contract": "AKE_USDT", "settle": "usdt", "state": "warning", "update_time": 1788433195 },
+                { "contract": "BTW_USDT", "settle": "usdt", "state": "adl_risk", "update_time": 1788433195 }
+            ]
+        })
+        .to_string();
+
+        let data = parse_ws_adl_warning_gate(&frame).unwrap();
+
+        assert_eq!(data.len(), 2);
+        assert_eq!(data[0].contract, "AKE_USDT");
+        assert_eq!(data[0].settle, "usdt");
+        assert_eq!(data[0].state, "warning");
+        assert_eq!(data[0].update_time, Some(json!(1788433195)));
+        assert_eq!(data[1].state, "adl_risk");
+    }
+
+    #[test]
+    fn parses_single_object_result() {
+        let frame = json!({
+            "time": 1788433195,
+            "channel": "futures.adl_warning",
+            "event": "update",
+            "result": { "contract": "AKE_USDT", "settle": "usdt", "state": "normal" }
+        })
+        .to_string();
+
+        let data = parse_ws_adl_warning_gate(&frame).unwrap();
+
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0].state, "normal");
+        assert_eq!(data[0].update_time, None);
+    }
+
+    #[test]
+    fn subscribe_ack_yields_no_data() {
+        let frame = json!({
+            "time": 1788433195,
+            "channel": "futures.adl_warning",
+            "event": "subscribe",
+            "payload": ["!all"],
+            "result": { "status": "success" }
+        })
+        .to_string();
+
+        assert!(parse_ws_adl_warning_gate(&frame).unwrap().is_empty());
+    }
+}

--- a/src/arch/market_assets/exchange/okx/api_utils.rs
+++ b/src/arch/market_assets/exchange/okx/api_utils.rs
@@ -9,6 +9,10 @@ use crate::arch::{
         base_data::{
             InstrumentType, MarginMode, OrderSide, OrderType, PositionSide, SUBSCRIBE_LOWER,
         },
+        exchange::okx::{
+            config_assets::OKX_WS_ADL_WARNING, okx_ws_msg::OkxWsData,
+            schemas::ws::adl_warning::WsAdlWarningOkx,
+        },
     },
     task_execution::task_ws::CandleParam,
 };
@@ -133,6 +137,42 @@ pub fn ws_subscribe_msg_okx(channel: &str, insts: Option<&[String]>) -> String {
     subscribe_msg.to_string()
 }
 
+pub fn ws_subscribe_adl_warning_msg_okx(insts: Option<&[String]>) -> String {
+    let args: Vec<_> = match insts {
+        Some(list) => list
+            .iter()
+            .map(|inst| {
+                json!({
+                    "channel": OKX_WS_ADL_WARNING,
+                    "instType": "SWAP",
+                    "instFamily": cli_perp_to_okx_inst_family(inst),
+                })
+            })
+            .collect(),
+        None => vec![json!({ "channel": OKX_WS_ADL_WARNING, "instType": "SWAP" })],
+    };
+
+    let subscribe_msg = json!({
+        "op": SUBSCRIBE_LOWER,
+        "args": args
+    });
+
+    subscribe_msg.to_string()
+}
+
+/// Decodes one raw `adl-warning` frame delivered through `on_ws_other`.
+///
+/// Subscription acknowledgements and other event frames decode to an empty
+/// vector. OKX pushes this channel only while a family is in the `warning` or
+/// `adl` state, so callers must treat silence as `normal` and age out stale
+/// states themselves.
+pub fn parse_ws_adl_warning_okx(raw_json: &str) -> InfraResult<Vec<WsAdlWarningOkx>> {
+    match OkxWsData::<WsAdlWarningOkx>::decode_batch(raw_json.as_bytes())? {
+        OkxWsData::ChannelBatch(batch) => Ok(batch.data),
+        OkxWsData::Event(_) => Ok(Vec::new()),
+    }
+}
+
 pub fn get_okx_timestamp() -> String {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -155,6 +195,22 @@ pub fn cli_perp_to_okx_inst(symbol: &str) -> String {
     }
 
     upper.replace('_', "-")
+}
+
+pub fn cli_perp_to_okx_inst_family(symbol: &str) -> String {
+    let inst = cli_perp_to_okx_inst(symbol);
+    if let Some(family) = inst.strip_suffix("-SWAP") {
+        return family.to_string();
+    }
+
+    match inst.rsplit_once('-') {
+        Some((family, expiry))
+            if expiry.len() == 6 && expiry.chars().all(|c| c.is_ascii_digit()) =>
+        {
+            family.to_string()
+        },
+        _ => inst,
+    }
 }
 
 pub fn cli_inst_to_okx_inst(symbol: &str, inst_type: &InstrumentType) -> InfraResult<String> {

--- a/src/arch/market_assets/exchange/okx/config_assets.rs
+++ b/src/arch/market_assets/exchange/okx/config_assets.rs
@@ -42,3 +42,4 @@ pub const OKX_CT_LEADTRADER_SUBPOSITIONS_HISTORY: &str =
 
 /// WebSocket channels
 pub const OKX_WS_LOGIN: &str = "GET/users/self/verify";
+pub const OKX_WS_ADL_WARNING: &str = "adl-warning";

--- a/src/arch/market_assets/exchange/okx/okx_cli.rs
+++ b/src/arch/market_assets/exchange/okx/okx_cli.rs
@@ -1504,6 +1504,7 @@ impl OkxCli {
             WsChannel::Candles(_) => OKX_WS_BUS,
             WsChannel::Lob(_) | WsChannel::Trades(None) => OKX_WS_PUB,
             WsChannel::Other(s) if s == "instruments" || s == "funding-rate" => OKX_WS_BUS,
+            WsChannel::Other(s) if s == OKX_WS_ADL_WARNING => OKX_WS_PUB,
             _ => return Err(InfraError::Unimplemented),
         };
 
@@ -1519,6 +1520,9 @@ impl OkxCli {
             WsChannel::Candles(channel) => self._ws_subscribe_candle(channel, insts),
             WsChannel::Trades(trades_param) => self._ws_subscribe_trades(trades_param, insts),
             WsChannel::Lob(lob_param) => self._ws_subscribe_lob(lob_param, insts),
+            WsChannel::Other(channel) if channel == OKX_WS_ADL_WARNING => {
+                Ok(ws_subscribe_adl_warning_msg_okx(insts))
+            },
             _ => Err(InfraError::Unimplemented),
         }
     }
@@ -1641,6 +1645,27 @@ mod tests {
             cli.get_mark_prices_raw(Some(InstrumentType::Spot)).await,
             Err(InfraError::ApiCliError(_))
         ));
+    }
+
+    #[test]
+    fn builds_okx_adl_warning_connect_and_subscribe_messages() {
+        let cli = OkxCli::default();
+        let channel = WsChannel::Other(OKX_WS_ADL_WARNING.to_string());
+        let insts = vec!["BTC_USDT_PERP".to_string()];
+
+        assert_eq!(cli._get_public_connect_msg(&channel).unwrap(), OKX_WS_PUB);
+
+        let all: Value =
+            serde_json::from_str(&cli._get_public_sub_msg(&channel, None).unwrap()).unwrap();
+        assert_eq!(all["op"], "subscribe");
+        assert_eq!(all["args"][0]["channel"], "adl-warning");
+        assert_eq!(all["args"][0]["instType"], "SWAP");
+        assert!(all["args"][0].get("instFamily").is_none());
+
+        let family: Value =
+            serde_json::from_str(&cli._get_public_sub_msg(&channel, Some(&insts)).unwrap())
+                .unwrap();
+        assert_eq!(family["args"][0]["instFamily"], "BTC-USDT");
     }
 
     #[test]

--- a/src/arch/market_assets/exchange/okx/schemas/ws.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/ws.rs
@@ -1,6 +1,7 @@
 pub(crate) mod account_bal_and_pos;
 pub(crate) mod account_order;
 pub(crate) mod account_position;
+pub(crate) mod adl_warning;
 pub(crate) mod candles;
 pub(crate) mod lob;
 pub(crate) mod trades;

--- a/src/arch/market_assets/exchange/okx/schemas/ws/adl_warning.rs
+++ b/src/arch/market_assets/exchange/okx/schemas/ws/adl_warning.rs
@@ -1,0 +1,72 @@
+use serde::Deserialize;
+use serde_json::Value;
+
+/// Market-level ADL state of one instrument family: `normal`, `warning` or `adl`.
+///
+/// Since 2026-06 OKX no longer pushes this channel while a family is in the
+/// `normal` state, so the absence of frames means normal and consumers must age
+/// out a previously received `warning` or `adl` state themselves. `maxBal`,
+/// `bal`, `decRate` and `adlType` currently arrive as empty strings.
+#[allow(non_snake_case)]
+#[derive(Clone, Debug, Deserialize)]
+pub struct WsAdlWarningOkx {
+    pub instType: String,
+    pub instFamily: String,
+    pub state: String,
+    #[serde(default)]
+    pub maxBal: Option<Value>,
+    #[serde(default)]
+    pub bal: Option<Value>,
+    #[serde(default)]
+    pub decRate: Option<Value>,
+    #[serde(default)]
+    pub adlType: Option<Value>,
+    #[serde(default)]
+    pub ts: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::arch::market_assets::exchange::okx::api_utils::parse_ws_adl_warning_okx;
+
+    #[test]
+    fn parses_warning_frame_with_empty_fields() {
+        let frame = json!({
+            "arg": { "channel": "adl-warning", "instType": "SWAP", "instFamily": "BTC-USDT" },
+            "data": [{
+                "instType": "SWAP",
+                "instFamily": "BTC-USDT",
+                "state": "warning",
+                "maxBal": "",
+                "bal": "",
+                "decRate": "",
+                "adlType": "",
+                "ts": "1788433195394"
+            }]
+        })
+        .to_string();
+
+        let data = parse_ws_adl_warning_okx(&frame).unwrap();
+
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0].instType, "SWAP");
+        assert_eq!(data[0].instFamily, "BTC-USDT");
+        assert_eq!(data[0].state, "warning");
+        assert_eq!(data[0].ts.as_deref(), Some("1788433195394"));
+        assert_eq!(data[0].maxBal, Some(json!("")));
+    }
+
+    #[test]
+    fn subscribe_ack_yields_no_data() {
+        let frame = json!({
+            "event": "subscribe",
+            "arg": { "channel": "adl-warning", "instType": "SWAP" },
+            "connId": "a4d3ae55"
+        })
+        .to_string();
+
+        assert!(parse_ws_adl_warning_okx(&frame).unwrap().is_empty());
+    }
+}


### PR DESCRIPTION
Market-level ADL state for the two venues that expose it, raw schemas only.

- Gate: `GateFuturesCli::get_adl_risk_states(settle)` over `GET /futures/{settle}/adl_risk_states`
- Gate: `futures.adl_warning` public channel via `WsChannel::Other`, `parse_ws_adl_warning_gate`
- OKX: `adl-warning` public channel via `WsChannel::Other`, `parse_ws_adl_warning_okx`,
  market-wide subscription or per `instFamily`

OKX and Gate stay silent while every family is normal, so consumers must age out
warning states themselves; noted in the schema docs.

Verified live: Gate REST returns 981 contracts, both websocket subscriptions are
acknowledged. Data frames are covered by fixtures only since no venue is in warning.

Bumps the crate to 0.3.16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)