### PR TITLE
refactor(lob): drop order_id from get_order_history

### DIFF
--- a/src/arch/market_assets/exchange/binance/binance_spot_cli.rs
+++ b/src/arch/market_assets/exchange/binance/binance_spot_cli.rs
@@ -121,9 +121,8 @@ impl LobPrivateRest for BinanceSpotCli {
         start_time_us: Option<u64>,
         end_time_us: Option<u64>,
         limit: Option<u32>,
-        order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
-        self._get_order_history(inst, start_time_us, end_time_us, limit, order_id)
+        self._get_order_history(inst, start_time_us, end_time_us, limit)
             .await
     }
 }
@@ -757,24 +756,17 @@ impl BinanceSpotCli {
         start_time_us: Option<u64>,
         end_time_us: Option<u64>,
         limit: Option<u32>,
-        order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
         let mut query_string = format!("symbol={}", cli_spot_to_binance_spot(inst));
-        let endpoint = if let Some(order_id) = order_id {
-            query_string.push_str(&format!("&orderId={order_id}"));
-            BINANCE_SPOT_PLACE_ORDER
-        } else {
-            if let Some(start_time_us) = start_time_us {
-                query_string.push_str(&format!("&startTime={}", micros_to_millis(start_time_us)));
-            }
-            if let Some(end_time_us) = end_time_us {
-                query_string.push_str(&format!("&endTime={}", micros_to_millis(end_time_us)));
-            }
-            if let Some(limit) = limit {
-                query_string.push_str(&format!("&limit={limit}"));
-            }
-            BINANCE_SPOT_ALL_ORDERS
-        };
+        if let Some(start_time_us) = start_time_us {
+            query_string.push_str(&format!("&startTime={}", micros_to_millis(start_time_us)));
+        }
+        if let Some(end_time_us) = end_time_us {
+            query_string.push_str(&format!("&endTime={}", micros_to_millis(end_time_us)));
+        }
+        if let Some(limit) = limit {
+            query_string.push_str(&format!("&limit={limit}"));
+        }
 
         let res: RestResBinance<RestOrderHistoryBinanceSpot> = self
             .api_key
@@ -785,7 +777,7 @@ impl BinanceSpotCli {
                 RequestMethod::Get,
                 Some(&query_string),
                 BINANCE_SPOT_BASE_URL,
-                endpoint,
+                BINANCE_SPOT_ALL_ORDERS,
             )
             .await?;
 

--- a/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
+++ b/src/arch/market_assets/exchange/binance/binance_um_futures_cli.rs
@@ -173,9 +173,8 @@ impl LobPrivateRest for BinanceUmCli {
         start_time_us: Option<u64>,
         end_time_us: Option<u64>,
         limit: Option<u32>,
-        order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
-        self._get_order_history(inst, start_time_us, end_time_us, limit, order_id)
+        self._get_order_history(inst, start_time_us, end_time_us, limit)
             .await
     }
 }
@@ -1164,13 +1163,8 @@ impl BinanceUmCli {
         start_time_us: Option<u64>,
         end_time_us: Option<u64>,
         limit: Option<u32>,
-        order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
         let mut query_string = format!("symbol={}", cli_perp_to_pure_uppercase(inst));
-
-        if let Some(oid) = order_id {
-            query_string.push_str(&format!("&orderId={}", oid));
-        }
 
         if let Some(start_time_us) = start_time_us {
             query_string.push_str(&format!("&startTime={}", micros_to_millis(start_time_us)));

--- a/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_futures_cli.rs
@@ -173,9 +173,8 @@ impl LobPrivateRest for GateFuturesCli {
         start_time_us: Option<u64>,
         end_time_us: Option<u64>,
         limit: Option<u32>,
-        order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
-        self._get_order_history(inst, start_time_us, end_time_us, limit, order_id)
+        self._get_order_history(inst, start_time_us, end_time_us, limit)
             .await
     }
 }
@@ -1116,34 +1115,21 @@ impl GateFuturesCli {
         start_time_us: Option<u64>,
         end_time_us: Option<u64>,
         limit: Option<u32>,
-        order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
         let settle = infer_settle_from_inst(inst);
         let contract = cli_perp_to_gate_inst(inst);
 
-        let (endpoint, query_string) = if let Some(order_id) = order_id {
-            (
-                GATE_FUTURES_ORDER
-                    .replace("{settle}", &settle)
-                    .replace("{order_id}", order_id),
-                None,
-            )
-        } else {
-            let mut query = format!("status=finished&contract={}", contract);
-            if let Some(start_time_us) = start_time_us {
-                query.push_str(&format!("&from={}", micros_to_seconds(start_time_us)));
-            }
-            if let Some(end_time_us) = end_time_us {
-                query.push_str(&format!("&to={}", micros_to_seconds(end_time_us)));
-            }
-            if let Some(limit) = limit {
-                query.push_str(&format!("&limit={}", limit));
-            }
-            (
-                GATE_FUTURES_ORDERS.replace("{settle}", &settle),
-                Some(query),
-            )
-        };
+        let endpoint = GATE_FUTURES_ORDERS.replace("{settle}", &settle);
+        let mut query_string = format!("status=finished&contract={}", contract);
+        if let Some(start_time_us) = start_time_us {
+            query_string.push_str(&format!("&from={}", micros_to_seconds(start_time_us)));
+        }
+        if let Some(end_time_us) = end_time_us {
+            query_string.push_str(&format!("&to={}", micros_to_seconds(end_time_us)));
+        }
+        if let Some(limit) = limit {
+            query_string.push_str(&format!("&limit={}", limit));
+        }
 
         let res: RestResGate<RestFuturesOrderHistoryGateFutures> = self
             .api_key
@@ -1152,7 +1138,7 @@ impl GateFuturesCli {
             .send_signed_request(
                 &self.client,
                 RequestMethod::Get,
-                query_string.as_deref(),
+                Some(&query_string),
                 None,
                 GATE_BASE_URL,
                 &endpoint,

--- a/src/arch/market_assets/exchange/gate/gate_spot_cli.rs
+++ b/src/arch/market_assets/exchange/gate/gate_spot_cli.rs
@@ -138,9 +138,8 @@ impl LobPrivateRest for GateSpotCli {
         start_time_us: Option<u64>,
         end_time_us: Option<u64>,
         limit: Option<u32>,
-        order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
-        self._get_order_history(inst, start_time_us, end_time_us, limit, order_id)
+        self._get_order_history(inst, start_time_us, end_time_us, limit)
             .await
     }
 }
@@ -650,27 +649,18 @@ impl GateSpotCli {
         start_time_us: Option<u64>,
         end_time_us: Option<u64>,
         limit: Option<u32>,
-        order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
         let currency_pair = inst.to_uppercase();
-        let (endpoint, query_string) = if let Some(order_id) = order_id {
-            (
-                GATE_SPOT_ORDER.replace("{order_id}", order_id),
-                format!("currency_pair={currency_pair}"),
-            )
-        } else {
-            let mut query = format!("currency_pair={currency_pair}&status=finished");
-            if let Some(start_time_us) = start_time_us {
-                query.push_str(&format!("&from={}", micros_to_seconds(start_time_us)));
-            }
-            if let Some(end_time_us) = end_time_us {
-                query.push_str(&format!("&to={}", micros_to_seconds(end_time_us)));
-            }
-            if let Some(limit) = limit {
-                query.push_str(&format!("&limit={limit}"));
-            }
-            (GATE_SPOT_ORDERS.into(), query)
-        };
+        let mut query_string = format!("currency_pair={currency_pair}&status=finished");
+        if let Some(start_time_us) = start_time_us {
+            query_string.push_str(&format!("&from={}", micros_to_seconds(start_time_us)));
+        }
+        if let Some(end_time_us) = end_time_us {
+            query_string.push_str(&format!("&to={}", micros_to_seconds(end_time_us)));
+        }
+        if let Some(limit) = limit {
+            query_string.push_str(&format!("&limit={limit}"));
+        }
 
         let res: RestResGate<RestOrderHistoryGateSpot> = self
             .api_key
@@ -682,7 +672,7 @@ impl GateSpotCli {
                 Some(&query_string),
                 None,
                 GATE_BASE_URL,
-                &endpoint,
+                GATE_SPOT_ORDERS,
             )
             .await?;
 

--- a/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/hyperliquid_cli.rs
@@ -177,9 +177,8 @@ impl LobPrivateRest for HyperliquidCli {
         start_time_us: Option<u64>,
         end_time_us: Option<u64>,
         limit: Option<u32>,
-        order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
-        self._get_order_history(inst, start_time_us, end_time_us, limit, order_id)
+        self._get_order_history(inst, start_time_us, end_time_us, limit)
             .await
     }
 }
@@ -1115,27 +1114,13 @@ impl HyperliquidCli {
         start_time_us: Option<u64>,
         end_time_us: Option<u64>,
         limit: Option<u32>,
-        order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
         validate_hyperliquid_order_history_range(start_time_us, end_time_us)?;
 
-        let user = self._owner_address()?;
-        let body = match order_id {
-            Some(order_id) => json!({
-                "type": "orderStatus",
-                "user": user,
-                "oid": order_id.parse::<u64>().map_err(|_| {
-                    InfraError::ApiCliError(format!(
-                        "Invalid Hyperliquid order_id, expected u64 string: {}",
-                        order_id
-                    ))
-                })?,
-            }),
-            None => json!({
-                "type": "historicalOrders",
-                "user": user,
-            }),
-        };
+        let body = json!({
+            "type": "historicalOrders",
+            "user": self._owner_address()?,
+        });
 
         let normalized_inst = normalize_hyperliquid_cli_inst(inst);
         let raw_coin = self._inst_to_trade_coin(inst)?;
@@ -1165,7 +1150,6 @@ impl HyperliquidCli {
             start_time_us,
             end_time_us,
             limit,
-            order_id.is_none(),
         )
     }
 

--- a/src/arch/market_assets/exchange/hyperliquid/schemas/rest/order_status.rs
+++ b/src/arch/market_assets/exchange/hyperliquid/schemas/rest/order_status.rs
@@ -121,11 +121,8 @@ pub fn finalize_hyperliquid_order_history(
     start_time_us: Option<u64>,
     end_time_us: Option<u64>,
     limit: Option<u32>,
-    require_recent_window_coverage: bool,
 ) -> InfraResult<Vec<OrderDetailData>> {
-    if require_recent_window_coverage {
-        ensure_recent_orders_cover_start(&data, start_time_us)?;
-    }
+    ensure_recent_orders_cover_start(&data, start_time_us)?;
 
     Ok(filter_order_history(
         data,
@@ -232,7 +229,6 @@ mod tests {
             Some(1_500_000),
             Some(3_500_000),
             Some(2),
-            true,
         )
         .unwrap();
 
@@ -251,15 +247,9 @@ mod tests {
             .map(|idx| order_detail("BTC_USDC_PERP", &idx.to_string(), 2_000_000 + idx as u64))
             .collect::<Vec<_>>();
 
-        let err = finalize_hyperliquid_order_history(
-            data,
-            "BTC_USDC_PERP",
-            Some(1_000_000),
-            None,
-            None,
-            true,
-        )
-        .unwrap_err();
+        let err =
+            finalize_hyperliquid_order_history(data, "BTC_USDC_PERP", Some(1_000_000), None, None)
+                .unwrap_err();
 
         assert!(format!("{err:?}").contains("historicalOrders only returns the most recent"));
     }

--- a/src/arch/market_assets/exchange/lob_clients.rs
+++ b/src/arch/market_assets/exchange/lob_clients.rs
@@ -288,31 +288,30 @@ impl LobPrivateRest for LobClients {
         start_time_us: Option<u64>,
         end_time_us: Option<u64>,
         limit: Option<u32>,
-        order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
         match self {
             LobClients::Hyperliquid(c) => {
-                c.get_order_history(inst, start_time_us, end_time_us, limit, order_id)
+                c.get_order_history(inst, start_time_us, end_time_us, limit)
                     .await
             },
             LobClients::BinanceSpot(c) => {
-                c.get_order_history(inst, start_time_us, end_time_us, limit, order_id)
+                c.get_order_history(inst, start_time_us, end_time_us, limit)
                     .await
             },
             LobClients::BinanceUm(c) => {
-                c.get_order_history(inst, start_time_us, end_time_us, limit, order_id)
+                c.get_order_history(inst, start_time_us, end_time_us, limit)
                     .await
             },
             LobClients::GateFutures(c) => {
-                c.get_order_history(inst, start_time_us, end_time_us, limit, order_id)
+                c.get_order_history(inst, start_time_us, end_time_us, limit)
                     .await
             },
             LobClients::GateSpot(c) => {
-                c.get_order_history(inst, start_time_us, end_time_us, limit, order_id)
+                c.get_order_history(inst, start_time_us, end_time_us, limit)
                     .await
             },
             LobClients::Okx(c) => {
-                c.get_order_history(inst, start_time_us, end_time_us, limit, order_id)
+                c.get_order_history(inst, start_time_us, end_time_us, limit)
                     .await
             },
             _ => Err(InfraError::Unimplemented),

--- a/src/arch/market_assets/exchange/okx/okx_cli.rs
+++ b/src/arch/market_assets/exchange/okx/okx_cli.rs
@@ -170,9 +170,8 @@ impl LobPrivateRest for OkxCli {
         start_time_us: Option<u64>,
         end_time_us: Option<u64>,
         limit: Option<u32>,
-        order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
-        self._get_order_history(inst, start_time_us, end_time_us, limit, order_id)
+        self._get_order_history(inst, start_time_us, end_time_us, limit)
             .await
     }
 }
@@ -1485,29 +1484,17 @@ impl OkxCli {
         start_time_us: Option<u64>,
         end_time_us: Option<u64>,
         limit: Option<u32>,
-        order_id: Option<&str>,
     ) -> InfraResult<Vec<OrderDetailData>> {
-        let okx_inst = cli_perp_to_okx_inst(inst);
-        let raw = if let Some(order_id) = order_id {
-            vec![
-                self.get_order_raw(OkxOrderReq {
-                    inst_id: okx_inst,
-                    ord_id: Some(order_id.into()),
-                    cl_ord_id: None,
-                })
-                .await?,
-            ]
-        } else {
-            self.get_order_history_raw(OkxOrderHistoryReq {
+        let raw = self
+            .get_order_history_raw(OkxOrderHistoryReq {
                 inst_type: "SWAP".into(),
-                inst_id: Some(okx_inst),
+                inst_id: Some(cli_perp_to_okx_inst(inst)),
                 begin: start_time_us.map(micros_to_millis),
                 end: end_time_us.map(micros_to_millis),
                 limit,
                 ..Default::default()
             })
-            .await?
-        };
+            .await?;
 
         let data = raw.into_iter().map(OrderDetailData::from).collect();
 

--- a/src/arch/traits/market_lob.rs
+++ b/src/arch/traits/market_lob.rs
@@ -163,7 +163,6 @@ pub trait LobPrivateRest: Send + Sync {
         _start_time_us: Option<u64>,
         _end_time_us: Option<u64>,
         _limit: Option<u32>,
-        _order_id: Option<&str>,
     ) -> impl Future<Output = InfraResult<Vec<OrderDetailData>>> + Send {
         ready(Err(InfraError::Unimplemented))
     }
@@ -171,9 +170,7 @@ pub trait LobPrivateRest: Send + Sync {
     /// Fetches one order by exchange order id.
     ///
     /// Queries the venue's single-order endpoint and returns the order's
-    /// current state. Prefer this over passing `order_id` to
-    /// [`get_order_history`](LobPrivateRest::get_order_history), which is a
-    /// history-list filter whose meaning differs between venues.
+    /// current state.
     fn get_order(
         &self,
         _inst: &str,


### PR DESCRIPTION
Follow-up to #133. `get_order_history(..., Some(order_id))` meant an exact lookup on Gate (`orders/{id}`), OKX (`trade/order`) and Hyperliquid (`orderStatus`) but a list lower bound on Binance UM (`allOrders?orderId=`). Single-order lookups now live in `get_order`, so the parameter is removed.

- `LobPrivateRest::get_order_history(inst, start_time_us, end_time_us, limit)`; `LobClients` forwarding updated.
- Binance UM, Binance spot, Gate futures, Gate spot, OKX, Hyperliquid: the `if let Some(order_id)` branch is deleted, each `_get_order_history` is one list request (`allOrders`, `orders?status=finished`, `orders-history`, `historicalOrders`).
- Hyperliquid `finalize_hyperliquid_order_history` loses `require_recent_window_coverage`; the check always runs (the flag was `order_id.is_none()` and had no other caller). Tests adjusted.
- Net −81 lines; `get_order` untouched.

Live check on largepo (`all_test`, read-only) with `api_checker order_lookup_probe` built against this branch: history -> `get_order` agree on id/status/size/executed for Binance UM, Gate futures, OKX and Hyperliquid; `get_order(inst, "1")` is an `Err` on all four (-2013 / ORDER_NOT_FOUND / 51603 / unknownOid).

Breaking for external implementors (signature change). No version bump; #132, #133 and this one are meant to ship together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)