### PR TITLE
feat(strategy): on_lagged hook for dropped events, prepare 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrema_infra"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 
 readme = "README.md"

--- a/src/arch/strategy_base/handler/handler_core.rs
+++ b/src/arch/strategy_base/handler/handler_core.rs
@@ -64,6 +64,7 @@ where
             MuxItem::Event(event) => dispatch_task_event(&mut strategy, event).await,
             MuxItem::Lagged { key, skipped } => {
                 error!(task_key = ?key, skipped, "task event receiver lagged");
+                strategy.on_lagged(key, skipped).await;
             },
             MuxItem::LaggedSuppressed => {},
         }
@@ -285,6 +286,47 @@ mod tests {
         async fn on_schedule(&mut self, msg: InfraMsg<AltScheduleEvent>) {
             let _ = self.events.send(msg.task_id);
         }
+    }
+
+    #[derive(Clone)]
+    struct LagProbe {
+        lags: mpsc::UnboundedSender<(TaskKey, u64)>,
+    }
+
+    impl Strategy for LagProbe {
+        async fn initialize(&mut self) {}
+    }
+
+    impl CommandEmitter for LagProbe {
+        fn command_init(&mut self, _registry: Arc<CommandRegistry>) {}
+
+        fn command_registry(&self) -> Arc<CommandRegistry> {
+            Arc::new(CommandRegistry::default())
+        }
+    }
+
+    impl EventHandler for LagProbe {
+        async fn on_lagged(&mut self, key: TaskKey, skipped: u64) {
+            let _ = self.lags.send((key, skipped));
+        }
+    }
+
+    #[tokio::test]
+    async fn lagged_receiver_notifies_the_strategy_with_key_and_count() {
+        let key = scheduler_key(7);
+        let (sender, receiver) = task_receiver(key.clone(), 1);
+        for _ in 0..3 {
+            sender.send(schedule_event(7)).unwrap();
+        }
+
+        let (lags, mut received) = mpsc::unbounded_channel();
+        let handler = tokio::spawn(strategy_handler_loop(LagProbe { lags }, vec![receiver]));
+
+        let (lagged_key, skipped) = received.recv().await.expect("lag notice");
+        assert_eq!(lagged_key, key);
+        assert_eq!(skipped, 2);
+        drop(sender);
+        handler.await.unwrap();
     }
 
     async fn exercise_handler_path(receiver_count: usize) {

--- a/src/arch/strategy_base/hlist_core.rs
+++ b/src/arch/strategy_base/hlist_core.rs
@@ -10,7 +10,7 @@ use crate::arch::{
             ws_events::*,
         },
     },
-    task_execution::{task_alt::AltTaskInfo, task_ws::WsTaskInfo},
+    task_execution::{TaskKey, task_alt::AltTaskInfo, task_ws::WsTaskInfo},
     traits::strategy::*,
 };
 
@@ -142,6 +142,12 @@ where
     async fn on_acc_bal_pos(&mut self, msg: InfraMsg<Vec<WsAccBalPos>>) {
         let fut_head = self.head.on_acc_bal_pos(msg.clone());
         let fut_tail = self.tail.on_acc_bal_pos(msg);
+        tokio::join!(fut_head, fut_tail);
+    }
+
+    async fn on_lagged(&mut self, key: TaskKey, skipped: u64) {
+        let fut_head = self.head.on_lagged(key.clone(), skipped);
+        let fut_tail = self.tail.on_lagged(key, skipped);
         tokio::join!(fut_head, fut_tail);
     }
 

--- a/src/arch/traits/strategy.rs
+++ b/src/arch/traits/strategy.rs
@@ -9,6 +9,7 @@ use crate::arch::{
         },
     },
     task_execution::{
+        TaskKey,
         task_alt::{AltTaskInfo, AltTaskType},
         task_ws::{WsChannel, WsTaskInfo},
     },
@@ -327,6 +328,17 @@ pub trait EventHandler {
         &mut self,
         _msg: InfraMsg<Vec<WsOtherMessage>>,
     ) -> impl Future<Output = ()> + Send {
+        ready(())
+    }
+
+    /// Called when this module's receiver for `key` fell behind and the
+    /// runtime dropped `skipped` events from that task.
+    ///
+    /// Delivery is lossy by design: the ring for one task is bounded and a
+    /// slow module loses the oldest events rather than stalling the
+    /// publisher. Other tasks' channels are unaffected. The module decides
+    /// what to resynchronise, for example re-reading account state over REST.
+    fn on_lagged(&mut self, _key: TaskKey, _skipped: u64) -> impl Future<Output = ()> + Send {
         ready(())
     }
 }


### PR DESCRIPTION
Broadcast delivery is lossy by design (bounded ring per task; a slow module loses the oldest events instead of stalling the publisher), but until now a module whose receiver fell behind only produced the runtime's `task event receiver lagged` ERROR and could not react.

- `EventHandler::on_lagged(key: TaskKey, skipped: u64)`, default no-op, so existing implementors are unaffected.
- `strategy_handler_loop` calls it right after logging the lag; `HCons` forwards it to head and tail like every other event.
- Test `lagged_receiver_notifies_the_strategy_with_key_and_count`: capacity-1 ring, three events, the strategy is told `skipped = 2` with the matching key.
- `Cargo.toml` 0.4.1 (this plus #136 monotonic Hyperliquid nonce).

First consumer: portfolio_orchestrator marks the account for a REST position resync on the next hedge slice instead of waiting for the 30 s refresh (Lqz13Th/portfolio_orchestrator draft PR).

clippy clean with default features, `lob_clients`, `--all-features`; tests 191 + 7 + 9; `cargo publish --dry-run` verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)