### PR TITLE
feat(gate): expose the raw futures contracts list, prepare 0.3.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.3.16"
+version = "0.3.17"
 edition = "2024"
 
 readme = "README.md"

--- a/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
@@ -503,6 +503,13 @@ impl GateFuturesCli {
         res.into_vec()
     }
 
+    pub async fn get_futures_contracts_raw(
+        &self,
+        settle: &str,
+    ) -> InfraResult<Vec<RestContractGateFutures>> {
+        self._get_futures_contracts(settle, None, None).await
+    }
+
     pub async fn get_tickers_raw(&self, settle: &str) -> InfraResult<Vec<RestTickerGateFutures>> {
         let endpoint = GATE_FUTURES_TICKERS.replace("{settle}", settle);
         let url = [GATE_BASE_URL, &endpoint].concat();


### PR DESCRIPTION
## Summary

`get_funding_rate_info`, `get_funding_rate_live_all` and `get_instrument_info` on `GateFuturesCli` all GET `/futures/{settle}/contracts` (1.27 MB for usdt) and map the same list three different ways. funding_carry calls all three every 30 s refresh, so each live instance downloads the same list three times per round on top of the orchestrator's own instrument refresh, and the three requests land in the same second as everything else. Live logs show the occasional truncated body on exactly those seconds.

## Change

- `get_futures_contracts_raw(settle)` returns the deserialised contracts list once, next to `get_tickers_raw` / `get_positions_raw`. The three converting methods are untouched; callers that want one fetch map the list with the existing `From<RestContractGateFutures>` impls.
- Version bump to 0.3.17 so this and #130 (reqwest source chain in REST/body errors) ship in one release.

No behaviour change for existing callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)