### PR TITLE
fix(rest): report the reqwest source chain on REST and body errors

### DIFF
--- a/src/arch/market_assets/api_general.rs
+++ b/src/arch/market_assets/api_general.rs
@@ -253,15 +253,43 @@ where
     Ok(ts_to_micros(de_u64_from_string_or_number(deserializer)?))
 }
 
+pub fn describe_reqwest_error(e: &reqwest::Error) -> String {
+    let mut out = e.to_string();
+    let mut source = std::error::Error::source(e);
+    while let Some(inner) = source {
+        out.push_str(": ");
+        out.push_str(&inner.to_string());
+        source = inner.source();
+    }
+    let flags: Vec<&str> = [
+        (e.is_timeout(), "timeout"),
+        (e.is_connect(), "connect"),
+        (e.is_request(), "request"),
+        (e.is_body(), "body"),
+        (e.is_decode(), "decode"),
+    ]
+    .into_iter()
+    .filter_map(|(hit, name)| hit.then_some(name))
+    .collect();
+    if !flags.is_empty() {
+        out.push_str(" [");
+        out.push_str(&flags.join(","));
+        out.push(']');
+    }
+    out
+}
+
 pub async fn parse_json_response<T>(label: &str, response: reqwest::Response) -> InfraResult<T>
 where
     T: DeserializeOwned,
 {
     let status = response.status();
-    let bytes = response
-        .bytes()
-        .await
-        .map_err(|e| InfraError::Msg(format!("[{label}] body read failed: {e}")))?;
+    let bytes = response.bytes().await.map_err(|e| {
+        InfraError::Msg(format!(
+            "[{label}] body read failed: {}",
+            describe_reqwest_error(&e)
+        ))
+    })?;
 
     let mut bytes = match bytes.try_into_mut() {
         Ok(bytes) => bytes,
@@ -319,6 +347,22 @@ pub struct CancelOrderParams {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn describe_reqwest_error_keeps_the_source_chain_and_flags() {
+        let err = reqwest::Client::new()
+            .get("http://127.0.0.1:9/")
+            .send()
+            .await
+            .expect_err("closed port must fail");
+        let described = describe_reqwest_error(&err);
+        assert!(described.starts_with(&err.to_string()));
+        assert!(described.len() > err.to_string().len(), "{described}");
+        assert!(
+            described.contains("[") && described.contains("connect"),
+            "{described}"
+        );
+    }
 
     #[test]
     fn maps_supported_candle_intervals_to_millis() {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,7 +13,7 @@ pub enum InfraError {
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 
-    #[error("REST API error: {0}")]
+    #[error("REST API error: {}", crate::arch::market_assets::api_general::describe_reqwest_error(.0))]
     RestApi(#[from] reqwest::Error),
 
     #[error("WebSocket error: {0}")]


### PR DESCRIPTION
## Summary

`reqwest::Error`'s `Display` stops at the top-level kind, so a body cut by the server (`stream reset by peer` / `connection closed before message completed`) and a body read that hit the client's total timeout (`operation timed out`) both reached the logs as `error decoding response body for url (...)`. Five live orchestrator instances log 5–30 of these per day against Gate's 1.27 MB `contracts` list and Binance's `exchangeInfo`, and the line cannot say which side gave up.

## Change

- `api_general::describe_reqwest_error` renders the error followed by its full `source()` chain and the kind flags that apply (`timeout`, `connect`, `request`, `body`, `decode`).
- `parse_json_response` uses it for `body read failed`; `InfraError::RestApi`'s `#[error]` uses it for send errors. Message prefixes are unchanged, only the tail gains detail.

No behaviour change.

## Tests

- `describe_reqwest_error_keeps_the_source_chain_and_flags`: a real `reqwest::Error` from a closed local port keeps the original `Display` as prefix, gains the chain, and carries the `connect` flag.

`cargo fmt`, `cargo clippy --all-targets` clean; `cargo test` 65 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)