### PR TITLE
chore: prepare extrema infra 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.3.17"
+version = "0.4.0"
 edition = "2024"
 
 readme = "README.md"
@@ -30,7 +30,7 @@ futures = "0.3.34"
 futures-util = "0.3.34"
 
 # HTTP / WebSocket
-reqwest = { version = "0.13.4", features = ["json", "gzip"] }
+reqwest = { version = "0.13.5", features = ["json", "gzip"] }
 tokio-tungstenite = { version = "0.30.0", features = ["rustls-tls-webpki-roots"] }
 tungstenite = "0.30.0"
 
@@ -52,7 +52,7 @@ rustls = { version = "0.23.43", features = ["aws-lc-rs"] }
 
 # IPC / Model inference / Data processing
 zeromq = { version = "0.6.0", optional = true }
-tract-onnx = { version = "0.23.6", optional = true }
+tract-onnx = { version = "0.23.7", optional = true }
 polars = { version = "0.55.2", default-features = false, optional = true }
 
 # Logging & Tracing

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ selected client does not support return `InfraError::Unimplemented`.
 
 - **MarketLobApi = LobPublicRest + LobPrivateRest**
   - **LobPublicRest**: market data (ticker, mark price, orderbook, candles, instruments).
-  - **LobPrivateRest**: trading operations (init API key, place/cancel orders, get balance, get positions).
+  - **LobPrivateRest**: trading operations (init API key, place/cancel orders, open orders, order history, single-order lookup, get balance, get positions).
 
 ---
 
@@ -330,7 +330,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-extrema_infra = { version = "0.3", features = ["all"] }
+extrema_infra = { version = "0.4", features = ["all"] }
 
 # For local development.
 # extrema_infra = { path = "../extrema_infra", features = ["all"] }

--- a/src/arch/traits/conversion.rs
+++ b/src/arch/traits/conversion.rs
@@ -1,4 +1,4 @@
-use crate::errors::{InfraError, InfraResult};
+use crate::errors::InfraResult;
 
 pub trait IntoWsData {
     type Output;
@@ -6,7 +6,7 @@ pub trait IntoWsData {
 }
 
 /// Unwraps an exchange REST response envelope into infra data, mapping the
-/// venue's error payload to [`InfraError`].
+/// venue's error payload to [`InfraError`](crate::errors::InfraError).
 pub trait IntoInfraData<T> {
     /// All items of a list payload; a single object becomes a one-item list.
     fn into_vec(self) -> InfraResult<Vec<T>>;
@@ -17,14 +17,20 @@ pub trait IntoInfraData<T> {
 }
 
 /// The single element of a list payload; none or several is an error.
+#[cfg(any(
+    feature = "hyperliquid",
+    feature = "binance",
+    feature = "gate",
+    feature = "okx"
+))]
 pub(crate) fn exactly_one<T>(items: Vec<T>) -> InfraResult<T> {
     let mut items = items.into_iter();
     match (items.next(), items.next()) {
         (Some(item), None) => Ok(item),
-        (None, _) => Err(InfraError::ApiCliError(
+        (None, _) => Err(crate::errors::InfraError::ApiCliError(
             "expected exactly one item, got none".to_string(),
         )),
-        (Some(_), Some(_)) => Err(InfraError::ApiCliError(
+        (Some(_), Some(_)) => Err(crate::errors::InfraError::ApiCliError(
             "expected exactly one item, got several".to_string(),
         )),
     }

--- a/src/arch/traits/conversion.rs
+++ b/src/arch/traits/conversion.rs
@@ -5,14 +5,19 @@ pub trait IntoWsData {
     fn into_ws(self) -> Self::Output;
 }
 
+/// Unwraps an exchange REST response envelope into infra data, mapping the
+/// venue's error payload to [`InfraError`].
 pub trait IntoInfraData<T> {
+    /// All items of a list payload; a single object becomes a one-item list.
     fn into_vec(self) -> InfraResult<Vec<T>>;
 
+    /// Exactly one item, for single-object endpoints. An empty or multi-item
+    /// payload is an error rather than a truncated result.
     fn into_one(self) -> InfraResult<T>;
 }
 
 /// The single element of a list payload; none or several is an error.
-pub fn exactly_one<T>(items: Vec<T>) -> InfraResult<T> {
+pub(crate) fn exactly_one<T>(items: Vec<T>) -> InfraResult<T> {
     let mut items = items.into_iter();
     match (items.next(), items.next()) {
         (Some(item), None) => Ok(item),

--- a/src/arch/traits/market_lob.rs
+++ b/src/arch/traits/market_lob.rs
@@ -153,10 +153,11 @@ pub trait LobPrivateRest: Send + Sync {
         ready(Err(InfraError::Unimplemented))
     }
 
-    /// Fetches historical orders.
+    /// Fetches historical orders from the venue's order-history list endpoint.
     ///
     /// `start_time_us` and `end_time_us` are Unix timestamps in microseconds.
     /// Exchange adapters convert them to the precision required by the venue.
+    /// Use [`get_order`](LobPrivateRest::get_order) to look one order up by id.
     fn get_order_history(
         &self,
         _inst: &str,


### PR DESCRIPTION
Release prep for 0.4.0, a breaking release collecting:

- #132 OKX websocket `filled_size` reads `accFillSz` (accumulated fill).
- #133 `LobPrivateRest::get_order` (required), `IntoInfraVec` -> `IntoInfraData` with required `into_one`, standalone single-order requests per client.
- #134 `get_order_history` without the `order_id` filter.

This PR:

- `Cargo.toml`: version 0.4.0, reqwest 0.13.5, tract-onnx 0.23.7.
- `README.md`: dependency snippet `version = "0.4"`, `LobPrivateRest` summary now lists open orders, order history and single-order lookup.
- `IntoInfraData` and its two methods documented; `get_order_history` doc points to `get_order` for lookups by id.
- `exactly_one` is `pub(crate)`: the prelude re-exports `traits::conversion::*`, and this helper is only used by the four REST wrappers.

Checks: fmt, clippy `-D warnings`, tests 189 + 7 + 9, `cargo doc --no-deps` no warnings, `cargo publish --dry-run` packages 261 files and verifies.

Downstream after release: portfolio_orchestrator (branch `chore/migrate-get-order`, already migrated) and funding_carry bump to 0.4.0; extrema_guard stays on 0.3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)